### PR TITLE
Don't clash with stdlib's random()

### DIFF
--- a/include/utils/random.h
+++ b/include/utils/random.h
@@ -5,15 +5,15 @@
 
 typedef struct random_t {
     uint32_t seed;
-} random;
+};
 
-void random_seed(random *r, uint32_t seed);
+void random_seed(struct random_t *r, uint32_t seed);
 
 /* Return a random integer in 0 <= r < upperbound */
-uint32_t random_int(random *r, uint32_t upperbound);
+uint32_t random_int(struct random_t *r, uint32_t upperbound);
 
 /* Return a random integer in 0 <= r <= UINT_MAX */
-uint32_t random_intmax(random *r);
+uint32_t random_intmax(struct random_t *r);
 
 /* Same as the above but keeps an internal state
  * Use as a replacement of rand()

--- a/src/utils/random.c
+++ b/src/utils/random.c
@@ -3,6 +3,8 @@
 
 // A simple psuedorandom number generator
 
+typedef struct random_t random;
+
 static random rand = { 1 };
 
 void random_seed(random *r, uint32_t seed) {


### PR DESCRIPTION
I needed to do this change to even compile, because the struct random_t typedef clashes with stdlib's random function.
