### PR TITLE
Lower CMake version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,6 @@ before_install:
  - if test $CC = gcc; then sudo apt-get install -qq gcc-4.9; fi
  - if test $CC = gcc; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 20; fi
  - if test $CC = gcc; then sudo update-alternatives --config gcc; fi
- - wget "http://www.cmake.org/files/v3.0/cmake-3.0.0.tar.gz"
- - tar xf "cmake-3.0.0.tar.gz"
- - cd "cmake-3.0.0"
- - ./bootstrap --prefix=/usr/local
- - make
- - sudo make install
- - cd ..
 
 before_script:
 - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_SUBMODULES=On -DUSE_OGGVORBIS=On -DUSE_PNG=On -DUSE_TESTS=On .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8)
 project(OpenOMF C)
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-scripts)
 


### PR DESCRIPTION
Lots of distro's are still shipping CMake 2.8, so it would be rather nice to keep CMake 2.8 compatibility for another year or so.

Also, a minor tweak to the window title.