### PR TITLE
Change unix default resource path, add environment variable overides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,6 @@ INSTALL(TARGETS openomf
     COMPONENT Binaries
 )
 INSTALL(FILES resources/openomf.bk resources/openomf_icon.png
-    DESTINATION share/openomf/
+    DESTINATION share/games/openomf/
     COMPONENT Data
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -143,12 +143,14 @@ OpenOMF loads the original data files from the original OMF:2097 game using libS
 
 On linux in debug mode, the OMF resource files should be put in resources/ subdirectory.
 
-On linux in release mode, the resources should be located in ../share/openomf/. So if your binary is
-in /usr/local/bin, the resources should be put in /usr/local/share/openomf/. With release or testing packages, the resources should be extracted to /usr/share/openomf/.
+On linux in release mode, the resources should be located in ../share/games/openomf/, relative to the openomf binary. So if your binary is
+in /usr/local/bin, the resources should be put in /usr/local/share/games/openomf/. With release or testing packages, the resources should be extracted to /usr/share/games/openomf/.
 
 On MacOS and windows, the resources should be put into the resources/ subdirectory.
 
 Note! Only BK,AF,PIC,TRN,PSM and DAT files are required, others may be removed to save space.
+
+You can override these default paths by setting the OPENOMF_RESOURCE_DIR environment variable to an absolute directory. Plugins have a similiar environment variable called OPENOMF_PLUGIN_DIR.
 
 4. Play the game!
 -----------------

--- a/src/resources/pathmanager.c
+++ b/src/resources/pathmanager.c
@@ -111,12 +111,14 @@ int pm_init() {
     // check if we have overrides from the environment
     char *resource_env = getenv("OPENOMF_RESOURCE_DIR");
     if (resource_env) {
-        sprintf(local_paths[RESOURCE_PATH], "%s", resource_env);
+        char *ext = resource_env[strlen(resource_env)-1] == '/' ? "" : "/";
+        local_path_build(RESOURCE_PATH, resource_env, ext);
     }
 
     char *plugin_env = getenv("OPENOMF_PLUGIN_DIR");
     if (plugin_env) {
-        sprintf(local_paths[PLUGIN_PATH], "%s", plugin_env);
+        char *ext = plugin_env[strlen(plugin_env)-1] == '/' ? "" : "/";
+        local_path_build(PLUGIN_PATH, plugin_env, ext);
     }
 
 

--- a/src/resources/pathmanager.c
+++ b/src/resources/pathmanager.c
@@ -79,10 +79,10 @@ int pm_init() {
                 local_path_build(PLUGIN_PATH, bin_base_dir, "plugins\\");
                 m_ok = 1;
             } else if(!strcasecmp(SDL_GetPlatform(), "Linux")) {
-                // on linux, the resources will be in ../share/openomf, relative to the binary
+                // on linux, the resources will be in ../share/games/openomf, relative to the binary
                 // so if openomf is installed to /usr/local/bin,
-                // the resources will be in /usr/local/share/openomf
-                local_path_build(RESOURCE_PATH, bin_base_dir, "../share/openomf/");
+                // the resources will be in /usr/local/share/games/openomf
+                local_path_build(RESOURCE_PATH, bin_base_dir, "../share/games/openomf/");
                 local_path_build(PLUGIN_PATH, bin_base_dir, "../lib/openomf/");
                 m_ok = 1;
             } else if(!strcasecmp(SDL_GetPlatform(), "Mac OS X")) {
@@ -107,6 +107,18 @@ int pm_init() {
             local_path_build(PLUGIN_PATH, "plugins/", "");
         }
     }
+
+    // check if we have overrides from the environment
+    char *resource_env = getenv("OPENOMF_RESOURCE_DIR");
+    if (resource_env) {
+        sprintf(local_paths[RESOURCE_PATH], "%s", resource_env);
+    }
+
+    char *plugin_env = getenv("OPENOMF_PLUGIN_DIR");
+    if (plugin_env) {
+        sprintf(local_paths[PLUGIN_PATH], "%s", plugin_env);
+    }
+
 
     // Set resource paths
     for(int i = 0; i < NUMBER_OF_RESOURCES; i++) {

--- a/src/resources/pathmanager.c
+++ b/src/resources/pathmanager.c
@@ -27,12 +27,12 @@ static char* resource_paths[NUMBER_OF_RESOURCES];
 // Build directory
 static void local_path_build(int path_id, const char *path, const char *ext) {
     int len = strlen(path) + strlen(ext) + 1;
-    local_paths[path_id] = malloc(len);
+    local_paths[path_id] = realloc(local_paths[path_id], len);
     sprintf(local_paths[path_id], "%s%s", path, ext);
 }
 static void resource_path_build(int path_id, const char *path, const char *ext) {
     int len = strlen(path) + strlen(ext) + 1;
-    resource_paths[path_id] = malloc(len);
+    resource_paths[path_id] = realloc(resource_paths[path_id], len);
     sprintf(resource_paths[path_id], "%s%s", path, ext);
 }
 
@@ -54,6 +54,8 @@ int pm_init() {
 
     // Clear everything
     errormessage[0] = 0;
+    memset(local_paths, 0, sizeof(local_paths));
+    memset(resource_paths, 0, sizeof(resource_paths));
 
     // Find local basedir
     local_base_dir = pm_get_local_base_dir();

--- a/src/resources/pathmanager.c
+++ b/src/resources/pathmanager.c
@@ -36,6 +36,11 @@ static void resource_path_build(int path_id, const char *path, const char *ext) 
     sprintf(resource_paths[path_id], "%s%s", path, ext);
 }
 
+int str_ends_with_sep(const char *str) {
+    int pos = strlen(str) - 1;
+    return (str[pos] == '/' || str[pos] == '\\');
+}
+
 // Makes sure resource file exists
 int pm_validate_resources() {
     for(int i = 0; i < NUMBER_OF_RESOURCES; i++) {
@@ -110,16 +115,21 @@ int pm_init() {
         }
     }
 
+    char *platform_sep = "/";
+    if(!strcasecmp(SDL_GetPlatform(), "Windows")) {
+        platform_sep = "\\";
+    }
+
     // check if we have overrides from the environment
     char *resource_env = getenv("OPENOMF_RESOURCE_DIR");
     if (resource_env) {
-        char *ext = resource_env[strlen(resource_env)-1] == '/' ? "" : "/";
+        char *ext = str_ends_with_sep(resource_env) ? "" : platform_sep;
         local_path_build(RESOURCE_PATH, resource_env, ext);
     }
 
     char *plugin_env = getenv("OPENOMF_PLUGIN_DIR");
     if (plugin_env) {
-        char *ext = plugin_env[strlen(plugin_env)-1] == '/' ? "" : "/";
+        char *ext = str_ends_with_sep(plugin_env) ? "" : platform_sep;
         local_path_build(PLUGIN_PATH, plugin_env, ext);
     }
 


### PR DESCRIPTION
The default resource path on linux, in release mode, is now
../share/games/openomf/, relative to the binary. This can be overridden
by the environment variable OPENOMF_RESOURCE_DIR, which should be an
absolute path with a trailing slash.

A similar environment variable override is provided for the plugin path:
OPENOMF_PLUGIN_DIR.

cc @katajakasa @animehunter 