### PR TITLE
HARs should go down at 0 health no matter endurance level

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -514,23 +514,21 @@ void har_take_damage(object *obj, str* string, float damage) {
     }
 
     // Handle health changes
-    int oldhealth = h->health;
-    if(h->health <= 0) { h->health = 0; }
-    if (oldhealth <= 0) {
-        // har has no health left and is left only with endurance.
-        // one hit will end them
+    if(h->health <= 0) {
+        h->health = 0;
         h->endurance = 0.0f;
-    } else {
-        h->endurance -= damage;
-        if(h->endurance < 1.0f) {
-            if (h->state == STATE_STUNNED) {
-                // refill endurance
-                h->endurance = h->endurance_max;
-            } else {
-                h->endurance = 0.0f;
-            }
+    }
+
+    h->endurance -= damage;
+    if(h->endurance < 1.0f) {
+        if (h->state == STATE_STUNNED) {
+            // refill endurance
+            h->endurance = h->endurance_max;
+        } else {
+            h->endurance = 0.0f;
         }
     }
+
 
     // Take a screencap of enemy har
     if(h->health == 0 && h->endurance < 1.0f) {


### PR DESCRIPTION
Partially related to #290 

In OMF 2.1, if a HAR has little health, a shot which bring its health to 0 will end the match.
In OpenOMF, in same situation, the HAR is still standing because there is some endurance left.

This PR should make things much in line with OMF behaviour