### PR TITLE
Add a naive implementation of hashmap resizing function

### DIFF
--- a/include/utils/hashmap.h
+++ b/include/utils/hashmap.h
@@ -4,6 +4,11 @@
 #include "utils/iterator.h"
 #include "utils/allocator.h"
 
+enum hashmap_flags {
+    HASHMAP_AUTO_INC = 0x1,
+    HASHMAP_AUTO_DEC = 0x2
+};
+
 typedef struct hashmap_pair_t hashmap_pair;
 typedef struct hashmap_node_t hashmap_node;
 typedef struct hashmap_t hashmap;
@@ -21,14 +26,22 @@ struct hashmap_node_t {
 struct hashmap_t {
     hashmap_node **buckets;
     unsigned int buckets_x;
+    unsigned int buckets_x_min;
+    unsigned int buckets_x_max;
     unsigned int reserved;
+    float min_pressure;
+    float max_pressure;
+    unsigned int flags;
     allocator alloc;
 };
 
 void hashmap_create(hashmap *hashmap, int n_size); // actual size will be 2^n_size
 void hashmap_create_with_allocator(hashmap *hashmap, int n_size, allocator alloc);
 void hashmap_free(hashmap *hashmap);
+void hashmap_set_opts(hashmap *hm, unsigned int flags, float min_pressure, float max_pressure, int buckets_min, int buckets_max);
 int hashmap_resize(hashmap *hm, int n_size);
+float hashmap_get_pressure(hashmap *hm);
+void hashmap_autoresize(hashmap *hm);
 unsigned int hashmap_size(const hashmap *hashmap);
 unsigned int hashmap_reserved(const hashmap *hashmap);
 void* hashmap_put(hashmap *hm, const void *key, unsigned int keylen, const void *val, unsigned int vallen);

--- a/include/utils/hashmap.h
+++ b/include/utils/hashmap.h
@@ -28,6 +28,7 @@ struct hashmap_t {
 void hashmap_create(hashmap *hashmap, int n_size); // actual size will be 2^n_size
 void hashmap_create_with_allocator(hashmap *hashmap, int n_size, allocator alloc);
 void hashmap_free(hashmap *hashmap);
+int hashmap_resize(hashmap *hm, int n_size);
 unsigned int hashmap_size(const hashmap *hashmap);
 unsigned int hashmap_reserved(const hashmap *hashmap);
 void* hashmap_put(hashmap *hm, const void *key, unsigned int keylen, const void *val, unsigned int vallen);

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -9,6 +9,22 @@
 #define TINY_MASK(x) (((uint32_t)1<<(x))-1)
 #define BUCKETS_SIZE(x) (pow(2,(x)))
 
+#define AUTO_INC_CHECK() \
+    if(hm->flags & HASHMAP_AUTO_INC \
+        && hm->buckets_x < hm->buckets_x_max \
+        && hashmap_get_pressure(hm) > hm->max_pressure) \
+    { \
+        hashmap_resize(hm, hm->buckets_x+1); \
+    }
+
+#define AUTO_DEC_CHECK() \
+    if(hm->flags & HASHMAP_AUTO_DEC \
+        && hm->buckets_x > hm->buckets_x_min \
+        && hashmap_get_pressure(hm) > hm->max_pressure) \
+    { \
+        hashmap_resize(hm, hm->buckets_x-1); \
+    }
+
 // The rest
 
 uint32_t fnv_32a_buf(const void *buf, unsigned int len, unsigned int x) {
@@ -27,7 +43,7 @@ uint32_t fnv_32a_buf(const void *buf, unsigned int len, unsigned int x) {
   * Creates a new hashmap. This is just like hashmap_create, but
   * allows the user to define the memory allocation functions.
   *
-  * \param hm Allocated memory pointer
+  * \param hm Allocated hashmap pointer
   * \param n_size Size of the hashmap. Final size will be pow(2, n_size)
   * \param alloc Allocation functions
   */
@@ -49,7 +65,7 @@ void hashmap_create_with_allocator(hashmap *hm, int n_size, allocator alloc) {
   *
   * \todo Make a better create function
   *
-  * \param hm Allocated memory pointer
+  * \param hm Allocated hashmap pointer
   * \param n_size Size of the hashmap. Final size will be pow(2, n_size)
   */
 void hashmap_create(hashmap *hm, int n_size) {
@@ -60,6 +76,67 @@ void hashmap_create(hashmap *hm, int n_size) {
     hashmap_create_with_allocator(hm, n_size, alloc);
 }
 
+/** \brief Set hashmap options
+  *
+  * Used to set hashmap resizing options and pressures.
+  *
+  * Available flags:
+  * - HASHMAP_AUTO_INC: Enables automatic hashmap size increasing (set pressure via max_pressure)
+  * - HASHMAP_AUTO_DEC: Enables automatic hashmap size decreasing (set pressure via min_pressure)
+  *
+  * Decent default for pressures might be 0.25 for minimum and 0.75 for maximum. These can and should
+  * of course be tweaked as necessary, since resizing is a rather expensive operation and should be
+  * avoided if necessary.
+  * 
+  * buckets_min and buckets_max define the minimum and maximum amount of buckets available in the
+  * hashmap.
+  *
+  * min_pressure and max_pressure will only be used if HASHMAP_AUTO_INC and HASHMAP_AUTO_DEC are set,
+  * respectively. Same with buckets_min and buckets_max.
+  *
+  * \param hm Allocated hashmap pointer
+  * \param flags Feature flags (eg. HASHMAP_AUTO_INC|HASHMAP_AUTO_DEC)
+  * \param min_pressure Minimum pressure value for auto-resize (eg. 0.25)
+  * \param max_pressure Maximum pressure value for auto-resize (eg. 0.75)
+  * \param buckets_min Minimum amount of buckets (must be >= 2)
+  * \param buckets_max Maximum amount of buckets
+  */
+void hashmap_set_opts(hashmap *hm, 
+    unsigned int flags,
+    float min_pressure, float max_pressure,
+    int buckets_min, int buckets_max)
+{
+    hm->flags = flags & 0x3;
+    hm->min_pressure = min_pressure;
+    hm->max_pressure = max_pressure;
+    hm->buckets_x_min = buckets_min >= 2 ? buckets_min : 2;
+    hm->buckets_x_max = buckets_max;
+}
+
+/** \brief Get current hashmap pressure
+  *
+  * Simply gets the current fill pressure for the hashmap.
+  * Calculated as reserved_buckets / total_buckets.
+  *
+  * \param hm Allocated hashmap pointer
+  */
+float hashmap_get_pressure(hashmap *hm) {
+    return ((float)hm->reserved) / ((float)BUCKETS_SIZE(hm->buckets_x));
+}
+
+/** \brief Runs pressure checks and resizes if necessary
+  *
+  * This function checks if either the minimun or maximum pressure checks are on
+  * and if the pressure values have been exceeded. If they are, resize operation
+  * will be run.
+  *
+  * \param hm Allocated hashmap pointer
+  */
+void hashmap_autoresize(hashmap *hm) {
+    AUTO_INC_CHECK()
+    AUTO_DEC_CHECK()
+}
+
 /** \brief Resizes the hashmap
   *
   * Note! This is a very naive implementation. During the rehashing, a separate
@@ -67,7 +144,7 @@ void hashmap_create(hashmap *hm, int n_size) {
   *
   * \todo Make a better resize function
   *
-  * \param hm Allocated memory pointer
+  * \param hm Allocated hashmap pointer
   * \param n_size Size of the hashmap. Final size will be pow(2, n_size)
   */
 int hashmap_resize(hashmap *hm, int n_size) {
@@ -175,6 +252,13 @@ unsigned int hashmap_reserved(const hashmap *hm) {
   * contents of the value memory block will be copied. However,
   * any memory _pointed to_ by it will NOT be copied. So be careful!
   *
+  * If autoresizing is on, this will first check if the hashmap needs
+  * to be increased in size. If yes, size will be doubled and a full 
+  * rehashing operation will be run. This will take time!
+  *
+  * This function does NOT automatically decrease size, even if HASHMAP_AUTO_DEC
+  * flag is enabled.
+  *
   * \param hm Hashmap
   * \param key Pointer to key memory block
   * \param keylen Length of the key memory block
@@ -184,7 +268,10 @@ unsigned int hashmap_reserved(const hashmap *hm) {
   */
 void* hashmap_put(hashmap *hm,
                   const void *key, unsigned int keylen,
-                  const void *val, unsigned int vallen) {
+                  const void *val, unsigned int vallen)
+{
+    AUTO_INC_CHECK()
+
     unsigned int index = fnv_32a_buf(key, keylen, hm->buckets_x);
     hashmap_node *root = hm->buckets[index];
     hashmap_node *seek = root;
@@ -233,12 +320,21 @@ void* hashmap_put(hashmap *hm,
   * iterator may lead to weird behavior. If you wish to delete inside an
   * iterator, please use hashmap_delete.
   *
+  * If autoresizing is on, this will first check if the hashmap needs
+  * to be decreased in size. If yes, size will be cut in half and a full 
+  * rehashing operation will be run. This will take time!
+  *
+  * This function does NOT automatically increase size, even if HASHMAP_AUTO_INC
+  * flag is enabled.
+  *
   * \param hm Hashmap
   * \param key Pointer to key memory block
   * \param keylen Length of the key memory block
   * \return Returns 0 on success, 1 on error (not found).
   */
 int hashmap_del(hashmap *hm, const void *key, unsigned int keylen) {
+    AUTO_DEC_CHECK()
+
     unsigned int index = fnv_32a_buf(key, keylen, hm->buckets_x);
 
     // Get node
@@ -343,6 +439,11 @@ void hashmap_idel(hashmap *hm, unsigned int key) {
   * Deletes an item from the hashmap by a matching iterator key.
   * This function is iterator safe. In theory, this function
   * should not fail, as the iterable value should exist.
+  *
+  * Note! This function does NOT autoresize at all, even if the flags
+  * are enabled. This is to avoid trouble while iterating. If you do
+  * a large amount of deletions here and suspect the minimum limit has been
+  * reached, call hashmap_autoresize to run a check and resize operation.
   *
   * \param hm Hashmap
   * \param iter Iterator

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -50,6 +50,11 @@ uint32_t fnv_32a_buf(const void *buf, unsigned int len, unsigned int x) {
 void hashmap_create_with_allocator(hashmap *hm, int n_size, allocator alloc) {
     hm->alloc = alloc;
     hm->buckets_x = n_size;
+    hm->buckets_x_min = 4;
+    hm->buckets_x_max = 31;
+    hm->min_pressure = 0.25;
+    hm->max_pressure = 0.75;
+    hm->flags = 0;
     size_t b_size = hashmap_size(hm) * sizeof(hashmap_node*);
     hm->buckets = hm->alloc.cmalloc(b_size);
     memset(hm->buckets, 0, b_size);

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -68,6 +68,11 @@ void hashmap_create_with_allocator(hashmap *hm, int n_size, allocator alloc) {
   * but the bucket count is actually calculated pow(2, n_size). So for example value
   * 8 means 256 buckets, and 9 would be 512 buckets.
   *
+  * Note that if you are planning on using the autoresize feature with auto decrease option, 
+  * the n_size should be the same as the min_buckets value in hashmap_set_opts() call.
+  * If you don't fill the hashmap to full size at the start before calling hashmap_del(),
+  * the delete function will start automatically decreasing the hashmap size.
+  *
   * \todo Make a better create function
   *
   * \param hm Allocated hashmap pointer

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -326,7 +326,7 @@ void* hashmap_put(hashmap *hm,
   * iterator may lead to weird behavior. If you wish to delete inside an
   * iterator, please use hashmap_delete.
   *
-  * If autoresizing is on, this will first check if the hashmap needs
+  * If autoresizing is on, this will check if the hashmap needs
   * to be decreased in size. If yes, size will be cut in half and a full 
   * rehashing operation will be run. This will take time!
   *

--- a/testing/test_hashmap.c
+++ b/testing/test_hashmap.c
@@ -62,6 +62,14 @@ void test_hashmap_insert(void) {
     return;
 }
 
+void test_hashmap_resize(void) {
+    CU_ASSERT(hashmap_resize(&test_map, 8) == 1);
+    CU_ASSERT(hashmap_resize(&test_map, 10) == 0);
+    CU_ASSERT_PTR_NOT_NULL(test_map.buckets);
+    CU_ASSERT(test_map.buckets_x = 10);
+    CU_ASSERT(hashmap_size(&test_map) == 1024);
+}
+
 void test_hashmap_get(void) {
     unsigned int *val;
     unsigned int vlen;
@@ -126,6 +134,7 @@ void hashmap_test_suite(CU_pSuite suite) {
     // Add tests
     if(CU_add_test(suite, "Test for hashmap create", test_hashmap_create) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap insert operation", test_hashmap_insert) == NULL) { return; }
+    if(CU_add_test(suite, "Test for hashmap resize operation", test_hashmap_resize) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap get operation", test_hashmap_get) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap delete operation", test_hashmap_delete) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap iterator ", test_hashmap_iterator) == NULL) { return; }

--- a/testing/test_hashmap.c
+++ b/testing/test_hashmap.c
@@ -62,6 +62,12 @@ void test_hashmap_insert(void) {
     return;
 }
 
+void test_hashmap_get_pressure(void) {
+    float pr = hashmap_get_pressure(&test_map);
+    CU_ASSERT(pr >= 3.9);
+    CU_ASSERT(pr <= 3.91);
+}
+
 void test_hashmap_resize(void) {
     CU_ASSERT(hashmap_resize(&test_map, 8) == 1);
     CU_ASSERT(hashmap_resize(&test_map, 10) == 0);
@@ -134,6 +140,7 @@ void hashmap_test_suite(CU_pSuite suite) {
     // Add tests
     if(CU_add_test(suite, "Test for hashmap create", test_hashmap_create) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap insert operation", test_hashmap_insert) == NULL) { return; }
+    if(CU_add_test(suite, "Test for hashmap get pressure operation", test_hashmap_get_pressure) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap resize operation", test_hashmap_resize) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap get operation", test_hashmap_get) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap delete operation", test_hashmap_delete) == NULL) { return; }

--- a/testing/test_hashmap.c
+++ b/testing/test_hashmap.c
@@ -136,6 +136,54 @@ void test_hashmap_clear(void) {
     CU_ASSERT(hashmap_reserved(&test_map) == 0);
 }
 
+void hashmap_test_autoresize(void) {
+    hashmap_create(&test_map, 2);
+
+    hashmap_set_opts(&test_map, HASHMAP_AUTO_INC|HASHMAP_AUTO_DEC, 0.25, 0.75, 2, 8);
+    CU_ASSERT(test_map.buckets_x_max == 8);
+    CU_ASSERT(test_map.buckets_x_min == 2);
+    CU_ASSERT(test_map.flags & HASHMAP_AUTO_INC);
+    CU_ASSERT(test_map.flags & HASHMAP_AUTO_DEC);
+    CU_ASSERT_DOUBLE_EQUAL(test_map.max_pressure, 0.75, 0.01);
+    CU_ASSERT_DOUBLE_EQUAL(test_map.min_pressure, 0.25, 0.01);
+
+    CU_ASSERT(test_map.buckets_x == 2);
+
+    unsigned int c_key = 0;
+    unsigned int c_value = 0xFFFF;
+
+    hashmap_put(&test_map, &c_key, sizeof(int), &c_value, sizeof(int));
+    CU_ASSERT_DOUBLE_EQUAL(hashmap_get_pressure(&test_map), 0.25, 0.01);
+    c_key++;
+    c_value--;
+
+    hashmap_put(&test_map, &c_key, sizeof(int), &c_value, sizeof(int));
+    CU_ASSERT_DOUBLE_EQUAL(hashmap_get_pressure(&test_map), 0.5, 0.01);
+    c_key++;
+    c_value--;
+
+    hashmap_put(&test_map, &c_key, sizeof(int), &c_value, sizeof(int));
+    CU_ASSERT_DOUBLE_EQUAL(hashmap_get_pressure(&test_map), 0.75, 0.01);
+    c_key++;
+    c_value--;
+
+    hashmap_put(&test_map, &c_key, sizeof(int), &c_value, sizeof(int));
+    CU_ASSERT_DOUBLE_EQUAL(hashmap_get_pressure(&test_map), 0.5, 0.01);
+    CU_ASSERT(test_map.buckets_x == 3);
+
+
+    hashmap_del(&test_map, &c_key, sizeof(int));
+    c_key--;
+    hashmap_del(&test_map, &c_key, sizeof(int));
+    c_key--;
+    hashmap_del(&test_map, &c_key, sizeof(int));
+
+    CU_ASSERT_DOUBLE_EQUAL(hashmap_get_pressure(&test_map), 0.25, 0.01);
+    CU_ASSERT(test_map.buckets_x == 2);
+
+    hashmap_free(&test_map);
+}
+
 void hashmap_test_suite(CU_pSuite suite) {
     // Add tests
     if(CU_add_test(suite, "Test for hashmap create", test_hashmap_create) == NULL) { return; }
@@ -148,4 +196,5 @@ void hashmap_test_suite(CU_pSuite suite) {
     if(CU_add_test(suite, "Test for hashmap iterator delete operation", test_hashmap_iter_del) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap clear operation", test_hashmap_clear) == NULL) { return; }
     if(CU_add_test(suite, "Test for hashmap free operation", test_hashmap_free) == NULL) { return; }
+    if(CU_add_test(suite, "Test for hashmap auto resize", hashmap_test_autoresize) == NULL) { return; }
 }


### PR DESCRIPTION
1. Creates a new hashmap bucket list
2. Rehashes nodes from the old list and adds them to the new list
3. frees up old list and sets the new list as hashmap main bucket list.

Also adds the autoresize stuff.

This can and should be optimized!