### PR TITLE
Attempt to fix flails scrap move

### DIFF
--- a/include/game/protos/player.h
+++ b/include/game/protos/player.h
@@ -56,6 +56,7 @@ typedef struct player_animation_state_t {
     uint8_t finished;
     uint8_t disable_d;
     uint8_t shadow_corner_hack;
+    uint8_t wall_splat_hack;
 
     void *spawn_userdata;
     void *destroy_userdata;

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1254,7 +1254,7 @@ void har_tick(object *obj) {
     // Make sure HAR doesn't walk through walls
     // TODO: Roof!
     vec2i pos = object_get_pos(obj);
-    if (h->state != STATE_DEFEAT) {
+    if (h->state != STATE_DEFEAT || obj->animation_state.wall_splat_hack) {
         int wall_flag = player_frame_isset(obj, "aw");
         int wall = 0;
         int hit = 0;

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -101,6 +101,7 @@ void player_create(object *obj) {
     obj->animation_state.disable_d = 0;
     obj->animation_state.enemy = NULL;
     obj->animation_state.shadow_corner_hack = 0;
+    obj->animation_state.wall_splat_hack = 0;
     obj->slide_state.timer = 0;
     obj->slide_state.vel = vec2f_create(0,0);
     sd_script_create(&obj->animation_state.parser);
@@ -281,6 +282,15 @@ void player_run(object *obj) {
             } else {
                 object_set_direction(obj, OBJECT_FACE_RIGHT);
             }
+        }
+
+        // If CW (wallcheck) flag is on and we're touching the wall, then disable d tag.
+        if(sd_script_isset(frame, "cw")) {
+            har *enemy_h = state->enemy->userdata;
+            if(enemy_h->is_wallhugging) {
+                state->disable_d = 1;
+            }
+            state->enemy->animation_state.wall_splat_hack = 1;
         }
 
         /*if (sd_script_isset(frame, "bm")) {
@@ -542,6 +552,7 @@ void player_run(object *obj) {
         if(sd_script_isset(frame, "bj")) {
             int new_ani = sd_script_get(frame, "bj");
             har_set_ani(obj, new_ani, 0);
+            DEBUG("BJ: Moving to animation %d", new_ani);
         }
 
 


### PR DESCRIPTION
We don't really _know_ what CW tag is supposed to do, but since only flails scrap + destruction uses it, we can piggyback on it to hack other stuff. 

This is kind of an **ugly hack** and doesn't yet fix everything.