### PR TITLE
formats: Break loop instead of modifying the loop counter in body

### DIFF
--- a/src/formats/script.c
+++ b/src/formats/script.c
@@ -187,7 +187,7 @@ int sd_script_decode(sd_script *script, const char* str, int *inv_pos) {
                         frame->tags[tag_number].value = read_next_int(str, &i);
                     }
                     tag_number++;
-                    k = 0; // Stop here.
+                    break;
                 }
             }
             if(!found) {


### PR DESCRIPTION
This addresses a static analyzer complaint.