### PR TITLE
utils: Wrap omf_free() macro in do { .. } while (0)

### DIFF
--- a/include/utils/allocator.h
+++ b/include/utils/allocator.h
@@ -11,9 +11,9 @@ void *omf_calloc_real(size_t nmemb, size_t size, const char *file, int line);
     omf_realloc_real((ptr), (size), __FILE__, __LINE__)
 void *omf_realloc_real(void *ptr, size_t size, const char *file, int line);
 
-#define omf_free(ptr) { \
-    free(ptr);          \
-    (ptr) = NULL;       \
-}
+#define omf_free(ptr) do { \
+    free(ptr);             \
+    (ptr) = NULL;          \
+} while(0)
 
 #endif // _ALLOCATOR_H


### PR DESCRIPTION
This is to address a sonarcloud complaint.

Issue #399 fixup.