### PR TITLE
Move all libdumb calls to dumb_source.c

### DIFF
--- a/src/audio/sources/dumb_source.c
+++ b/src/audio/sources/dumb_source.c
@@ -81,11 +81,15 @@ void dumb_source_close(audio_source *src) {
     destroy_sample_buffer(local->sig_samples);
     omf_free(local);
     source_set_userdata(src, local);
+    dumb_exit();  // Free libdumb memory
     DEBUG("Libdumb Source: Closed.");
 }
 
 int dumb_source_init(audio_source *src, const char* file, int channels, int freq, int resampler) {
     dumb_source *local = omf_calloc(1, sizeof(dumb_source));
+
+    // Make sure libdumb is initialized
+    dumb_register_stdfiles();
 
     // Load file and initialize renderer
     char *ext = strrchr(file, '.') + 1;

--- a/src/main.c
+++ b/src/main.c
@@ -5,9 +5,6 @@
 #include <stdio.h>
 #include <SDL.h>
 #include <argtable2.h>
-#ifdef USE_DUMB
-#include <dumb.h>
-#endif
 #include <enet/enet.h>
 #include "engine.h"
 #include "utils/log.h"
@@ -227,11 +224,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    // Init libDumb
-#ifdef USE_DUMB
-    dumb_register_stdfiles();
-#endif // USE_DUMB
-
 #endif // STANDALONE_SERVER
 
     // Init enet
@@ -256,9 +248,6 @@ exit_4:
 exit_3:
     SDL_Quit();
 exit_2:
-#ifdef USE_DUMB
-    dumb_exit();
-#endif
     settings_save();
     settings_free();
 exit_1:


### PR DESCRIPTION
Move all libdumb usage to dumb_source.c. This is safe, as dumb_register_stdfiles() can be called repeatedly, and dumb_exit() will only clear cache (it will be re-filled when needed).

This removes libdumb stuff from main.c. We will probably drop this later, as libxmp seems to be available everywhere and has equal playback quality.