### PR TITLE
Run formatting check in GA CI using clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,9 @@ BraceWrapping:
   AfterUnion:      false
   BeforeElse:      false
   IndentBraces:    false
+  AfterEnum:       false
 AllowShortFunctionsOnASingleLine: false
 AllowShortBlocksOnASingleLine: false
 AlignArrayOfStructures: Left
 IndentCaseLabels: true
+AllowShortEnumsOnASingleLine: false

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -10,6 +10,18 @@ on:
 
 jobs:
 
+  # Check code formatting correctness
+  # -----------------------------------------------------------------------------------------------
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check
+      uses: jidicula/clang-format-action@v4.5.0
+      with:
+        clang-format-version: '13'
+
   # Run unittests on modern-ish versions of gcc and clang.
   # -----------------------------------------------------------------------------------------------
   unittest:
@@ -49,7 +61,7 @@ jobs:
   # Build ubuntu package, release artifact and update "latest" release if necessary.
   # -----------------------------------------------------------------------------------------------
   build_ubuntu:
-    needs: unittest
+    needs: [unittest, formatting-check]
 
     name: Build ubuntu-latest
     runs-on: ubuntu-latest
@@ -103,7 +115,7 @@ jobs:
   # Build macos package, release artifact and update "latest" release if necessary.
   # -----------------------------------------------------------------------------------------------
   build_macos:
-    needs: unittest
+    needs: [unittest, formatting-check]
 
     name: Build macos-11
     runs-on: macos-11
@@ -141,7 +153,7 @@ jobs:
   # Build windows package, release artifact and update "latest" release if necessary.
   # -----------------------------------------------------------------------------------------------
   build_windows:
-    needs: unittest
+    needs: [unittest, formatting-check]
 
     name: Build windows-amd64
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,11 +243,18 @@ endif()
 # Formatting via clang-format
 if(USE_FORMAT)
     include(ClangFormat)
-    target_clangformat_setup(openomf_core)
-    target_clangformat_setup(openomf)
-    foreach(TARGET ${TOOL_TARGET_NAMES})
-        target_clangformat_setup(${TARGET})
-    endforeach()
+    file(
+        GLOB_RECURSE
+        SRC_FILES
+        RELATIVE ${CMAKE_SOURCE_DIR}
+        "include/*.h"
+        "src/*.c"
+        "tools/*.c"
+        "tools/*.h"
+        "testing/*.c"
+        "testing/*.h"
+    )
+    clangformat_setup(${SRC_FILES})
     message(STATUS "Development: clang-format enabled")
 else()
     message(STATUS "Development: clang-format disabled")

--- a/include/audio/audio.h
+++ b/include/audio/audio.h
@@ -2,21 +2,21 @@
 #define AUDIO_H
 
 #include "audio/music.h"
-#include "audio/sound.h"
 #include "audio/sink.h"
+#include "audio/sound.h"
 #include "audio/source.h"
-#include "audio/stream.h"
 #include "audio/sources/dumb_source.h"
 #include "audio/sources/vorbis_source.h"
+#include "audio/stream.h"
 
 int audio_get_sink_count();
-const char* audio_get_sink_name(int id);
-int audio_is_sink_available(const char* sink_name);
-const char* audio_get_first_sink_name();
-int audio_init(const char* sink_name);
+const char *audio_get_sink_name(int id);
+int audio_is_sink_available(const char *sink_name);
+const char *audio_get_first_sink_name();
+int audio_init(const char *sink_name);
 void audio_render();
 void audio_close();
 
-audio_sink* audio_get_sink();
+audio_sink *audio_get_sink();
 
 #endif // AUDIO_H

--- a/include/audio/music.h
+++ b/include/audio/music.h
@@ -4,8 +4,8 @@
 #include "audio/source.h"
 
 typedef struct {
-	int id;
-	const char *name;
+    int id;
+    const char *name;
 } module_source;
 
 int music_play(unsigned int id);
@@ -15,8 +15,8 @@ void music_stop();
 int music_playing();
 void music_set_volume(float volume);
 unsigned int music_get_resource();
-module_source* music_get_module_sources();
-audio_source_freq* music_module_get_freqs(int id);
-audio_source_resampler* music_module_get_resamplers(int id);
+module_source *music_get_module_sources();
+audio_source_freq *music_module_get_freqs(int id);
+audio_source_resampler *music_module_get_resamplers(int id);
 
 #endif // MUSIC_H

--- a/include/audio/sink.h
+++ b/include/audio/sink.h
@@ -1,9 +1,9 @@
 #ifndef SINK_H
 #define SINK_H
 
-#include "utils/hashmap.h"
-#include "audio/stream.h"
 #include "audio/source.h"
+#include "audio/stream.h"
+#include "utils/hashmap.h"
 
 #define VOLUME_DEFAULT 1.0f
 #define PANNING_DEFAULT 0.0f
@@ -49,7 +49,7 @@ float sink_get_stream_volume(audio_sink *sink, int sid);
 float sink_get_stream_pitch(audio_sink *sink, int sid);
 
 void sink_set_userdata(audio_sink *sink, void *userdata);
-void* sink_get_userdata(audio_sink *sink);
+void *sink_get_userdata(audio_sink *sink);
 void sink_set_close_cb(audio_sink *sink, sink_close_cb cbfunc);
 void sink_set_format_stream_cb(audio_sink *sink, sink_format_stream_cb cbfunc);
 

--- a/include/audio/sinks/openal_stream.h
+++ b/include/audio/sinks/openal_stream.h
@@ -3,8 +3,8 @@
 
 #ifdef USE_OPENAL
 
-#include "audio/stream.h"
 #include "audio/sink.h"
+#include "audio/stream.h"
 
 int openal_stream_init(audio_stream *stream, audio_sink *sink);
 

--- a/include/audio/source.h
+++ b/include/audio/source.h
@@ -20,13 +20,13 @@ struct audio_source_t {
 typedef struct {
     int internal_id;
     int is_default;
-    const char* name;
+    const char *name;
 } audio_source_resampler;
 
 typedef struct {
     int freq;
     int is_default;
-    const char* name;
+    const char *name;
 } audio_source_freq;
 
 void source_init(audio_source *src);
@@ -46,7 +46,7 @@ int source_get_loop(audio_source *src);
 int source_get_resampler(audio_source *src);
 
 void source_set_userdata(audio_source *src, void *userdata);
-void* source_get_userdata(audio_source *src);
+void *source_get_userdata(audio_source *src);
 void source_set_update_cb(audio_source *src, source_update_cb cbfunc);
 void source_set_close_cb(audio_source *src, source_close_cb cbfunc);
 

--- a/include/audio/sources/dumb_source.h
+++ b/include/audio/sources/dumb_source.h
@@ -5,9 +5,9 @@
 
 #include "audio/source.h"
 
-int dumb_source_init(audio_source *src, const char* file, int channels, int freq, int resampler);
-audio_source_freq* dumb_get_freqs();
-audio_source_resampler* dumb_get_resamplers();
+int dumb_source_init(audio_source *src, const char *file, int channels, int freq, int resampler);
+audio_source_freq *dumb_get_freqs();
+audio_source_resampler *dumb_get_resamplers();
 
 #endif // USE_DUMB
 

--- a/include/audio/sources/vorbis_source.h
+++ b/include/audio/sources/vorbis_source.h
@@ -5,7 +5,7 @@
 
 #include "audio/source.h"
 
-int vorbis_source_init(audio_source *src, const char* file);
+int vorbis_source_init(audio_source *src, const char *file);
 
 #endif // USE_OGGVORBIS
 

--- a/include/audio/sources/xmp_source.h
+++ b/include/audio/sources/xmp_source.h
@@ -5,9 +5,9 @@
 
 #include "audio/source.h"
 
-int xmp_source_init(audio_source *src, const char* file, int channels, int freq, int resampler);
-audio_source_freq* xmp_get_freqs();
-audio_source_resampler* xmp_get_resamplers();
+int xmp_source_init(audio_source *src, const char *file, int channels, int freq, int resampler);
+audio_source_freq *xmp_get_freqs();
+audio_source_resampler *xmp_get_resamplers();
 
 #endif // USE_XMP
 

--- a/include/audio/stream.h
+++ b/include/audio/stream.h
@@ -11,7 +11,8 @@ typedef void (*stream_update_cb)(audio_stream *stream);
 typedef void (*stream_apply_cb)(audio_stream *stream);
 typedef void (*stream_close_cb)(audio_stream *stream);
 
-enum {
+enum
+{
     STREAM_STATUS_PLAYING,
     STREAM_STATUS_STOPPED,
     STREAM_STATUS_FINISHED
@@ -44,7 +45,7 @@ void stream_set_finished(audio_stream *stream);
 int stream_get_status(audio_stream *stream);
 
 void stream_set_userdata(audio_stream *stream, void *userdata);
-void* stream_get_userdata(audio_stream *stream);
+void *stream_get_userdata(audio_stream *stream);
 void stream_set_update_cb(audio_stream *stream, stream_update_cb cbfunc);
 void stream_set_close_cb(audio_stream *stream, stream_close_cb cbfunc);
 void stream_set_play_cb(audio_stream *stream, stream_play_cb cbfunc);

--- a/include/console/console.h
+++ b/include/console/console.h
@@ -1,11 +1,11 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
-#include <SDL.h>
 #include "game/game_state_type.h"
+#include <SDL.h>
 
 // return 0 on success, otherwise return error code
-typedef int(*command_func)(game_state *scene, int argc, char **argv);
+typedef int (*command_func)(game_state *scene, int argc, char **argv);
 
 int console_init();
 void console_close();

--- a/include/console/console_type.h
+++ b/include/console/console_type.h
@@ -1,8 +1,8 @@
 #ifndef CONSOLE_TYPE_H
 #define CONSOLE_TYPE_H
 
-#include <SDL.h>
 #include "game/protos/scene.h"
+#include <SDL.h>
 
 typedef struct console_t {
     font font;

--- a/include/controller/controller.h
+++ b/include/controller/controller.h
@@ -1,12 +1,13 @@
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
 
-#include "game/protos/object.h"
 #include "game/objects/har.h"
+#include "game/protos/object.h"
 #include "game/utils/serial.h"
 #include "utils/list.h"
 
-enum {
+enum
+{
     ACT_STOP = 0x01,
     ACT_KICK = 0x02,
     ACT_PUNCH = 0x04,
@@ -18,7 +19,8 @@ enum {
     ACT_FLUSH = 0x100
 };
 
-enum {
+enum
+{
     CTRL_TYPE_KEYBOARD,
     CTRL_TYPE_GAMEPAD,
     CTRL_TYPE_NETWORK,
@@ -26,7 +28,8 @@ enum {
     CTRL_TYPE_REC
 };
 
-enum {
+enum
+{
     EVENT_TYPE_ACTION,
     EVENT_TYPE_SYNC,
     EVENT_TYPE_HB,
@@ -63,16 +66,16 @@ struct controller_t {
     int repeat;
 };
 
-void controller_init(controller* ctrl);
-void controller_cmd(controller* ctrl, int action, ctrl_event **ev);
+void controller_init(controller *ctrl);
+void controller_cmd(controller *ctrl, int action, ctrl_event **ev);
 void controller_sync(controller *ctrl, const serial *ser, ctrl_event **ev);
-void controller_close(controller* ctrl, ctrl_event **ev);
+void controller_close(controller *ctrl, ctrl_event **ev);
 int controller_poll(controller *ctrl, ctrl_event **ev);
 int controller_tick(controller *ctrl, int ticks, ctrl_event **ev);
 int controller_dyntick(controller *ctrl, int ticks, ctrl_event **ev);
 int controller_update(controller *ctrl, serial *state);
 int controller_har_hook(controller *ctrl, har_event event);
-void controller_add_hook(controller *ctrl, controller *source, void(*fp)(controller *ctrl, int act_type));
+void controller_add_hook(controller *ctrl, controller *source, void (*fp)(controller *ctrl, int act_type));
 void controller_clear_hooks(controller *ctrl);
 void controller_free_chain(ctrl_event *ev);
 void controller_set_repeat(controller *ctrl, int repeat);

--- a/include/controller/joystick.h
+++ b/include/controller/joystick.h
@@ -28,7 +28,6 @@ struct joystick_t {
 int joystick_create(controller *ctrl, int joystick_id);
 void joystick_free(controller *ctrl);
 
-
 int joystick_count();
 int joystick_nth_id(int n);
 int joystick_name_to_id(const char *name, int offset);

--- a/include/engine.h
+++ b/include/engine.h
@@ -7,8 +7,8 @@ typedef struct engine_init_flags_t {
     char rec_file[255];
 } engine_init_flags;
 
-int engine_init(); // Init window, audiodevice, etc.
+int engine_init();                              // Init window, audiodevice, etc.
 void engine_run(engine_init_flags *init_flags); // Run game
-void engine_close(); // Kill window, audiodev
+void engine_close();                            // Kill window, audiodev
 
 #endif // ENGINE_H

--- a/include/formats/actions.h
+++ b/include/formats/actions.h
@@ -10,17 +10,18 @@
 #define SD_ACTIONS_H
 
 /*! \brief Contains all actions a HAR can do during a match
-*/
-typedef enum {
-    SD_ACT_NONE =  0x0,  ///< No action
+ */
+typedef enum
+{
+    SD_ACT_NONE = 0x0,   ///< No action
     SD_ACT_PUNCH = 0x1,  ///< Punch/select
-    SD_ACT_KICK  = 0x2,  ///< Kick/select
-    SD_ACT_UP    = 0x4,  ///< Move up (jump)
-    SD_ACT_DOWN  = 0x8,  ///< Move down (crouch)
-    SD_ACT_LEFT  = 0x10, ///< Move left (walk)
+    SD_ACT_KICK = 0x2,   ///< Kick/select
+    SD_ACT_UP = 0x4,     ///< Move up (jump)
+    SD_ACT_DOWN = 0x8,   ///< Move down (crouch)
+    SD_ACT_LEFT = 0x10,  ///< Move left (walk)
     SD_ACT_RIGHT = 0x20, ///< Move right (walk)
 } sd_action;
 
-#define SD_MOVE_MASK (SD_ACT_UP|SD_ACT_DOWN|SD_ACT_LEFT|SD_ACT_RIGHT) ///< Mask of all movement keys
+#define SD_MOVE_MASK (SD_ACT_UP | SD_ACT_DOWN | SD_ACT_LEFT | SD_ACT_RIGHT) ///< Mask of all movement keys
 
 #endif // SD_ACTIONS_H

--- a/include/formats/af.h
+++ b/include/formats/af.h
@@ -10,8 +10,8 @@
 #ifndef SD_AF_H
 #define SD_AF_H
 
-#include <stdint.h>
 #include "formats/move.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,20 +24,20 @@ extern "C" {
  * Contains information about a single HAR (combat robot).
  */
 typedef struct {
-    uint16_t file_id;  ///< File ID
+    uint16_t file_id;     ///< File ID
     uint16_t exec_window; ///< Move execution window (?)
-    float endurance; ///< HAR Endurance
-    uint8_t unknown_b; ///< Unknown value
-    uint16_t health; ///< HAR Health
-    float forward_speed; ///< HAR fwd speed
-    float reverse_speed; ///< HAR bwd speed
-    float jump_speed; ///< HAR jump speed
-    float fall_speed; ///< HAR fall speed
-    uint8_t unknown_c; ///< Unknown value
-    uint8_t unknown_d; ///< Unknown value
+    float endurance;      ///< HAR Endurance
+    uint8_t unknown_b;    ///< Unknown value
+    uint16_t health;      ///< HAR Health
+    float forward_speed;  ///< HAR fwd speed
+    float reverse_speed;  ///< HAR bwd speed
+    float jump_speed;     ///< HAR jump speed
+    float fall_speed;     ///< HAR fall speed
+    uint8_t unknown_c;    ///< Unknown value
+    uint8_t unknown_d;    ///< Unknown value
 
     sd_move *moves[MAX_AF_MOVES]; ///< All HAR moves.
-    char soundtable[30]; ///< All sounds used by the animations in this HAR file.
+    char soundtable[30];          ///< All sounds used by the animations in this HAR file.
 } sd_af_file;
 
 /*! \brief Initialize AF file structure
@@ -96,7 +96,7 @@ int sd_af_set_move(sd_af_file *af, int index, const sd_move *move);
  * \param af AF struct pointer.
  * \param index Index of the move. Must be 0 <= index <= 69.
  */
-sd_move* sd_af_get_move(sd_af_file *af, int index);
+sd_move *sd_af_get_move(sd_af_file *af, int index);
 
 /*! \brief Load AF file
  *
@@ -124,7 +124,7 @@ int sd_af_load(sd_af_file *af, const char *filename);
  * \param af AF struct pointer.
  * \param filename Name of the AF file
  */
-int sd_af_save(const sd_af_file *af, const char* filename);
+int sd_af_save(const sd_af_file *af, const char *filename);
 
 /*! \brief Free AF file structure
  *

--- a/include/formats/animation.h
+++ b/include/formats/animation.h
@@ -10,23 +10,22 @@
 #ifndef SD_ANIMATION_H
 #define SD_ANIMATION_H
 
-#include <stdint.h>
-#include "formats/sprite.h"
 #include "formats/colcoord.h"
 #include "formats/internal/reader.h"
 #include "formats/internal/writer.h"
-
+#include "formats/sprite.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define SD_ANIMATION_STRING_MAX 1024 ///< Maximum animation string size
-#define SD_EXTRA_STRING_MAX 512 ///< Maximum extra string size
+#define SD_EXTRA_STRING_MAX 512      ///< Maximum extra string size
 
-#define SD_SPRITE_COUNT_MAX 255 ///< Maximum amount of sprites allowed (technical limitation)
+#define SD_SPRITE_COUNT_MAX 255   ///< Maximum amount of sprites allowed (technical limitation)
 #define SD_COLCOORD_COUNT_MAX 256 ///< Maximum amount of collision coordinates allowed \todo find out the real maximum
-#define SD_EXTRASTR_COUNT_MAX 10 ///< Maximum amount of extra strings.
+#define SD_EXTRASTR_COUNT_MAX 10  ///< Maximum amount of extra strings.
 
 /*! \brief Generic animation container
  *
@@ -42,19 +41,19 @@ extern "C" {
  */
 typedef struct {
     // Header
-    int16_t start_x; ///< Animation start position, X-axis
-    int16_t start_y; ///< Animation start position, Y-axis
-    int32_t null; ///< Probably filler data
-    uint16_t coord_count; ///< Number of collision coordinates in animation frames
-    uint8_t sprite_count; ///< Number of sprites in animation
+    int16_t start_x;            ///< Animation start position, X-axis
+    int16_t start_y;            ///< Animation start position, Y-axis
+    int32_t null;               ///< Probably filler data
+    uint16_t coord_count;       ///< Number of collision coordinates in animation frames
+    uint8_t sprite_count;       ///< Number of sprites in animation
     uint8_t extra_string_count; ///< Number of extra strings in animation
 
     // Sprites and their collision coordinates
     sd_coord coord_table[SD_COLCOORD_COUNT_MAX]; ///< Collision coordinates
-    sd_sprite *sprites[SD_SPRITE_COUNT_MAX]; ///< Sprites
+    sd_sprite *sprites[SD_SPRITE_COUNT_MAX];     ///< Sprites
 
     // String header & Extra strings
-    char anim_string[SD_ANIMATION_STRING_MAX]; ///< Animation string
+    char anim_string[SD_ANIMATION_STRING_MAX];                      ///< Animation string
     char extra_strings[SD_EXTRASTR_COUNT_MAX][SD_EXTRA_STRING_MAX]; ///< Extra strings
 } sd_animation;
 
@@ -67,7 +66,7 @@ typedef struct {
  *
  * \param animation Allocated animation struct pointer.
  */
-int sd_animation_create(sd_animation* animation);
+int sd_animation_create(sd_animation *animation);
 
 /*! \brief Copy animation structure
  *
@@ -152,7 +151,7 @@ int sd_animation_pop_coord(sd_animation *animation);
  * \param animation Animation struct to modify
  * \param num Coordinate index
  */
-sd_coord* sd_animation_get_coord(sd_animation *animation, int num);
+sd_coord *sd_animation_get_coord(sd_animation *animation, int num);
 
 /*! \brief Sets the animation string
  *
@@ -228,7 +227,7 @@ int sd_animation_pop_extra_string(sd_animation *animation);
  * \param animation Animation struct to modify.
  * \param num Extra string index
  */
-char* sd_animation_get_extra_string(sd_animation *animation, int num);
+char *sd_animation_get_extra_string(sd_animation *animation, int num);
 
 /*! \brief Get extra string count
  *
@@ -292,12 +291,10 @@ int sd_animation_pop_sprite(sd_animation *animation);
  * \param animation Animation struct to modify.
  * \param num Sprite index
  */
-sd_sprite* sd_animation_get_sprite(sd_animation *animation, int num);
-
+sd_sprite *sd_animation_get_sprite(sd_animation *animation, int num);
 
 int sd_animation_load(sd_reader *reader, sd_animation *animation);
 int sd_animation_save(sd_writer *writer, const sd_animation *animation);
-
 
 #ifdef __cplusplus
 }

--- a/include/formats/bk.h
+++ b/include/formats/bk.h
@@ -10,16 +10,16 @@
 #ifndef SD_BK_H
 #define SD_BK_H
 
-#include <stdint.h>
-#include "formats/palette.h"
 #include "formats/bkanim.h"
+#include "formats/palette.h"
 #include "formats/vga_image.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define MAX_BK_ANIMS 50 ///< Amount of animations in the BK file. This is fixed!
+#define MAX_BK_ANIMS 50   ///< Amount of animations in the BK file. This is fixed!
 #define MAX_BK_PALETTES 8 ///< Maximum amount of palettes allowed in BK file.
 
 /*! \brief BK file information
@@ -27,12 +27,12 @@ extern "C" {
  * Contains information about an OMF:2097 scene. Eg. arenas, menus, intro, etc.
  */
 typedef struct {
-    uint32_t file_id; ///< File ID
-    uint8_t unknown_a; ///< Unknown value
+    uint32_t file_id;      ///< File ID
+    uint8_t unknown_a;     ///< Unknown value
     uint8_t palette_count; ///< Number of palettes in the BK file
 
-    sd_bk_anim *anims[MAX_BK_ANIMS]; ///< All animations contained by the BK file
-    sd_vga_image *background; ///< Background image. If NULL, a black background will be used.
+    sd_bk_anim *anims[MAX_BK_ANIMS];    ///< All animations contained by the BK file
+    sd_vga_image *background;           ///< Background image. If NULL, a black background will be used.
     palette *palettes[MAX_BK_PALETTES]; ///< All palettes in the BK file.
 
     char soundtable[30]; ///< All sounds used by the animations in this BK file.
@@ -91,7 +91,7 @@ int sd_bk_set_background(sd_bk_file *bk, const sd_vga_image *img);
  *
  * \param bk BK struct pointer.
  */
-sd_vga_image* sd_bk_get_background(const sd_bk_file *bk);
+sd_vga_image *sd_bk_get_background(const sd_bk_file *bk);
 
 /*! \brief Set bk animation
  *
@@ -123,7 +123,7 @@ int sd_bk_set_anim(sd_bk_file *bk, int index, const sd_bk_anim *anim);
  * \param bk BK struct pointer.
  * \param index Animation index. Must be 0 <= index <= 49
  */
-sd_bk_anim* sd_bk_get_anim(const sd_bk_file *bk, int index);
+sd_bk_anim *sd_bk_get_anim(const sd_bk_file *bk, int index);
 
 /*! \brief Set palette
  *
@@ -212,7 +212,7 @@ int sd_bk_load(sd_bk_file *bk, const char *filename);
  * \param bk BK struct pointer.
  * \param filename Name of the BK file to save into.
  */
-int sd_bk_save(const sd_bk_file *bk, const char* filename);
+int sd_bk_save(const sd_bk_file *bk, const char *filename);
 
 /*! \brief Free BK file structure
  *

--- a/include/formats/bkanim.h
+++ b/include/formats/bkanim.h
@@ -10,11 +10,10 @@
 #ifndef SD_BKANIM_H
 #define SD_BKANIM_H
 
-#include <stdint.h>
 #include "formats/animation.h"
 #include "formats/internal/reader.h"
 #include "formats/internal/writer.h"
-
+#include <stdint.h>
 
 #define SD_BK_FOOTER_STRING_MAX 512 ///< Max BK footer string length
 
@@ -27,16 +26,15 @@ extern "C" {
  * Information about the BK specific animation things.
  */
 typedef struct {
-    uint8_t null; ///< Always 0 ?
-    uint8_t chain_hit; ///< Animation to chain to if collision/hit
-    uint8_t chain_no_hit; ///< Animation to chain to on no collision/hit
-    uint8_t load_on_start; ///< Actually repeat flag
-    uint16_t probability; ///< Probability of animation
-    uint8_t hazard_damage; ///< Hazard damage on hit
+    uint8_t null;                                ///< Always 0 ?
+    uint8_t chain_hit;                           ///< Animation to chain to if collision/hit
+    uint8_t chain_no_hit;                        ///< Animation to chain to on no collision/hit
+    uint8_t load_on_start;                       ///< Actually repeat flag
+    uint16_t probability;                        ///< Probability of animation
+    uint8_t hazard_damage;                       ///< Hazard damage on hit
     char footer_string[SD_BK_FOOTER_STRING_MAX]; ///< Footer string
-    sd_animation *animation; ///< Animation ptr or NULL. On BK save, must be != NULL.
+    sd_animation *animation;                     ///< Animation ptr or NULL. On BK save, must be != NULL.
 } sd_bk_anim;
-
 
 /*! \brief Initialize BK animation info structure
  *
@@ -101,7 +99,7 @@ int sd_bk_anim_set_animation(sd_bk_anim *bka, const sd_animation *animation);
  *
  * \param bka BK animation info struct to modify.
  */
-sd_animation* sd_bk_anim_get_animation(const sd_bk_anim *bka);
+sd_animation *sd_bk_anim_get_animation(const sd_bk_anim *bka);
 
 /*! \brief Set BK animation info footer string
  *

--- a/include/formats/chr.h
+++ b/include/formats/chr.h
@@ -11,8 +11,8 @@
 #define SD_CHR_H
 
 #include "formats/palette.h"
-#include "formats/sprite.h"
 #include "formats/pilot.h"
+#include "formats/sprite.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,8 +25,8 @@ extern "C" {
  * Contains information about the current state of an enemy in the selected tournament.
  */
 typedef struct {
-    sd_pilot pilot;      ///< Enemy pilot data
-    char unknown[25];    ///< Unknown data TODO: Find out what this does
+    sd_pilot pilot;   ///< Enemy pilot data
+    char unknown[25]; ///< Unknown data TODO: Find out what this does
 } sd_chr_enemy;
 
 /*! \brief CHR Saved game
@@ -35,10 +35,10 @@ typedef struct {
  * \todo find out what the unknown data fields are.
  */
 typedef struct {
-    sd_pilot pilot;      ///< Pilot data
-    palette pal;         ///< Pilot palette
-    uint32_t unknown_b;  ///< Unkown value. Maybe tells if there is photo data ?
-    sd_sprite *photo;    ///< Pilot photo
+    sd_pilot pilot;                         ///< Pilot data
+    palette pal;                            ///< Pilot palette
+    uint32_t unknown_b;                     ///< Unkown value. Maybe tells if there is photo data ?
+    sd_sprite *photo;                       ///< Pilot photo
     sd_chr_enemy *enemies[MAX_CHR_ENEMIES]; ///< List of enemy states in current tournament
 } sd_chr_file;
 
@@ -103,7 +103,7 @@ int sd_chr_save(sd_chr_file *chr, const char *filename);
  * \param chr CHR struct pointer.
  * \param enemy_num Enemy number to find
  */
-const sd_chr_enemy* sd_chr_get_enemy(sd_chr_file *chr, int enemy_num);
+const sd_chr_enemy *sd_chr_get_enemy(sd_chr_file *chr, int enemy_num);
 
 #ifdef __cplusplus
 }

--- a/include/formats/colcoord.h
+++ b/include/formats/colcoord.h
@@ -24,9 +24,9 @@ extern "C" {
  * frame_id entry tells which sprite in animation the coordinate belongs to.
  */
 typedef struct {
-    int16_t x; ///< X position coordinate
-    int16_t y; ///< Y position coordinate
-    uint8_t null; ///< Probably null padding
+    int16_t x;        ///< X position coordinate
+    int16_t y;        ///< Y position coordinate
+    uint8_t null;     ///< Probably null padding
     uint8_t frame_id; ///< Sprite the coordinate belongs to
 } sd_coord;
 

--- a/include/formats/error.h
+++ b/include/formats/error.h
@@ -16,26 +16,27 @@ extern "C" {
 #endif
 
 #ifdef DEBUGMODE
-    void debug_print(const char* fn, int line, const char *fmt, ...);
-    #define DEBUGLOG(...) debug_print(__func__, __LINE__, __VA_ARGS__)
+void debug_print(const char *fn, int line, const char *fmt, ...);
+#define DEBUGLOG(...) debug_print(__func__, __LINE__, __VA_ARGS__)
 #else
-    #define DEBUGLOG(...) ///< Prints debug text if the debugging mode is on.
+#define DEBUGLOG(...) ///< Prints debug text if the debugging mode is on.
 #endif
 
 /*! \brief Errorcode list.
  */
-enum SD_ERRORCODE {
-    SD_SUCCESS, ///< Success message
-    SD_FILE_OPEN_ERROR, ///< File could not be opened
-    SD_FILE_INVALID_TYPE, ///< File was of invalid type
-    SD_FILE_PARSE_ERROR, ///< File had a syntax error
-    SD_ANIM_INVALID_STRING, ///< Invalid animation string
-    SD_OUT_OF_MEMORY, ///< Out of memory error
-    SD_INVALID_INPUT, ///< Function encountered unexpected/invalid arguments
+enum SD_ERRORCODE
+{
+    SD_SUCCESS,              ///< Success message
+    SD_FILE_OPEN_ERROR,      ///< File could not be opened
+    SD_FILE_INVALID_TYPE,    ///< File was of invalid type
+    SD_FILE_PARSE_ERROR,     ///< File had a syntax error
+    SD_ANIM_INVALID_STRING,  ///< Invalid animation string
+    SD_OUT_OF_MEMORY,        ///< Out of memory error
+    SD_INVALID_INPUT,        ///< Function encountered unexpected/invalid arguments
     SD_FORMAT_NOT_SUPPORTED, ///< File format is not supported
-    SD_INVALID_TAG, ///< Invalid tag in animation string
-    SD_FILE_WRITE_ERROR, ///< File could not be written
-    SD_FILE_READ_ERROR ///< File could not be read
+    SD_INVALID_TAG,          ///< Invalid tag in animation string
+    SD_FILE_WRITE_ERROR,     ///< File could not be written
+    SD_FILE_READ_ERROR       ///< File could not be read
 };
 
 /*! \brief Get text error for error ID
@@ -46,7 +47,7 @@ enum SD_ERRORCODE {
  * \param errorcode Errorcode
  * \return Error message
  */
-const char* sd_get_error(int errorcode);
+const char *sd_get_error(int errorcode);
 
 #ifdef __cplusplus
 }

--- a/include/formats/fonts.h
+++ b/include/formats/fonts.h
@@ -10,8 +10,8 @@
 #ifndef SD_FONTS_H
 #define SD_FONTS_H
 
-#include <stdint.h>
 #include "formats/rgba_image.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -98,13 +98,7 @@ int sd_font_save(const sd_font *font, const char *filename);
  * \param g Green color index (0 - 0xFF)
  * \param b Blue color index (0 - 0xFF)
  */
-int sd_font_decode(
-    const sd_font *font,
-    sd_rgba_image* surface,
-    uint8_t ch,
-    uint8_t r,
-    uint8_t g,
-    uint8_t b);
+int sd_font_decode(const sd_font *font, sd_rgba_image *surface, uint8_t ch, uint8_t r, uint8_t g, uint8_t b);
 
 #ifdef __cplusplus
 }

--- a/include/formats/internal/memreader.h
+++ b/include/formats/internal/memreader.h
@@ -1,8 +1,8 @@
 #ifndef MEMREADER_H
 #define MEMREADER_H
 
-#include <stdint.h>
 #include "formats/internal/reader.h"
+#include <stdint.h>
 
 typedef struct memreader_t {
     char *buf;
@@ -11,8 +11,8 @@ typedef struct memreader_t {
     long pos;
 } memreader;
 
-memreader* memreader_open(char *buf, long len);
-memreader* memreader_open_from_reader(sd_reader *reader, int len);
+memreader *memreader_open(char *buf, long len);
+memreader *memreader_open_from_reader(sd_reader *reader, int len);
 void memreader_close(memreader *reader);
 long memreader_size(const memreader *reader);
 long memreader_pos(const memreader *reader);

--- a/include/formats/internal/memwriter.h
+++ b/include/formats/internal/memwriter.h
@@ -1,8 +1,8 @@
 #ifndef MEMWRITER_H
 #define MEMWRITER_H
 
-#include <stdint.h>
 #include "formats/internal/writer.h"
+#include <stdint.h>
 
 typedef struct memwriter_t {
     char *buf;
@@ -10,7 +10,7 @@ typedef struct memwriter_t {
     long data_len; // Current data size in buffer
 } memwriter;
 
-memwriter* memwriter_open();
+memwriter *memwriter_open();
 void memwriter_save(const memwriter *src, sd_writer *dst);
 void memwriter_close(memwriter *writer);
 long memwriter_pos(const memwriter *writer);

--- a/include/formats/internal/reader.h
+++ b/include/formats/internal/reader.h
@@ -1,14 +1,14 @@
 #ifndef SD_READER_H
 #define SD_READER_H
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "utils/str.h"
 
 typedef struct sd_reader sd_reader;
 
-sd_reader* sd_reader_open(const char *file);
+sd_reader *sd_reader_open(const char *file);
 
 /**
  * Check for errors
@@ -41,17 +41,17 @@ int16_t sd_peek_word(sd_reader *reader);
 int32_t sd_peek_dword(sd_reader *reader);
 float sd_peek_float(sd_reader *reader);
 
-int sd_read_scan(const sd_reader *reader, const char* format, ...);
+int sd_read_scan(const sd_reader *reader, const char *format, ...);
 int sd_read_line(const sd_reader *reader, char *buffer, int maxlen);
 
 /**
-  * Compare following nbytes amount of data and given buffer. Does not advance file pointer.
-  */
+ * Compare following nbytes amount of data and given buffer. Does not advance file pointer.
+ */
 int sd_match(sd_reader *reader, const char *buf, unsigned int nbytes);
 
 /**
-  * Skip following nbytes amount of data.
-  */
+ * Skip following nbytes amount of data.
+ */
 void sd_skip(sd_reader *reader, unsigned int nbytes);
 
 /**
@@ -65,6 +65,6 @@ void sd_skip(sd_reader *reader, unsigned int nbytes);
  */
 void sd_read_str(sd_reader *reader, str *dst);
 
-char* sd_read_variable_str(sd_reader *r);
+char *sd_read_variable_str(sd_reader *r);
 
 #endif // SD_READER_H

--- a/include/formats/internal/writer.h
+++ b/include/formats/internal/writer.h
@@ -1,17 +1,17 @@
 #ifndef SD_WRITER_H
 #define SD_WRITER_H
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "utils/str.h"
 
 typedef struct sd_writer sd_writer;
 
 /**
-  * Open file for writing. If file exists, it will be overwritten.
-  */
-sd_writer* sd_writer_open(const char *file);
+ * Open file for writing. If file exists, it will be overwritten.
+ */
+sd_writer *sd_writer_open(const char *file);
 
 /**
  * Check for errors
@@ -19,13 +19,13 @@ sd_writer* sd_writer_open(const char *file);
 int sd_writer_errno(const sd_writer *writer);
 
 /**
-  * Close file.
-  */
+ * Close file.
+ */
 void sd_writer_close(sd_writer *writer);
 
 /**
-  * Returns the position of the file pointer
-  */
+ * Returns the position of the file pointer
+ */
 long sd_writer_pos(sd_writer *writer);
 
 int sd_writer_seek_start(const sd_writer *writer, long offset);
@@ -33,8 +33,8 @@ int sd_writer_seek_cur(const sd_writer *writer, long offset);
 int sd_writer_seek_end(const sd_writer *writer, long offset);
 
 /**
-  * Write a buffer to file.
-  */
+ * Write a buffer to file.
+ */
 int sd_write_buf(sd_writer *writer, const char *buf, int len);
 
 int sd_write_fprintf(const sd_writer *writer, const char *format, ...);
@@ -54,7 +54,7 @@ void sd_write_fill(sd_writer *writer, char content, int len);
 
 /**
  * @brief Writes a string object
- * 
+ *
  * @param writer Writer object
  * @param src Source string
  * @param null_terminated Should the string be null terminated when written (true = yes);

--- a/include/formats/language.h
+++ b/include/formats/language.h
@@ -93,7 +93,7 @@ int sd_language_save(sd_language *language, const char *filename);
  * \param language Language struct pointer.
  * \param num Language entry number to get.
  */
-const sd_lang_string* sd_language_get(const sd_language *language, int num);
+const sd_lang_string *sd_language_get(const sd_language *language, int num);
 
 #ifdef __cplusplus
 }

--- a/include/formats/move.h
+++ b/include/formats/move.h
@@ -10,16 +10,16 @@
 #ifndef SD_MOVE_H
 #define SD_MOVE_H
 
-#include <stdint.h>
 #include "formats/animation.h"
 #include "formats/internal/reader.h"
 #include "formats/internal/writer.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define SD_MOVE_STRING_MAX 21 ///< Maximum allowed move string length
+#define SD_MOVE_STRING_MAX 21         ///< Maximum allowed move string length
 #define SD_MOVE_FOOTER_STRING_MAX 512 ///< Maximum allowed footer string length
 
 /*! \brief HAR Move information
@@ -30,27 +30,27 @@ extern "C" {
 typedef struct {
     sd_animation *animation; ///< Animation field for Move. When saving AF file, this should be != NULL.
 
-    uint16_t unknown_0; ///< Unknown value
-    uint16_t unknown_2; ///< Unknown value
-    uint8_t unknown_4; ///< Unknown value
-    uint8_t unknown_5; ///< Unknown value
-    uint8_t unknown_6; ///< Unknown value
-    uint8_t unknown_7; ///< Unknown value
-    uint8_t unknown_8; ///< Unknown value
-    uint8_t unknown_9; ///< Unknown value
-    uint8_t unknown_10; ///< Unknown value
-    uint8_t unknown_11; ///< Unknown value
-    uint8_t next_anim_id; ///< Next animation ID
-    uint8_t category; ///< Move category ID
-    uint8_t unknown_14; ///< Unknown value
-    uint8_t scrap_amount; ///< Scrap amount when this move connects
-    uint8_t successor_id; ///< Successor animation ID
+    uint16_t unknown_0;    ///< Unknown value
+    uint16_t unknown_2;    ///< Unknown value
+    uint8_t unknown_4;     ///< Unknown value
+    uint8_t unknown_5;     ///< Unknown value
+    uint8_t unknown_6;     ///< Unknown value
+    uint8_t unknown_7;     ///< Unknown value
+    uint8_t unknown_8;     ///< Unknown value
+    uint8_t unknown_9;     ///< Unknown value
+    uint8_t unknown_10;    ///< Unknown value
+    uint8_t unknown_11;    ///< Unknown value
+    uint8_t next_anim_id;  ///< Next animation ID
+    uint8_t category;      ///< Move category ID
+    uint8_t unknown_14;    ///< Unknown value
+    uint8_t scrap_amount;  ///< Scrap amount when this move connects
+    uint8_t successor_id;  ///< Successor animation ID
     uint8_t damage_amount; ///< Damage amount when this move connects
-    uint8_t unknown_18; ///< Unknown value
-    uint8_t unknown_19; ///< Unknown value
-    uint8_t points;  ///< Score gained for this hit
+    uint8_t unknown_18;    ///< Unknown value
+    uint8_t unknown_19;    ///< Unknown value
+    uint8_t points;        ///< Score gained for this hit
 
-    char move_string[SD_MOVE_STRING_MAX];  ///< Move string
+    char move_string[SD_MOVE_STRING_MAX];          ///< Move string
     char footer_string[SD_MOVE_FOOTER_STRING_MAX]; ///< Footer string
 } sd_move;
 
@@ -117,7 +117,7 @@ int sd_move_set_animation(sd_move *move, const sd_animation *animation);
  *
  * \param move Move struct to modify.
  */
-sd_animation* sd_move_get_animation(const sd_move *move);
+sd_animation *sd_move_get_animation(const sd_move *move);
 
 /*! \brief Set move footer string for the Move struct.
  *
@@ -147,7 +147,6 @@ int sd_move_set_move_string(sd_move *move, const char *str);
 
 int sd_move_load(sd_reader *reader, sd_move *move);
 int sd_move_save(sd_writer *writer, const sd_move *move);
-
 
 #ifdef __cplusplus
 }

--- a/include/formats/palette.h
+++ b/include/formats/palette.h
@@ -10,11 +10,11 @@
 #ifndef PALETTE_H
 #define PALETTE_H
 
-#include <stdint.h>
 #include "formats/internal/memreader.h"
-#include "formats/internal/reader.h"
 #include "formats/internal/memwriter.h"
+#include "formats/internal/reader.h"
 #include "formats/internal/writer.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,7 +26,7 @@ extern "C" {
  * Conversion is done automatically on palette load and save.
  */
 typedef struct {
-    unsigned char data[256][3];   ///< Palette data (256 indices, 3 channels/index)
+    unsigned char data[256][3];    ///< Palette data (256 indices, 3 channels/index)
     unsigned char remaps[19][256]; ///< Palette remapping tables.
 } palette;
 

--- a/include/formats/pic.h
+++ b/include/formats/pic.h
@@ -36,7 +36,7 @@ typedef struct {
  * Contains a list of pilot face portraits.
  */
 typedef struct {
-    int photo_count;   ///< Photo count
+    int photo_count;                      ///< Photo count
     sd_pic_photo *photos[MAX_PIC_PHOTOS]; ///< Photo array
 } sd_pic_file;
 
@@ -100,7 +100,7 @@ int sd_pic_save(const sd_pic_file *pic, const char *filename);
  * \param pic PIC file struct pointer.
  * \param entry_id Photo picture number to get.
  */
-const sd_pic_photo* sd_pic_get(const sd_pic_file *pic, int entry_id);
+const sd_pic_photo *sd_pic_get(const sd_pic_file *pic, int entry_id);
 
 #ifdef __cplusplus
 }

--- a/include/formats/pilot.h
+++ b/include/formats/pilot.h
@@ -10,13 +10,12 @@
 #ifndef SD_PILOT_H
 #define SD_PILOT_H
 
-#include <stdint.h>
-#include "formats/palette.h"
-#include "formats/internal/reader.h"
 #include "formats/internal/memreader.h"
-#include "formats/internal/writer.h"
 #include "formats/internal/memwriter.h"
-
+#include "formats/internal/reader.h"
+#include "formats/internal/writer.h"
+#include "formats/palette.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,7 +63,8 @@ typedef struct {
 
     uint8_t secret;          ///< This character is a secret character, and only comes out when requirements match
     uint8_t only_fight_once; ///< This character can only be fought once per tournament
-    uint8_t req_enemy;       ///< Required defeated enemy for this character to appear (Value 0 if not set, otherwise character id + 1)
+    uint8_t req_enemy;       ///< Required defeated enemy for this character to appear (Value 0 if not set, otherwise
+                             ///< character id + 1)
     uint8_t req_difficulty;  ///< Required difficulty level for this character to appear
     uint8_t req_rank;        ///< Required minimum ranking for this character to appear
     uint8_t req_vitality;    ///< Required vitality for this character to appear
@@ -75,41 +75,41 @@ typedef struct {
     uint8_t req_scrap;       ///< Must have scrapped an enemy for this character to appear
     uint8_t req_destroy;     ///< Must have destroyed an enemy for this character to appear
 
-    uint8_t att_normal;      ///< Standard fighting method
-    uint8_t att_hyper;       ///< More aggressive
-    uint8_t att_jump;        ///< Jumps more often
-    uint8_t att_def;         ///< More defensive
-    uint8_t att_sniper;      ///< Tries to sneak in quick hits
+    uint8_t att_normal; ///< Standard fighting method
+    uint8_t att_hyper;  ///< More aggressive
+    uint8_t att_jump;   ///< Jumps more often
+    uint8_t att_def;    ///< More defensive
+    uint8_t att_sniper; ///< Tries to sneak in quick hits
 
-    uint16_t unk_block_d[3]; ///< Unknown
-    int16_t ap_throw;        ///< AI Preference for throw moves. Accepted value range (-400, 400).
-    int16_t ap_special;      ///< AI Preference for special moves. Accepted value range (-400, 400).
-    int16_t ap_jump;         ///< AI Preference for jump moves. Accepted value range (-400, 400).
-    int16_t ap_high;         ///< AI Preference for high moves. Accepted value range (-400, 400).
-    int16_t ap_low;          ///< AI Preference for low moves. Accepted value range (-400, 400).
-    int16_t ap_middle;       ///< AI Preference for middle moves. Accepted value range (-400, 400).
-    int16_t pref_jump;       ///< AI Preference for jump movement. Accepted value range (-400, 400).
-    int16_t pref_fwd;        ///< AI Preference for forwards movement. Accepted value range (-400, 400).
-    int16_t pref_back;       ///< AI Preference for backwards movement. Accepted value range (-400, 400).
-    uint32_t unknown_e;      ///< Unknown
-    float learning;          ///< How actively this pilot learns your combat tactics. Accepted value range (0-15).
-    float forget;            ///< How quickly this pilot forgets your combat tactics. Accepted value range (0-3).
-    char unk_block_f[14];    ///< Unknown. Probably pointers and scratch variables
+    uint16_t unk_block_d[3];       ///< Unknown
+    int16_t ap_throw;              ///< AI Preference for throw moves. Accepted value range (-400, 400).
+    int16_t ap_special;            ///< AI Preference for special moves. Accepted value range (-400, 400).
+    int16_t ap_jump;               ///< AI Preference for jump moves. Accepted value range (-400, 400).
+    int16_t ap_high;               ///< AI Preference for high moves. Accepted value range (-400, 400).
+    int16_t ap_low;                ///< AI Preference for low moves. Accepted value range (-400, 400).
+    int16_t ap_middle;             ///< AI Preference for middle moves. Accepted value range (-400, 400).
+    int16_t pref_jump;             ///< AI Preference for jump movement. Accepted value range (-400, 400).
+    int16_t pref_fwd;              ///< AI Preference for forwards movement. Accepted value range (-400, 400).
+    int16_t pref_back;             ///< AI Preference for backwards movement. Accepted value range (-400, 400).
+    uint32_t unknown_e;            ///< Unknown
+    float learning;                ///< How actively this pilot learns your combat tactics. Accepted value range (0-15).
+    float forget;                  ///< How quickly this pilot forgets your combat tactics. Accepted value range (0-3).
+    char unk_block_f[14];          ///< Unknown. Probably pointers and scratch variables
     uint16_t enemies_inc_unranked; ///< Enemies in current tournament, including unranked opponents
     uint16_t enemies_ex_unranked;  ///< Same as above, excluding unranked opponents.
 
-    uint16_t unk_d_a;        ///< Unknown.
-    uint32_t unk_d_b;        ///< Unknown. Possible a bitmask ?
+    uint16_t unk_d_a; ///< Unknown.
+    uint32_t unk_d_b; ///< Unknown. Possible a bitmask ?
 
-    uint32_t winnings;       ///< Money made by winning opponents
-    uint32_t total_value;    ///< Total value for the pilot
-    float unk_f_a;           ///< Unknown
-    float unk_f_b;           ///< Unknown
-    palette palette;         ///< Palette for photo ?
-    uint16_t unk_block_i;    ///< Unknown
-    uint16_t photo_id;       ///< Which face photo this pilot uses
+    uint32_t winnings;    ///< Money made by winning opponents
+    uint32_t total_value; ///< Total value for the pilot
+    float unk_f_a;        ///< Unknown
+    float unk_f_b;        ///< Unknown
+    palette palette;      ///< Palette for photo ?
+    uint16_t unk_block_i; ///< Unknown
+    uint16_t photo_id;    ///< Which face photo this pilot uses
 
-    char *quotes[10];        ///< Pilot quotes for each supported language
+    char *quotes[10]; ///< Pilot quotes for each supported language
 } sd_pilot;
 
 /*! \brief Initialize pilot struct

--- a/include/formats/rec.h
+++ b/include/formats/rec.h
@@ -10,12 +10,12 @@
 #ifndef SD_REC_H
 #define SD_REC_H
 
-#include <stdint.h>
-#include <stddef.h>
-#include "formats/pilot.h"
-#include "formats/palette.h"
-#include "formats/sprite.h"
 #include "formats/actions.h"
+#include "formats/palette.h"
+#include "formats/pilot.h"
+#include "formats/sprite.h"
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,12 +41,12 @@ typedef struct {
  * \todo Find out about the unknowns here
  */
 typedef struct {
-    sd_pilot info;       ///< Pilot information
-    uint8_t unknown_a;   ///< Unknown value \todo: Find this out
-    uint16_t unknown_b;  ///< Unknown value \todo: Find this out
-    palette pal;         ///< Palette for this pilot photo
-    uint8_t has_photo;   ///< Tells if the pilot has a photo sprite
-    sd_sprite photo;     ///< Photo sprite
+    sd_pilot info;      ///< Pilot information
+    uint8_t unknown_a;  ///< Unknown value \todo: Find this out
+    uint16_t unknown_b; ///< Unknown value \todo: Find this out
+    palette pal;        ///< Palette for this pilot photo
+    uint8_t has_photo;  ///< Tells if the pilot has a photo sprite
+    sd_sprite photo;    ///< Photo sprite
 } sd_rec_pilot;
 
 /*! \brief REC recording
@@ -63,29 +63,29 @@ typedef struct {
     int8_t unknown_b;       ///< Unknown \todo: Find out
     int8_t unknown_c;       ///< Unknown \todo: Find out
 
-    int16_t throw_range;    ///< Throw range (%)
-    int16_t hit_pause;      ///< Hit pause (ticks)
-    int16_t block_damage;   ///< Block damage (%)
-    int16_t vitality;       ///< Vitality (%)
-    int16_t jump_height;    ///< Jump height (%)
-    int16_t unknown_i;      ///< Unknown \todo: Find out
-    int16_t unknown_j;      ///< Unknown \todo: Find out
-    int16_t unknown_k;      ///< Unknown \todo: Find out
+    int16_t throw_range;  ///< Throw range (%)
+    int16_t hit_pause;    ///< Hit pause (ticks)
+    int16_t block_damage; ///< Block damage (%)
+    int16_t vitality;     ///< Vitality (%)
+    int16_t jump_height;  ///< Jump height (%)
+    int16_t unknown_i;    ///< Unknown \todo: Find out
+    int16_t unknown_j;    ///< Unknown \todo: Find out
+    int16_t unknown_k;    ///< Unknown \todo: Find out
 
-    uint8_t knock_down;     ///< Knock down (0 = None, 1 = Kicks, 2 = Punches, 3 = both)
-    uint8_t rehit_mode;     ///< Rehit mode (On/Off)
-    uint8_t def_throws;     ///< Def. Throws (On/Off)
-    uint8_t arena_id;       ///< Arena ID
-    uint8_t power[2];       ///< Power 1,2 (0-7?)
-    uint8_t hazards;        ///< Hazards (On/Off)
-    uint8_t round_type;     ///< Round type (0=1, 1=2/3, 2=3/5, 3=4/7)
-    uint8_t unknown_l;      ///< Currently unknown \todo Find out what this does
-    uint8_t hyper_mode;     ///< Hyper mode (On/Off)
+    uint8_t knock_down; ///< Knock down (0 = None, 1 = Kicks, 2 = Punches, 3 = both)
+    uint8_t rehit_mode; ///< Rehit mode (On/Off)
+    uint8_t def_throws; ///< Def. Throws (On/Off)
+    uint8_t arena_id;   ///< Arena ID
+    uint8_t power[2];   ///< Power 1,2 (0-7?)
+    uint8_t hazards;    ///< Hazards (On/Off)
+    uint8_t round_type; ///< Round type (0=1, 1=2/3, 2=3/5, 3=4/7)
+    uint8_t unknown_l;  ///< Currently unknown \todo Find out what this does
+    uint8_t hyper_mode; ///< Hyper mode (On/Off)
 
-    int8_t unknown_m;       ///< Unknown \todo: Find out
+    int8_t unknown_m; ///< Unknown \todo: Find out
 
     unsigned int move_count; ///< How many REC event records
-    sd_rec_move *moves; ///< REC event records list
+    sd_rec_move *moves;      ///< REC event records list
 } sd_rec_file;
 
 /*! \brief Initialize REC file structure

--- a/include/formats/rgba_image.h
+++ b/include/formats/rgba_image.h
@@ -19,10 +19,10 @@ extern "C" {
  * A very simple RGBA8888 image. Data size is always w * h * 4 bytes.
  */
 typedef struct {
-    unsigned int w; ///< Image pixel width
-    unsigned int h; ///< Image pixel height
+    unsigned int w;   ///< Image pixel width
+    unsigned int h;   ///< Image pixel height
     unsigned int len; ///< Image byte length
-    char *data; ///< Image data
+    char *data;       ///< Image data
 } sd_rgba_image;
 
 /*! \brief Initialize RGBA image structure

--- a/include/formats/score.h
+++ b/include/formats/score.h
@@ -25,11 +25,11 @@ extern "C" {
  * A single score entry for the scoreboard.
  */
 typedef struct {
-    uint32_t score;      ///< Player score
-    char name[16];       ///< Player name (NULL terminated)
-    uint32_t har_id:6;   ///< Har ID
-    uint32_t pilot_id:6; ///< Pilot ID
-    uint32_t padding:20; ///< empty padding
+    uint32_t score;        ///< Player score
+    char name[16];         ///< Player name (NULL terminated)
+    uint32_t har_id : 6;   ///< Har ID
+    uint32_t pilot_id : 6; ///< Pilot ID
+    uint32_t padding : 20; ///< empty padding
 } sd_score_entry;
 
 /*! \brief Scoreboard scores list
@@ -108,7 +108,7 @@ int sd_score_save(const sd_score *score, const char *filename);
  * \param page Scoreboard page number.
  * \param entry_id Score information entry id.
  */
-const sd_score_entry* sd_score_get(const sd_score *score, int page, int entry_id);
+const sd_score_entry *sd_score_get(const sd_score *score, int page, int entry_id);
 
 #ifdef __cplusplus
 }

--- a/include/formats/script.h
+++ b/include/formats/script.h
@@ -10,8 +10,8 @@
 #ifndef SD_SCRIPT_H
 #define SD_SCRIPT_H
 
-#include <stddef.h>
 #include "formats/taglist.h"
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,8 +22,8 @@ extern "C" {
  * Describes a single tag in animation frame.
  */
 typedef struct {
-    const char* key;  ///< Tag name
-    const char* desc; ///< Tag description
+    const char *key;  ///< Tag name
+    const char *desc; ///< Tag description
     int has_param;    ///< Tells if the tag has a parameter
     int value;        ///< Tag parameter value. Only valid if has_param = 1.
 } sd_script_tag;
@@ -45,8 +45,8 @@ typedef struct {
  * A valid string must contain at least a single frame.
  */
 typedef struct {
-    int frame_count;          ///< Amount of frames in the string
-    sd_script_frame *frames;  ///< List of frames in this string
+    int frame_count;         ///< Amount of frames in the string
+    sd_script_frame *frames; ///< List of frames in this string
 } sd_script;
 
 /*! \brief Initialize script parser
@@ -80,9 +80,10 @@ void sd_script_free(sd_script *script);
  *
  * \param script Script structure to fill. Must be formatted using sd_script_create().
  * \param str Animation string to parse
- * \param invalid_pos Will contain problematic position in string if SD_INVALID_TAG is returned. Will be ignored if set to NULL.
+ * \param invalid_pos Will contain problematic position in string if SD_INVALID_TAG is returned. Will be ignored if set
+ * to NULL.
  */
-int sd_script_decode(sd_script *script, const char* str, int *invalid_pos);
+int sd_script_decode(sd_script *script, const char *str, int *invalid_pos);
 
 /*! \brief Encode animation string
  *
@@ -103,7 +104,7 @@ int sd_script_decode(sd_script *script, const char* str, int *invalid_pos);
  * \param script Script structure to encode
  * \param str Target string buffer. Make sure it's large enough!
  */
-int sd_script_encode(const sd_script *script, char* str, size_t len);
+int sd_script_encode(const sd_script *script, char *str, size_t len);
 
 /*! \brief Find the encoded length of a script
  *
@@ -169,7 +170,7 @@ int sd_script_get_sprite_at_frame(const sd_script *script, int frame_id);
  * \param ticks A position in time in game ticks
  * \return Frame pointer or NULL
  */
-const sd_script_frame* sd_script_get_frame_at(const sd_script *script, int ticks);
+const sd_script_frame *sd_script_get_frame_at(const sd_script *script, int ticks);
 
 /*! \brief Returns the frame at a given position
  *
@@ -184,7 +185,7 @@ const sd_script_frame* sd_script_get_frame_at(const sd_script *script, int ticks
  * \param frame_number Frame number to get
  * \return Frame pointer or NULL
  */
-const sd_script_frame* sd_script_get_frame(const sd_script *script, int frame_number);
+const sd_script_frame *sd_script_get_frame(const sd_script *script, int frame_number);
 
 /*! \brief Returns the information of a tag in a frame.
  *
@@ -198,7 +199,7 @@ const sd_script_frame* sd_script_get_frame(const sd_script *script, int frame_nu
  * \param tag Tag to look for. Must have a trailing zero.
  * \return Tag descriptor pointer or NULL
  */
-const sd_script_tag* sd_script_get_tag(const sd_script_frame* frame, const char* tag);
+const sd_script_tag *sd_script_get_tag(const sd_script_frame *frame, const char *tag);
 
 /*! \brief Tells if the frame changed between two points in time
  *
@@ -300,7 +301,7 @@ int sd_script_is_first_frame_at(const sd_script *script, int ticks);
  * \param tag Tag name to find
  * \return 1 or 0
  */
-int sd_script_isset(const sd_script_frame *frame, const char* tag);
+int sd_script_isset(const sd_script_frame *frame, const char *tag);
 
 /*! \brief Returns the tag value in frame
  *
@@ -312,7 +313,7 @@ int sd_script_isset(const sd_script_frame *frame, const char* tag);
  * \param tag Tag name to find
  * \return Tag parameter value or 0.
  */
-int sd_script_get(const sd_script_frame *frame, const char* tag);
+int sd_script_get(const sd_script_frame *frame, const char *tag);
 
 /*! \brief Returns the next frame number with a given sprite ID
  *
@@ -348,7 +349,7 @@ int sd_script_next_frame_with_sprite(const sd_script *script, int sprite_id, int
  * \param current_tick Current tick time
  * \return Frame ID or -1 on error
  */
-int sd_script_next_frame_with_tag(const sd_script *script, const char* tag, int current_tick);
+int sd_script_next_frame_with_tag(const sd_script *script, const char *tag, int current_tick);
 
 /*! \brief Sets a tag for the given frame
  *
@@ -364,7 +365,7 @@ int sd_script_next_frame_with_tag(const sd_script *script, const char* tag, int 
  * \param tag Tag to add
  * \param value Value to set, if tag allows values.
  */
-int sd_script_set_tag(sd_script *script, int frame_id, const char* tag, int value);
+int sd_script_set_tag(sd_script *script, int frame_id, const char *tag, int value);
 
 /*! \brief Deletes a tag from the given frame
  *
@@ -377,10 +378,10 @@ int sd_script_set_tag(sd_script *script, int frame_id, const char* tag, int valu
  * \param frame_id Frame ID to modify
  * \param tag Tag to delete
  */
-int sd_script_delete_tag(sd_script *script, int frame_id, const char* tag);
+int sd_script_delete_tag(sd_script *script, int frame_id, const char *tag);
 
 /*! \brief Append a new frame to the end of the frame list
- * 
+ *
  * Appends a new frame to the end of the frame list, and sets its tick length and sprite ID.
  * Tag list will be empty after creation.
  *
@@ -394,7 +395,7 @@ int sd_script_delete_tag(sd_script *script, int frame_id, const char* tag);
 int sd_script_append_frame(sd_script *script, int tick_len, int sprite_id);
 
 /*! \brief Clear frame tags
- * 
+ *
  * Clears all tags from the given frame.
  *
  * \retval SD_SUCCESS on successful removal
@@ -406,7 +407,7 @@ int sd_script_append_frame(sd_script *script, int tick_len, int sprite_id);
 int sd_script_clear_tags(sd_script *script, int frame_id);
 
 /*! \brief Set frame tick length
- * 
+ *
  * Sets a new tick length for the given frame.
  *
  * \retval SD_SUCCESS on successful operation
@@ -419,7 +420,7 @@ int sd_script_clear_tags(sd_script *script, int frame_id);
 int sd_script_set_tick_len_at_frame(sd_script *script, int frame_id, int duration);
 
 /*! \brief Set frame sprite ID
- * 
+ *
  * Sets the sprite ID of the given frame.
  *
  * \retval SD_SUCCESS on successful operation

--- a/include/formats/setup.h
+++ b/include/formats/setup.h
@@ -10,67 +10,67 @@
 #ifndef SD_SETUP_H
 #define SD_SETUP_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-	uint16_t unk:2;
-	uint16_t rehit_mode:1;
-	uint16_t def_throws:1;
-	uint16_t unk2:1;
-	uint16_t power_1:3;
-	uint16_t unk3:2;
-	uint16_t power_2:3;
-	uint16_t unk4:3;
+    uint16_t unk : 2;
+    uint16_t rehit_mode : 1;
+    uint16_t def_throws : 1;
+    uint16_t unk2 : 1;
+    uint16_t power_1 : 3;
+    uint16_t unk3 : 2;
+    uint16_t power_2 : 3;
+    uint16_t unk4 : 3;
 } __attribute__((packed)) gflags0;
 
 typedef struct {
-	uint8_t knockdown:2;
-	uint8_t shadows:2;
-	uint8_t hazards:1;
-	uint8_t hyper_mode:1;
-	uint8_t screen_shakes:1;
-	uint8_t animations:1;
+    uint8_t knockdown : 2;
+    uint8_t shadows : 2;
+    uint8_t hazards : 1;
+    uint8_t hyper_mode : 1;
+    uint8_t screen_shakes : 1;
+    uint8_t animations : 1;
 } __attribute__((packed)) gflags1;
 
 typedef struct {
-	uint8_t palette_animation:1;
-	uint8_t unk2:2;
-	uint8_t snow_checking:1;
-	uint8_t unk3:4;
+    uint8_t palette_animation : 1;
+    uint8_t unk2 : 2;
+    uint8_t snow_checking : 1;
+    uint8_t unk3 : 4;
 } __attribute__((packed)) gflags2;
 
 typedef struct {
-	uint32_t stereo_reversed:1;
-	uint32_t match_count:2;
-	uint32_t unk:29;
+    uint32_t stereo_reversed : 1;
+    uint32_t match_count : 2;
+    uint32_t unk : 29;
 } __attribute__((packed)) gflags3;
 
 typedef struct {
-	uint8_t game_speed;
-	char unknown_a[211];
-	uint16_t unknown_b;
-	uint16_t unknown_c;
-	uint16_t unknown_d;
-	char unknown_e[18];
-	uint8_t difficulty;
-	uint8_t unknown_g;
-	uint16_t throw_range;
-	uint16_t hit_pause;
-	uint16_t block_damage;
-	uint16_t vitality;
-	uint16_t jump_height;
-	gflags0 general_flags_0;
-	gflags1 general_flags_1;
-	gflags2 general_flags_2;
-	gflags3 general_flags_3;
-	uint8_t sound_volume;
-	uint8_t music_volume;
-	char unknown_r[38];
+    uint8_t game_speed;
+    char unknown_a[211];
+    uint16_t unknown_b;
+    uint16_t unknown_c;
+    uint16_t unknown_d;
+    char unknown_e[18];
+    uint8_t difficulty;
+    uint8_t unknown_g;
+    uint16_t throw_range;
+    uint16_t hit_pause;
+    uint16_t block_damage;
+    uint16_t vitality;
+    uint16_t jump_height;
+    gflags0 general_flags_0;
+    gflags1 general_flags_1;
+    gflags2 general_flags_2;
+    gflags3 general_flags_3;
+    uint8_t sound_volume;
+    uint8_t music_volume;
+    char unknown_r[38];
 } __attribute__((packed)) sd_setup_file;
 
 int sd_setup_create(sd_setup_file *setup);

--- a/include/formats/sounds.h
+++ b/include/formats/sounds.h
@@ -72,7 +72,7 @@ void sd_sounds_free(sd_sound_file *sf);
  * \param sf Sound information struct pointer.
  * \param id Sound identifier (0 - 299).
  */
-const sd_sound* sd_sounds_get(const sd_sound_file *sf, int id);
+const sd_sound *sd_sounds_get(const sd_sound_file *sf, int id);
 
 /*! \brief Save a sound to an AU file.
  *

--- a/include/formats/sprite.h
+++ b/include/formats/sprite.h
@@ -11,11 +11,11 @@
 #ifndef SD_SPRITE_H
 #define SD_SPRITE_H
 
-#include <stdint.h>
-#include "formats/vga_image.h"
-#include "formats/rgba_image.h"
 #include "formats/internal/reader.h"
 #include "formats/internal/writer.h"
+#include "formats/rgba_image.h"
+#include "formats/vga_image.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,14 +29,14 @@ extern "C" {
  * "invisible" pixels it has.
  */
 typedef struct {
-    int16_t pos_x; ///< Position of sprite, X-axis
-    int16_t pos_y; ///< Position of sprite, Y-axis
-    uint8_t index; ///< Sprite index
+    int16_t pos_x;   ///< Position of sprite, X-axis
+    int16_t pos_y;   ///< Position of sprite, Y-axis
+    uint8_t index;   ///< Sprite index
     uint8_t missing; ///< Is sprite data missing? If this is 1, then data points to the data of another sprite.
-    uint16_t width; ///< Pixel width of the sprite
+    uint16_t width;  ///< Pixel width of the sprite
     uint16_t height; ///< Pixel height of the sprite
-    uint16_t len; ///< Byte length of the packed sprite data
-    char *data; ///< Packed sprite data
+    uint16_t len;    ///< Byte length of the packed sprite data
+    char *data;      ///< Packed sprite data
 } sd_sprite;
 
 /*! \brief Initialize sprite structure
@@ -88,11 +88,7 @@ void sd_sprite_free(sd_sprite *sprite);
  * \param pal Palette that should be used for the conversion
  * \param remapping Palette remapping table that should be used. -1 for none.
  */
-int sd_sprite_rgba_encode(
-    sd_sprite *dst,
-    const sd_rgba_image *src,
-    const palette *pal,
-    int remapping);
+int sd_sprite_rgba_encode(sd_sprite *dst, const sd_rgba_image *src, const palette *pal, int remapping);
 
 /*! \brief Decode sprite data to RGBA format
  *
@@ -110,11 +106,7 @@ int sd_sprite_rgba_encode(
  * \param pal Palette that should be used for the conversion
  * \param remapping Palette remapping table that should be used. -1 for none.
  */
-int sd_sprite_rgba_decode(
-    sd_rgba_image *dst,
-    const sd_sprite *src,
-    const palette *pal,
-    int remapping);
+int sd_sprite_rgba_decode(sd_rgba_image *dst, const sd_sprite *src, const palette *pal, int remapping);
 
 /*! \brief Decode sprite to VGA image format.
  *
@@ -130,9 +122,7 @@ int sd_sprite_rgba_decode(
  * \param dst Destination VGA image struct pointer.
  * \param src Source sprite image pointer
  */
-int sd_sprite_vga_decode(
-    sd_vga_image *dst,
-    const sd_sprite *src);
+int sd_sprite_vga_decode(sd_vga_image *dst, const sd_sprite *src);
 
 /*! \brief Encode sprite from VGA image format.
  *
@@ -144,9 +134,7 @@ int sd_sprite_vga_decode(
  * \param dst Destination Sprite image struct pointer.
  * \param src Source VGA image pointer
  */
-int sd_sprite_vga_encode(
-    sd_sprite *dst,
-    const sd_vga_image *src);
+int sd_sprite_vga_encode(sd_sprite *dst, const sd_vga_image *src);
 
 int sd_sprite_load(sd_reader *reader, sd_sprite *sprite);
 int sd_sprite_save(sd_writer *writer, const sd_sprite *sprite);

--- a/include/formats/taglist.h
+++ b/include/formats/taglist.h
@@ -19,9 +19,9 @@ extern "C" {
  * Contains information about a single animation tag.
  */
 typedef struct {
-    const char *tag;          ///< Tag string
-    const int has_param;      ///< Tells if the tag can be expected to have a parameter.
-    const char *description;  ///< A short description for the tag.
+    const char *tag;         ///< Tag string
+    const int has_param;     ///< Tells if the tag can be expected to have a parameter.
+    const char *description; ///< A short description for the tag.
 } sd_tag;
 
 extern const sd_tag sd_taglist[]; ///< A global list of tags
@@ -41,7 +41,7 @@ extern const int sd_taglist_size; ///< Taglist size
  * \param tag A pointer to the tag string in library memory. Will be ignored if set to NULL.
  * \param desc A pointer to the description in library memory. Will be ignored if set to NULL.
  */
-int sd_tag_info(const char* search_tag, int *req_param, const char **tag, const char **desc);
+int sd_tag_info(const char *search_tag, int *req_param, const char **tag, const char **desc);
 
 #ifdef __cplusplus
 }

--- a/include/formats/tournament.h
+++ b/include/formats/tournament.h
@@ -11,21 +11,22 @@
 #define SD_TOURNAMENT_H
 
 #include "formats/palette.h"
-#include "formats/sprite.h"
 #include "formats/pilot.h"
+#include "formats/sprite.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define MAX_TRN_ENEMIES 256 ///< Maximum amount of tournament enemies
-#define MAX_TRN_LOCALES 10 ///< Maximum amount of tournament locales (some of these are unused)
+#define MAX_TRN_LOCALES 10  ///< Maximum amount of tournament locales (some of these are unused)
 
 /*! \brief Locales
  *
  * List of tournament locales. Many of these are actually unused.
  */
-enum {
+enum
+{
     TRN_LANG_ENGLISH = 0,
     TRN_LANG_GERMAN,
     TRN_LANG_FRENCH,
@@ -54,19 +55,20 @@ typedef struct {
  * Tournament enemies, locales, quotes, name, etc.
  */
 typedef struct {
-    uint32_t enemy_count;           ///< Number of enemies in tournament
-    char bk_name[14];               ///< Tournament BK filename
-    float winnings_multiplier;      ///< Match winnings multiplier
-    int32_t unknown_a;              ///< Unknown /todo find out
-    int32_t registration_fee;       ///< Tournament registration fee
-    int32_t assumed_initial_value;  ///< Value the player is assumed to have reached, minus starting value, when entering this tournament.
-    int32_t tournament_id;          ///< ID for the tournament
-    char *pic_file;                 ///< Tournament PIC filename
+    uint32_t enemy_count;          ///< Number of enemies in tournament
+    char bk_name[14];              ///< Tournament BK filename
+    float winnings_multiplier;     ///< Match winnings multiplier
+    int32_t unknown_a;             ///< Unknown /todo find out
+    int32_t registration_fee;      ///< Tournament registration fee
+    int32_t assumed_initial_value; ///< Value the player is assumed to have reached, minus starting value, when entering
+                                   ///< this tournament.
+    int32_t tournament_id;         ///< ID for the tournament
+    char *pic_file;                ///< Tournament PIC filename
 
-    sd_pilot *enemies[MAX_TRN_ENEMIES]; ///< List of enemy pilots
+    sd_pilot *enemies[MAX_TRN_ENEMIES];             ///< List of enemy pilots
     sd_tournament_locale *locales[MAX_TRN_LOCALES]; ///< List of locales. If locale does not exist, it is NULL.
 
-    palette pal;                    ///< Tournament palette
+    palette pal; ///< Tournament palette
 } sd_tournament_file;
 
 /*! \brief Initialize TRN file structure

--- a/include/formats/vga_image.h
+++ b/include/formats/vga_image.h
@@ -11,8 +11,8 @@
 #ifndef SD_VGA_IMAGE_H
 #define SD_VGA_IMAGE_H
 
-#include "formats/rgba_image.h"
 #include "formats/palette.h"
+#include "formats/rgba_image.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +30,11 @@ extern "C" {
  * In VGA images, the len field should always be exactly w*h bytes long.
  */
 typedef struct {
-    unsigned int w;    ///< Pixel width
-    unsigned int h;    ///< Pixel height
-    unsigned int len;  ///< Byte length
-    char *data;        ///< Palette representation of image data
-    char *stencil;     ///< holds 0 or 1 indicating whether a pixel is present
+    unsigned int w;   ///< Pixel width
+    unsigned int h;   ///< Pixel height
+    unsigned int len; ///< Byte length
+    char *data;       ///< Palette representation of image data
+    char *stencil;    ///< holds 0 or 1 indicating whether a pixel is present
 } sd_vga_image;
 
 /*! \brief Initialize VGA image structure
@@ -107,11 +107,7 @@ int sd_vga_image_stencil_index(sd_vga_image *img, int stencil_index);
  * \param pal Palette that should be used for the conversion
  * \param remapping Palette remapping table that should be used. -1 for none.
  */
-int sd_vga_image_encode(
-    sd_vga_image *dst,
-    const sd_rgba_image *src,
-    const palette *pal,
-    int remapping);
+int sd_vga_image_encode(sd_vga_image *dst, const sd_rgba_image *src, const palette *pal, int remapping);
 
 /*! \brief Decode VGA data to RGBA format
  *
@@ -129,11 +125,7 @@ int sd_vga_image_encode(
  * \param pal Palette that should be used for the conversion
  * \param remapping Palette remapping table that should be used. -1 for none.
  */
-int sd_vga_image_decode(
-    sd_rgba_image *dst,
-    const sd_vga_image *src,
-    const palette *pal,
-    int remapping);
+int sd_vga_image_decode(sd_rgba_image *dst, const sd_vga_image *src, const palette *pal, int remapping);
 
 /*! \brief Load an indexed image from a PNG file.
  *

--- a/include/game/common_defines.h
+++ b/include/game/common_defines.h
@@ -1,11 +1,11 @@
 #ifndef COMMON_DEFINES_H
 #define COMMON_DEFINES_H
 
-const char* ai_difficulty_get_name(unsigned int id);
-const char* har_get_name(unsigned int id);
-const char* pilot_get_name(unsigned int id);
-const char* round_get_name(unsigned int id);
-const char* scene_get_name(unsigned int id);
+const char *ai_difficulty_get_name(unsigned int id);
+const char *har_get_name(unsigned int id);
+const char *pilot_get_name(unsigned int id);
+const char *round_get_name(unsigned int id);
+const char *scene_get_name(unsigned int id);
 
 int har_to_resource(unsigned int id);
 int scene_to_resource(unsigned int id);
@@ -18,7 +18,8 @@ extern const char *pilot_type_names[];
 extern const char *har_type_names[];
 extern const char *scene_type_names[];
 
-enum {
+enum
+{
     SCENE_NONE = 0,
     SCENE_INTRO,
     SCENE_OPENOMF,
@@ -44,7 +45,8 @@ enum {
     NUMBER_OF_SCENE_TYPES,
 };
 
-enum {
+enum
+{
     AI_DIFFICULTY_PUNCHING_BAG = 0,
     AI_DIFFICULTY_ROOKIE,
     AI_DIFFICULTY_VETERAN,
@@ -56,7 +58,8 @@ enum {
 };
 
 // These should match the resource list in order
-enum {
+enum
+{
     HAR_JAGUAR = 0,
     HAR_SHADOW,
     HAR_THORN,
@@ -71,7 +74,8 @@ enum {
     NUMBER_OF_HAR_TYPES,
 };
 
-enum {
+enum
+{
     PILOT_CRYSTAL = 0,
     PILOT_STEFFAN,
     PILOT_MILANO,
@@ -86,7 +90,8 @@ enum {
     NUMBER_OF_PILOT_TYPES,
 };
 
-enum {
+enum
+{
     ROUND_TYPE_ONE = 0,
     ROUND_TYPE_2_OF_3,
     ROUND_TYPE_3_OF_5,

--- a/include/game/game_player.h
+++ b/include/game/game_player.h
@@ -1,18 +1,18 @@
 #ifndef GAME_PLAYER_H
 #define GAME_PLAYER_H
 
-#include "formats/pilot.h"
-#include "game/protos/object.h"
+#include "controller/ai_controller.h"
 #include "controller/controller.h"
 #include "controller/keyboard.h"
 #include "controller/net_controller.h"
-#include "controller/ai_controller.h"
-#include "video/surface.h"
-#include "game/utils/score.h"
+#include "formats/pilot.h"
+#include "game/protos/object.h"
 #include "game/utils/har_screencap.h"
+#include "game/utils/score.h"
+#include "video/surface.h"
 
 typedef struct game_player_t {
-    int har_id; // HAR_JAGUAR to HAR_NOVA
+    int har_id;   // HAR_JAGUAR to HAR_NOVA
     int pilot_id; // 0 to 9
     object *har;
     controller *ctrl;
@@ -31,14 +31,14 @@ void game_player_create(game_player *gp);
 void game_player_free(game_player *gp);
 
 void game_player_set_har(game_player *gp, object *har);
-object* game_player_get_har(game_player *gp);
+object *game_player_get_har(game_player *gp);
 void game_player_set_ctrl(game_player *gp, controller *ctrl);
-controller* game_player_get_ctrl(game_player *gp);
+controller *game_player_get_ctrl(game_player *gp);
 void game_player_set_portrait(game_player *gp, surface *portrait);
-surface* game_player_get_portrait(game_player *gp);
+surface *game_player_get_portrait(game_player *gp);
 void game_player_set_selectable(game_player *gp, int selectable);
 int game_player_get_selectable(game_player *gp);
-sd_pilot* game_player_get_pilot(game_player *gp);
-chr_score* game_player_get_score(game_player *gp);
+sd_pilot *game_player_get_pilot(game_player *gp);
+chr_score *game_player_get_score(game_player *gp);
 
 #endif // GAME_PLAYER_H

--- a/include/game/game_state.h
+++ b/include/game/game_state.h
@@ -1,11 +1,11 @@
 #ifndef GAME_STATE_H
 #define GAME_STATE_H
 
-#include <SDL.h>
-#include "utils/vector.h"
-#include "utils/random.h"
-#include "game/utils/serial.h"
 #include "game/game_state_type.h"
+#include "game/utils/serial.h"
+#include "utils/random.h"
+#include "utils/vector.h"
+#include <SDL.h>
 
 typedef struct scene_t scene;
 typedef struct game_player_t game_player;
@@ -20,16 +20,16 @@ void game_state_static_tick(game_state *gs);
 void game_state_dynamic_tick(game_state *gs);
 void game_state_tick_controllers(game_state *gs);
 unsigned int game_state_get_tick(game_state *gs);
-scene* game_state_get_scene(game_state *gs);
+scene *game_state_get_scene(game_state *gs);
 unsigned int game_state_is_running(game_state *gs);
 unsigned int game_state_is_paused(game_state *gs);
 void game_state_set_paused(game_state *gs, unsigned int paused);
 void game_state_set_next(game_state *gs, unsigned int next_scene_id);
-game_player* game_state_get_player(game_state *gs, int player_id);
+game_player *game_state_get_player(game_state *gs, int player_id);
 int game_state_num_players(game_state *gs);
 void game_state_init_demo(game_state *gs);
 int game_state_ms_per_dyntick(game_state *gs);
-ticktimer* game_state_get_ticktimer(game_state *gs);
+ticktimer *game_state_get_ticktimer(game_state *gs);
 int game_state_serialize(game_state *gs, serial *ser);
 int game_state_unserialize(game_state *gs, serial *ser, int rtt);
 

--- a/include/game/game_state_type.h
+++ b/include/game/game_state_type.h
@@ -1,21 +1,24 @@
 #ifndef GAME_STATE_TYPE_H
 #define GAME_STATE_TYPE_H
 
-#include "utils/vector.h"
 #include "engine.h"
+#include "utils/vector.h"
 
-enum {
+enum
+{
     RENDER_LAYER_BOTTOM = 0,
     RENDER_LAYER_MIDDLE,
     RENDER_LAYER_TOP
 };
 
-enum {
+enum
+{
     ROLE_CLIENT,
     ROLE_SERVER
 };
 
-enum {
+enum
+{
     NET_MODE_NONE,
     NET_MODE_CLIENT,
     NET_MODE_SERVER
@@ -50,7 +53,7 @@ typedef struct game_state_t {
     int this_wait_ticks;
 
     int next_requires_refresh; // If next frame requires a texture refresh, this should be set to 1
-    int net_mode; // NET_MODE_NONE, NET_MODE_CLIENT, NET_MODE_SERVER
+    int net_mode;              // NET_MODE_NONE, NET_MODE_CLIENT, NET_MODE_SERVER
     scene *sc;
     vector objects;
     game_player *players[2];

--- a/include/game/gui/component.h
+++ b/include/game/gui/component.h
@@ -9,15 +9,17 @@
 #ifndef COMPONENT_H
 #define COMPONENT_H
 
-#include <SDL.h>
 #include "controller/controller.h"
+#include <SDL.h>
 
-enum {
-    COM_ENABLED = 0,   ///< Component enabled. Component is colored and can be interacted with.
-    COM_DISABLED = 1,  ///< Component disabled. Component is grayed out, and cannot be interacted with.
+enum
+{
+    COM_ENABLED = 0,  ///< Component enabled. Component is colored and can be interacted with.
+    COM_DISABLED = 1, ///< Component disabled. Component is grayed out, and cannot be interacted with.
 };
 
-enum {
+enum
+{
     COM_UNSELECTED = 0, ///< Componen unselected. Used in eg. menu sizers.
     COM_SELECTED = 1,   ///< Component selected. Used in eg. menu sizers.
 };
@@ -30,7 +32,7 @@ typedef int (*component_action_cb)(component *c, int action);
 typedef void (*component_layout_cb)(component *c, int x, int y, int w, int h);
 typedef void (*component_tick_cb)(component *c);
 typedef void (*component_free_cb)(component *c);
-typedef component* (*component_find_cb)(component *c, int id);
+typedef component *(*component_find_cb)(component *c, int id);
 
 /*! \brief Basic GUI object
  *
@@ -41,39 +43,41 @@ typedef component* (*component_find_cb)(component *c, int id);
  * Component_layout call for a sizer will cause all its children widgets and  sizers to be set also.
  */
 struct component_t {
-    int x;                      ///< Horizontal position of the object in pixels. This is in screen coordinates.
-    int y;                      ///< Vertical position of the object in pixels. This is in screen coordinates.
-    int w;                      ///< Width of the object in pixels.
-    int h;                      ///< Height of the object in pixels.
-    void *obj;                  ///< Specialization object pointer. Basically always Sizer or Widget struct.
+    int x;     ///< Horizontal position of the object in pixels. This is in screen coordinates.
+    int y;     ///< Vertical position of the object in pixels. This is in screen coordinates.
+    int w;     ///< Width of the object in pixels.
+    int h;     ///< Height of the object in pixels.
+    void *obj; ///< Specialization object pointer. Basically always Sizer or Widget struct.
 
-    int x_hint;                 ///< X position hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
-    int y_hint;                 ///< Y position hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
-    int w_hint;                 ///< W size hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
-    int h_hint;                 ///< H size hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
+    int x_hint; ///< X position hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
+    int y_hint; ///< Y position hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
+    int w_hint; ///< W size hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
+    int h_hint; ///< H size hint. Sizers may or may not obey this. -1 = not set. >=0 means set.
 
-    char supports_select;       ///< Whether the component can be selected by component_select() call.
-    char is_selected;           ///< Whether the component is selected
+    char supports_select; ///< Whether the component can be selected by component_select() call.
+    char is_selected;     ///< Whether the component is selected
 
-    char supports_disable;      ///< Whether the component can be disabled by component_disable() call.
-    char is_disabled;           ///< Whether the component is disabled
+    char supports_disable; ///< Whether the component can be disabled by component_disable() call.
+    char is_disabled;      ///< Whether the component is disabled
 
-    char supports_focus;        ///< Whether the component can be focused by component_focus() call.
-    char is_focused;            ///< Whether the component is focused
+    char supports_focus; ///< Whether the component can be focused by component_focus() call.
+    char is_focused;     ///< Whether the component is focused
 
     component_render_cb render; ///< Render function callback. This tells the component to draw itself.
     component_event_cb event;   ///< Event function callback. Direct SDL2 event handler.
     component_action_cb action; ///< Action function callback. Handles OpenOMF abstract key events.
-    component_layout_cb layout; ///< Layout function callback. This is called after the component tree is created. Sets component size and position.
+    component_layout_cb layout; ///< Layout function callback. This is called after the component tree is created. Sets
+                                ///< component size and position.
     component_tick_cb tick;     ///< Tick function callback. This is called periodically.
     component_free_cb free;     ///< Free function callback. Any component callbacks should be done here.
     component_find_cb find;     ///< Should only be set by widget and sizer. Used to look up widgets by ID.
 
-    component *parent;          ///< Parent component. For widgets, this should be always a sizer. For root sizer it will be NULL.
+    component
+        *parent; ///< Parent component. For widgets, this should be always a sizer. For root sizer it will be NULL.
 };
 
 // Create & free
-component* component_create();
+component *component_create();
 void component_free(component *c);
 
 // Internal callbacks
@@ -94,11 +98,11 @@ void component_set_size_hints(component *c, int w, int h);
 void component_set_pos_hints(component *c, int x, int y);
 
 // ID lookup stuff
-component* component_find(component *c, int id);
+component *component_find(component *c, int id);
 
 // Basic component callbacks
 void component_set_obj(component *c, void *obj);
-void* component_get_obj(const component *c);
+void *component_get_obj(const component *c);
 void component_set_render_cb(component *c, component_render_cb cb);
 void component_set_event_cb(component *c, component_event_cb cb);
 void component_set_action_cb(component *c, component_action_cb cb);

--- a/include/game/gui/dialog.h
+++ b/include/game/gui/dialog.h
@@ -1,16 +1,18 @@
 #ifndef DIALOG_H
 #define DIALOG_H
 
+#include "game/gui/component.h"
 #include "utils/vector.h"
 #include "video/surface.h"
-#include "game/gui/component.h"
 
-typedef enum dialog_style_t {
+typedef enum dialog_style_t
+{
     DIALOG_STYLE_YES_NO,
     DIALOG_STYLE_OK
 } dialog_style;
 
-typedef enum dialog_result_t {
+typedef enum dialog_result_t
+{
     DIALOG_RESULT_CANCEL,
     DIALOG_RESULT_YES_OK,
     DIALOG_RESULT_NO
@@ -19,7 +21,7 @@ typedef enum dialog_result_t {
 typedef struct component_t component;
 typedef struct dialog_t dialog;
 
-typedef void (*dialog_clicked_cb)(dialog*, dialog_result result);
+typedef void (*dialog_clicked_cb)(dialog *, dialog_result result);
 
 typedef struct dialog_t {
     int x;

--- a/include/game/gui/filler.h
+++ b/include/game/gui/filler.h
@@ -3,6 +3,6 @@
 
 #include "game/gui/component.h"
 
-component* filler_create();
+component *filler_create();
 
 #endif // FILLER_H

--- a/include/game/gui/frame.h
+++ b/include/game/gui/frame.h
@@ -11,12 +11,12 @@ typedef struct {
     component *root_node;
 } guiframe;
 
-guiframe* guiframe_create(int x, int y, int w, int h);
+guiframe *guiframe_create(int x, int y, int w, int h);
 void guiframe_set_root(guiframe *frame, component *root_node);
-component* guiframe_get_root(const guiframe *frame);
+component *guiframe_get_root(const guiframe *frame);
 void guiframe_free(guiframe *frame);
 
-component* guiframe_find(guiframe *frame, int id);
+component *guiframe_find(guiframe *frame, int id);
 
 void guiframe_tick(guiframe *frame);
 void guiframe_render(guiframe *frame);

--- a/include/game/gui/gauge.h
+++ b/include/game/gui/gauge.h
@@ -3,12 +3,13 @@
 
 #include "game/gui/component.h"
 
-typedef enum {
+typedef enum
+{
     GAUGE_SMALL,
     GAUGE_BIG
 } gauge_type;
 
-component* gauge_create(gauge_type type, int size, int lit);
+component *gauge_create(gauge_type type, int size, int lit);
 void gauge_set_lit(component *gauge, int lit);
 int gauge_get_lit(component *gauge);
 int gauge_get_size(component *gauge);

--- a/include/game/gui/gui.h
+++ b/include/game/gui/gui.h
@@ -2,17 +2,17 @@
 #define GUI_H
 
 #include "game/gui/component.h"
-#include "game/gui/widget.h"
-#include "game/gui/sizer.h"
 #include "game/gui/dialog.h"
+#include "game/gui/filler.h"
 #include "game/gui/frame.h"
+#include "game/gui/label.h"
 #include "game/gui/menu.h"
 #include "game/gui/menu_background.h"
+#include "game/gui/sizer.h"
 #include "game/gui/textbutton.h"
 #include "game/gui/textinput.h"
 #include "game/gui/textselector.h"
 #include "game/gui/textslider.h"
-#include "game/gui/filler.h"
-#include "game/gui/label.h"
+#include "game/gui/widget.h"
 
 #endif // GUI_H

--- a/include/game/gui/label.h
+++ b/include/game/gui/label.h
@@ -4,8 +4,8 @@
 #include "game/gui/component.h"
 #include "game/gui/text_render.h"
 
-component* label_create(const text_settings *tconf, const char *text);
+component *label_create(const text_settings *tconf, const char *text);
 void label_set_text(component *label, const char *text);
-text_settings* label_get_text_settings(component *c);
+text_settings *label_get_text_settings(component *c);
 
 #endif // LABEL_H

--- a/include/game/gui/menu.h
+++ b/include/game/gui/menu.h
@@ -1,15 +1,15 @@
 #ifndef MENU_H
 #define MENU_H
 
-#include "video/surface.h"
 #include "game/gui/component.h"
 #include "game/gui/frame.h"
+#include "video/surface.h"
 
 typedef void (*menu_tick_cb)(component *c);
 typedef void (*menu_free_cb)(component *c);
 typedef void (*menu_submenu_done_cb)(component *menu, component *submenu);
 
-typedef struct  {
+typedef struct {
     surface *bg;
     int selected;
     int obj_h;
@@ -25,19 +25,19 @@ typedef struct  {
     menu_tick_cb tick;
 } menu;
 
-component* menu_create(int obj_h);
+component *menu_create(int obj_h);
 void menu_attach(component *menu, component *c);
 void menu_select(component *menu, component *c);
-component* menu_selected(const component *menu);
+component *menu_selected(const component *menu);
 int menu_is_finished(const component *menu);
 
 void menu_set_submenu(component *menu, component *submenu);
 void menu_link_menu(component *menu, guiframe *linked_menu);
-component* menu_get_submenu(const component *menu);
+component *menu_get_submenu(const component *menu);
 void menu_set_submenu_done_cb(component *menu, menu_submenu_done_cb done_cb);
 
 void menu_set_userdata(component *menu, void *userdata);
-void* menu_get_userdata(const component *menu);
+void *menu_get_userdata(const component *menu);
 void menu_set_free_cb(component *menu, menu_free_cb cb);
 void menu_set_tick_cb(component *menu, menu_tick_cb cb);
 

--- a/include/game/gui/pilotpic.h
+++ b/include/game/gui/pilotpic.h
@@ -3,7 +3,7 @@
 
 #include "game/gui/component.h"
 
-component* pilotpic_create(int pic_id, int pilot_id);
+component *pilotpic_create(int pic_id, int pilot_id);
 void pilotpic_select(component *c, int pic_id, int pilot_id);
 int pilotpic_get_pilot_count(component *c, int pic_id);
 void pilotpic_next(component *c);

--- a/include/game/gui/progressbar.h
+++ b/include/game/gui/progressbar.h
@@ -1,8 +1,8 @@
 #ifndef PROGRESSBAR_H
 #define PROGRESSBAR_H
 
-#include "video/color.h"
 #include "game/gui/component.h"
+#include "video/color.h"
 
 typedef struct {
     color border_topleft_color;
@@ -25,7 +25,7 @@ extern const progressbar_theme _progressbar_theme_melee;
 #define PROGRESSBAR_LEFT 0
 #define PROGRESSBAR_RIGHT 1
 
-component* progressbar_create(progressbar_theme theme, int orientation, int percentage);
+component *progressbar_create(progressbar_theme theme, int orientation, int percentage);
 void progressbar_set_progress(component *bar, int percentage);
 void progressbar_set_flashing(component *bar, int flashing, int rate);
 

--- a/include/game/gui/sizer.h
+++ b/include/game/gui/sizer.h
@@ -10,13 +10,14 @@ typedef int (*sizer_action_cb)(component *c, int action);
 typedef void (*sizer_layout_cb)(component *c, int x, int y, int w, int h);
 typedef void (*sizer_tick_cb)(component *c);
 typedef void (*sizer_free_cb)(component *c);
-typedef component* (*sizer_find_cb)(component *c, int id);
+typedef component *(*sizer_find_cb)(component *c, int id);
 
 typedef struct {
-    void *obj; ///< Sizer specialization object, eg. menu, trnmenu
+    void *obj;   ///< Sizer specialization object, eg. menu, trnmenu
     vector objs; ///< Contains all the child objects in the sizer
 
-    float opacity; ///< Some sizers may want to fade their contents (eg. tournament menu). In these cases, if should be handled via this variable.
+    float opacity; ///< Some sizers may want to fade their contents (eg. tournament menu). In these cases, if should be
+                   ///< handled via this variable.
 
     sizer_render_cb render;
     sizer_event_cb event;
@@ -27,12 +28,12 @@ typedef struct {
     sizer_find_cb find;
 } sizer;
 
-component* sizer_create();
+component *sizer_create();
 
 void sizer_set_obj(component *c, void *obj);
-void* sizer_get_obj(const component *c);
+void *sizer_get_obj(const component *c);
 
-component* sizer_get(const component *c, int item);
+component *sizer_get(const component *c, int item);
 int sizer_size(const component *c);
 
 void sizer_set_render_cb(component *c, sizer_render_cb cb);

--- a/include/game/gui/spritebutton.h
+++ b/include/game/gui/spritebutton.h
@@ -5,13 +5,15 @@
 #include "game/gui/text_render.h"
 #include "video/surface.h"
 
-enum {
+enum
+{
     VALIGN_TOP = 0,
     VALIGN_MIDDLE,
     VALIGN_BOTTOM,
 };
 
-enum {
+enum
+{
     HALIGN_LEFT = 0,
     HALIGN_CENTER,
     HALIGN_RIGHT
@@ -19,6 +21,7 @@ enum {
 
 typedef void (*spritebutton_click_cb)(component *c, void *userdata);
 
-component* spritebutton_create(const text_settings *tconf, const char *text, surface *img, int disabled, spritebutton_click_cb cb, void *userdata);
+component *spritebutton_create(const text_settings *tconf, const char *text, surface *img, int disabled,
+                               spritebutton_click_cb cb, void *userdata);
 
 #endif // SPRITEBUTTON_H

--- a/include/game/gui/spriteimage.h
+++ b/include/game/gui/spriteimage.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "video/surface.h"
 
-component* spriteimage_create(surface *img);
+component *spriteimage_create(surface *img);
 
 #endif // SPRITEIMAGE_H

--- a/include/game/gui/text_render.h
+++ b/include/game/gui/text_render.h
@@ -1,18 +1,20 @@
 #ifndef TEXT_RENDER_H
 #define TEXT_RENDER_H
 
-#include <stdint.h>
-#include <stdbool.h>
-#include "video/color.h"
 #include "resources/fonts.h"
+#include "video/color.h"
+#include <stdbool.h>
+#include <stdint.h>
 
-typedef enum {
+typedef enum
+{
     TEXT_TOP = 0,
     TEXT_MIDDLE,
     TEXT_BOTTOM
 } text_valign;
 
-typedef enum {
+typedef enum
+{
     TEXT_LEFT = 0,
     TEXT_CENTER,
     TEXT_RIGHT
@@ -25,12 +27,14 @@ typedef struct {
     uint8_t bottom;
 } text_padding;
 
-typedef enum {
+typedef enum
+{
     TEXT_HORIZONTAL = 0,
     TEXT_VERTICAL,
 } text_direction;
 
-enum {
+enum
+{
     TEXT_SHADOW_NONE = 0,
     TEXT_SHADOW_TOP = 0x1,
     TEXT_SHADOW_BOTTOM = 0x2,
@@ -65,7 +69,8 @@ int text_char_width(const text_settings *settings);
 
 // Old functions
 void font_get_wrapped_size(const font *font, const char *text, int max_w, int *out_w, int *out_h);
-void font_get_wrapped_size_shadowed(const font *font, const char *text, int max_w, int shadow_flag, int *out_w, int *out_h);
+void font_get_wrapped_size_shadowed(const font *font, const char *text, int max_w, int shadow_flag, int *out_w,
+                                    int *out_h);
 void font_render_char(const font *font, char ch, int x, int y, color c);
 void font_render_char_shadowed(const font *font, char ch, int x, int y, color c, int shadow_flags);
 void font_render_len(const font *font, const char *text, int len, int x, int y, color c);

--- a/include/game/gui/textbutton.h
+++ b/include/game/gui/textbutton.h
@@ -6,9 +6,10 @@
 
 typedef void (*textbutton_click_cb)(component *c, void *userdata);
 
-component* textbutton_create(const text_settings *tconf, const char *text, int disabled, textbutton_click_cb cb, void *userdata);
+component *textbutton_create(const text_settings *tconf, const char *text, int disabled, textbutton_click_cb cb,
+                             void *userdata);
 void textbutton_set_border(component *c, color col);
-void textbutton_set_text(component *c, const char* text);
+void textbutton_set_text(component *c, const char *text);
 void textbutton_remove_border(component *c);
 
 #endif // TEXTBUTTON_H

--- a/include/game/gui/textinput.h
+++ b/include/game/gui/textinput.h
@@ -4,8 +4,8 @@
 #include "game/gui/component.h"
 #include "game/gui/text_render.h"
 
-component* textinput_create(const text_settings *tconf, const char *text, const char *initialoption);
-char* textinput_value(const component *c);
+component *textinput_create(const text_settings *tconf, const char *text, const char *initialoption);
+char *textinput_value(const component *c);
 void textinput_enable_background(component *c, int enabled);
 void textinput_set_max_chars(component *c, int max_chars);
 

--- a/include/game/gui/textselector.h
+++ b/include/game/gui/textselector.h
@@ -7,12 +7,15 @@
 
 typedef void (*textselector_toggle_cb)(component *c, void *userdata, int pos);
 
-component* textselector_create(const text_settings *tconf, const char *text, textselector_toggle_cb toggle_cb, void *userdata);
-component* textselector_create_bind(const text_settings *tconf, const char *text, textselector_toggle_cb toggle_cb, void *userdata, int *bind);
-component* textselector_create_bind_opts(const text_settings *tconf, const char *text, textselector_toggle_cb toggle_cb, void *userdata, int *bind, const char **opts, int opt_size);
+component *textselector_create(const text_settings *tconf, const char *text, textselector_toggle_cb toggle_cb,
+                               void *userdata);
+component *textselector_create_bind(const text_settings *tconf, const char *text, textselector_toggle_cb toggle_cb,
+                                    void *userdata, int *bind);
+component *textselector_create_bind_opts(const text_settings *tconf, const char *text, textselector_toggle_cb toggle_cb,
+                                         void *userdata, int *bind, const char **opts, int opt_size);
 void textselector_add_option(component *c, const char *option);
 void textselector_clear_options(component *c);
-const char* textselector_get_current_text(const component *c);
+const char *textselector_get_current_text(const component *c);
 int textselector_get_pos(const component *c);
 void textselector_set_pos(component *c, int pos);
 

--- a/include/game/gui/textslider.h
+++ b/include/game/gui/textslider.h
@@ -6,7 +6,9 @@
 
 typedef void (*textslider_slide_cb)(component *c, void *userdata, int pos);
 
-component* textslider_create(const text_settings *tconf, const char *text, unsigned int positions, int has_off, textslider_slide_cb cb, void *userdata);
-component* textslider_create_bind(const text_settings *tconf, const char *text, unsigned int positions, int has_off, textslider_slide_cb cb, void *userdata, int *bind);
+component *textslider_create(const text_settings *tconf, const char *text, unsigned int positions, int has_off,
+                             textslider_slide_cb cb, void *userdata);
+component *textslider_create_bind(const text_settings *tconf, const char *text, unsigned int positions, int has_off,
+                                  textslider_slide_cb cb, void *userdata, int *bind);
 
 #endif // TEXTSLIDER_H

--- a/include/game/gui/trn_menu.h
+++ b/include/game/gui/trn_menu.h
@@ -1,11 +1,11 @@
 #ifndef TRN_MENU_H
 #define TRN_MENU_H
 
+#include "game/game_state.h"
 #include "game/gui/component.h"
 #include "game/protos/object.h"
-#include "utils/vec.h"
 #include "resources/animation.h"
-#include "game/game_state.h"
+#include "utils/vec.h"
 
 typedef void (*trnmenu_tick_cb)(component *c);
 typedef void (*trnmenu_free_cb)(component *c);
@@ -20,7 +20,7 @@ typedef struct {
     int move;
 } trnmenu_hand;
 
-typedef struct  {
+typedef struct {
     int selected;
 
     surface *button_sheet;
@@ -42,13 +42,13 @@ typedef struct  {
     trnmenu_tick_cb tick;
 } trnmenu;
 
-component* trnmenu_create(surface *button_sheet, int sheet_x, int sheet_y);
+component *trnmenu_create(surface *button_sheet, int sheet_x, int sheet_y);
 void trnmenu_attach(component *menu, component *c);
 
 void trnmenu_bind_hand(component *menu, animation *hand, game_state *gs);
 
 void trnmenu_set_submenu(component *menu, component *submenu);
-component* trnmenu_get_submenu(const component *menu);
+component *trnmenu_get_submenu(const component *menu);
 void trnmenu_set_submenu_done_cb(component *menu, trnmenu_submenu_done_cb done_cb);
 int trnmenu_is_finished(const component *menu);
 void trnmenu_finish(component *menu);
@@ -56,7 +56,7 @@ void trnmenu_finish(component *menu);
 int trnmenu_is_fading(const component *menu);
 
 void trnmenu_set_userdata(component *menu, void *userdata);
-void* trnmenu_get_userdata(const component *menu);
+void *trnmenu_get_userdata(const component *menu);
 void trnmenu_set_free_cb(component *menu, trnmenu_free_cb cb);
 void trnmenu_set_tick_cb(component *menu, trnmenu_tick_cb cb);
 

--- a/include/game/gui/widget.h
+++ b/include/game/gui/widget.h
@@ -11,8 +11,8 @@ typedef void (*widget_tick_cb)(component *c);
 typedef void (*widget_free_cb)(component *c);
 
 typedef struct {
-    void *obj;                  ///< Pointer to internal object, eg. textbutton, etc.
-    int id;                     ///< Default is -1, which means "not set". User should always set positive values!
+    void *obj; ///< Pointer to internal object, eg. textbutton, etc.
+    int id;    ///< Default is -1, which means "not set". User should always set positive values!
 
     widget_render_cb render;
     widget_event_cb event;
@@ -22,10 +22,10 @@ typedef struct {
     widget_free_cb free;
 } widget;
 
-component* widget_create();
+component *widget_create();
 
 void widget_set_obj(component *c, void *obj);
-void* widget_get_obj(const component *c);
+void *widget_get_obj(const component *c);
 
 void widget_set_id(component *c, int id);
 int widget_get_id(const component *c);

--- a/include/game/gui/xysizer.h
+++ b/include/game/gui/xysizer.h
@@ -1,17 +1,17 @@
 #ifndef XYSIZER_H
 #define XYSIZER_H
 
-#include "video/surface.h"
 #include "game/gui/component.h"
+#include "video/surface.h"
 
-typedef struct  {
+typedef struct {
     int req_refresh;
     void *userdata;
 } xysizer;
 
-component* xysizer_create();
+component *xysizer_create();
 void xysizer_attach(component *sizer, component *c, int x, int y, int w, int h);
 void xysizer_set_userdata(component *sizer, void *userdata);
-void* xysizer_get_userdata(component *sizer);
+void *xysizer_get_userdata(component *sizer);
 
 #endif // XYSIZER_H

--- a/include/game/objects/har.h
+++ b/include/game/objects/har.h
@@ -1,17 +1,17 @@
 #ifndef HAR_H
 #define HAR_H
 
-#include "resources/af.h"
-#include "resources/bk.h"
-#include "resources/animation.h"
-#include "game/protos/object.h"
 #include "game/objects/arena_constraints.h"
+#include "game/protos/object.h"
+#include "resources/af.h"
+#include "resources/animation.h"
+#include "resources/bk.h"
 #include "utils/list.h"
 
 // For debug texture stuff
 #ifdef DEBUGMODE
-#include "video/surface.h"
 #include "video/image.h"
+#include "video/surface.h"
 #endif
 
 #define LAYER_HAR 0x02
@@ -23,7 +23,8 @@
 
 #define GROUP_PROJECTILE 2
 
-enum {
+enum
+{
     CAT_MISC = 0,
     CAT_CLOSE = 2,
     CAT_LOW = 4,
@@ -38,7 +39,8 @@ enum {
     CAT_DESTRUCTION
 };
 
-enum {
+enum
+{
     STATE_STANDING = 1,
     STATE_WALKTO,
     STATE_WALKFROM,
@@ -54,29 +56,30 @@ enum {
     STATE_SCRAP,
     STATE_DESTRUCTION,
     STATE_WALLDAMAGE, // Took damage from wall (electrocution)
-    STATE_DONE // destruction or scrap has completed
+    STATE_DONE        // destruction or scrap has completed
 };
 
-enum {
+enum
+{
     HAR_EVENT_JUMP,
     HAR_EVENT_AIR_TURN,
     HAR_EVENT_WALK,
-    HAR_EVENT_AIR_ATTACK_DONE, // Touched the floor after executing a move in the air
-    HAR_EVENT_ATTACK, // Executed a move, may not hit
-    HAR_EVENT_ENEMY_BLOCK, // Opponent blocked your move
+    HAR_EVENT_AIR_ATTACK_DONE,        // Touched the floor after executing a move in the air
+    HAR_EVENT_ATTACK,                 // Executed a move, may not hit
+    HAR_EVENT_ENEMY_BLOCK,            // Opponent blocked your move
     HAR_EVENT_ENEMY_BLOCK_PROJECTILE, // Opponent blocked your projectile
-    HAR_EVENT_BLOCK, // You blocked your opponents move
-    HAR_EVENT_BLOCK_PROJECTILE, // You blocked your opponents projectile
-    HAR_EVENT_LAND_HIT, // Landed a hit on the opponent
-    HAR_EVENT_LAND_HIT_PROJECTILE, // Landed a projectile hit on the opponent
-    HAR_EVENT_TAKE_HIT, // Hit by HAR
-    HAR_EVENT_TAKE_HIT_PROJECTILE, // Hit by projectile
-    HAR_EVENT_HAZARD_HIT, // Hit by hazard
+    HAR_EVENT_BLOCK,                  // You blocked your opponents move
+    HAR_EVENT_BLOCK_PROJECTILE,       // You blocked your opponents projectile
+    HAR_EVENT_LAND_HIT,               // Landed a hit on the opponent
+    HAR_EVENT_LAND_HIT_PROJECTILE,    // Landed a projectile hit on the opponent
+    HAR_EVENT_TAKE_HIT,               // Hit by HAR
+    HAR_EVENT_TAKE_HIT_PROJECTILE,    // Hit by projectile
+    HAR_EVENT_HAZARD_HIT,             // Hit by hazard
     HAR_EVENT_STUN,
     HAR_EVENT_ENEMY_STUN,
-    HAR_EVENT_RECOVER, // regained control after recoil/stun
+    HAR_EVENT_RECOVER,  // regained control after recoil/stun
     HAR_EVENT_HIT_WALL, // Touched a wall
-    HAR_EVENT_LAND, // Touched the floor
+    HAR_EVENT_LAND,     // Touched the floor
     HAR_EVENT_DEFEAT,
     HAR_EVENT_SCRAP,
     HAR_EVENT_DESTRUCTION,
@@ -89,12 +92,13 @@ typedef struct har_event_t {
     union {
         af_move *move; // for attack/hit
         bk_info *info; // for hazard hit
-        int wall; // for hit wall
+        int wall;      // for hit wall
         int direction; // jump direction
     };
 } har_event;
 
-enum {
+enum
+{
     DAMAGETYPE_LOW, // Damage to low area of har
     DAMAGETYPE_HIGH // Damage to high area of har
 };
@@ -117,7 +121,7 @@ typedef struct game_player_t game_player;
 
 typedef struct har_t {
     game_player *gp;
-    uint8_t id; // Har ID
+    uint8_t id;        // Har ID
     uint8_t player_id; // Player number, 0 or 1
     uint8_t pilot_id;  // Pilot ID
     uint8_t state;
@@ -126,15 +130,15 @@ typedef struct har_t {
     uint8_t close;
     uint8_t enqueued;
     af *af_data;
-    uint8_t damage_done; // Damage was done this animation
+    uint8_t damage_done;     // Damage was done this animation
     uint8_t damage_received; // Damage was received this animation
     uint8_t air_attacked;
-    uint8_t is_wallhugging; // HAR is standing right next to a wall
-    uint8_t is_grabbed; // Is being moved by another object. Set by ex, ey tags
+    uint8_t is_wallhugging;  // HAR is standing right next to a wall
+    uint8_t is_grabbed;      // Is being moved by another object. Set by ex, ey tags
     float last_damage_value; // Last damage value taken
 
-    float jump_boost;  // Agility generated speed modifier for jumping
-    float fall_boost;  // Agility generated speed modifier for falling
+    float jump_boost; // Agility generated speed modifier for jumping
+    float fall_boost; // Agility generated speed modifier for falling
 
     int in_stasis_ticks; // Handle stasis activator
 

--- a/include/game/objects/hazard.h
+++ b/include/game/objects/hazard.h
@@ -1,8 +1,8 @@
 #ifndef HAZARD_H
 #define HAZARD_H
 
-#include "game/protos/object.h"
 #include "game/game_state_type.h"
+#include "game/protos/object.h"
 #include "resources/bk.h"
 #include "resources/bk_info.h"
 

--- a/include/game/objects/projectile.h
+++ b/include/game/objects/projectile.h
@@ -1,8 +1,8 @@
 #ifndef PROJECTILE_H
 #define PROJECTILE_H
 
-#include "game/protos/object.h"
 #include "game/objects/har.h"
+#include "game/protos/object.h"
 
 typedef struct har_t har;
 

--- a/include/game/protos/intersect.h
+++ b/include/game/protos/intersect.h
@@ -11,5 +11,4 @@ int intersect_object_object(object *a, object *b);
 int intersect_object_point(object *obj, vec2i point);
 int intersect_sprite_hitpoint(object *obj, object *target, int level, vec2i *point);
 
-
 #endif // INTERSECT_H

--- a/include/game/protos/object.h
+++ b/include/game/protos/object.h
@@ -1,37 +1,41 @@
 #ifndef OBJECT_H
 #define OBJECT_H
 
+#include "game/protos/player.h"
+#include "game/utils/serial.h"
 #include "resources/animation.h"
 #include "resources/sprite.h"
-#include "video/screen_palette.h"
-#include "game/protos/player.h"
-#include "utils/vec.h"
 #include "utils/hashmap.h"
 #include "utils/random.h"
+#include "utils/vec.h"
+#include "video/screen_palette.h"
 #include "video/surface.h"
-#include "game/utils/serial.h"
 
 #define OBJECT_DEFAULT_LAYER 0x01
 #define OBJECT_NO_GROUP -1
 
 #define OBJECT_EVENT_BUFFER_SIZE 16
 
-enum {
+enum
+{
     OBJECT_FACE_LEFT = -1,
     OBJECT_FACE_RIGHT = 1
 };
 
-enum {
+enum
+{
     OWNER_EXTERNAL,
     OWNER_OBJECT
 };
 
-enum {
+enum
+{
     PLAY_BACKWARDS,
     PLAY_FORWARDS
 };
 
-enum {
+enum
+{
     EFFECT_NONE = 0,
     EFFECT_SHADOW = 0x1,
     EFFECT_DARK_TINT = 0x2,
@@ -43,13 +47,13 @@ typedef struct object_t object;
 typedef struct game_state_t game_state;
 
 typedef void (*object_free_cb)(object *obj);
-typedef int  (*object_act_cb)(object *obj, int action);
+typedef int (*object_act_cb)(object *obj, int action);
 typedef void (*object_tick_cb)(object *obj);
 typedef void (*object_move_cb)(object *obj);
 typedef void (*object_collide_cb)(object *a, object *b);
 typedef void (*object_finish_cb)(object *obj);
-typedef int  (*object_serialize_cb)(object *obj, serial *ser);
-typedef int  (*object_unserialize_cb)(object *obj, serial *ser, int animation_id, game_state *gs);
+typedef int (*object_serialize_cb)(object *obj, serial *ser);
+typedef int (*object_unserialize_cb)(object *obj, serial *ser, int animation_id, game_state *gs);
 typedef void (*object_debug_cb)(object *obj);
 typedef int (*object_palette_transform_cb)(object *obj, screen_palette *pal);
 
@@ -150,7 +154,7 @@ void object_set_delay(object *obj, int delay);
 void object_set_playback_direction(object *obj, int dir);
 
 void object_set_stl(object *obj, char *ptr);
-char* object_get_stl(const object *obj);
+char *object_get_stl(const object *obj);
 
 void object_set_animation_owner(object *obj, int owner);
 void object_set_animation(object *obj, animation *ani);
@@ -230,8 +234,8 @@ void object_set_vx(object *obj, float val);
 void object_set_vy(object *obj, float val);
 
 uint32_t object_get_age(object *obj);
-serial* object_get_last_serialization_point(const object *obj);
-serial* object_get_serialization_point(const object *obj, unsigned int ticks_ago);
+serial *object_get_last_serialization_point(const object *obj);
+serial *object_get_serialization_point(const object *obj, unsigned int ticks_ago);
 
 void object_set_spawn_cb(object *obj, object_state_add_cb cbf, void *userdata);
 void object_set_destroy_cb(object *obj, object_state_del_cb cbf, void *userdata);

--- a/include/game/protos/object_specializer.h
+++ b/include/game/protos/object_specializer.h
@@ -3,7 +3,8 @@
 
 typedef struct object_t object;
 
-enum {
+enum
+{
     SPECID_NONE = 0,
     SPECID_HAR = 1,
     SPECID_PROJECTILE,

--- a/include/game/protos/player.h
+++ b/include/game/protos/player.h
@@ -1,13 +1,14 @@
 #ifndef PLAYER_H
 #define PLAYER_H
 
-#include <stdint.h>
 #include "formats/script.h"
 #include "utils/vec.h"
+#include <stdint.h>
 
 typedef struct object_t object;
 
-typedef void (*object_state_add_cb)(object *parent, int id, vec2i pos, vec2f vel, uint8_t flags, int s, int g, void *userdata);
+typedef void (*object_state_add_cb)(object *parent, int id, vec2i pos, vec2f vel, uint8_t flags, int s, int g,
+                                    void *userdata);
 typedef void (*object_state_del_cb)(object *parent, int id, void *userdata);
 
 typedef struct player_sprite_state_t {
@@ -25,12 +26,12 @@ typedef struct player_sprite_state_t {
     int blend_start;
     int blend_finish;
 
-    int pal_ref_index; // bpd
+    int pal_ref_index;   // bpd
     int pal_entry_count; // bpn
     int pal_start_index; // bps
-    int pal_begin; // bpb
-    int pal_end; // bpd
-    int pal_tint; // bz
+    int pal_begin;       // bpb
+    int pal_end;         // bpd
+    int pal_tint;        // bz
 } player_sprite_state;
 
 typedef struct player_slide_op_t {

--- a/include/game/protos/scene.h
+++ b/include/game/protos/scene.h
@@ -1,16 +1,16 @@
 #ifndef SCENE_H
 #define SCENE_H
 
-#include <SDL.h>
 #include "controller/controller.h"
-#include "game/protos/object.h"
+#include "game/common_defines.h"
 #include "game/game_player.h"
 #include "game/game_state.h"
-#include "game/common_defines.h"
+#include "game/protos/object.h"
 #include "game/utils/serial.h"
 #include "game/utils/ticktimer.h"
 #include "resources/bk.h"
 #include "video/surface.h"
+#include <SDL.h>
 
 typedef struct scene_t scene;
 typedef struct game_player_t game_player;
@@ -61,7 +61,7 @@ int scene_serialize(scene *scene, serial *ser);
 int scene_unserialize(scene *scene, serial *ser);
 
 void scene_set_userdata(scene *scene, void *userdata);
-void* scene_get_userdata(scene *scene);
+void *scene_get_userdata(scene *scene);
 
 void scene_set_free_cb(scene *scene, scene_free_cb cbfunc);
 void scene_set_event_cb(scene *scene, scene_event_cb cbfunc);

--- a/include/game/scenes/arena.h
+++ b/include/game/scenes/arena.h
@@ -3,7 +3,8 @@
 
 #include "game/protos/scene.h"
 
-enum {
+enum
+{
     ARENA_STATE_STARTING,
     ARENA_STATE_FIGHTING,
     ARENA_STATE_ENDING

--- a/include/game/scenes/mainmenu/menu_audio.h
+++ b/include/game/scenes/mainmenu/menu_audio.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_audio_create(scene *s);
+component *menu_audio_create(scene *s);
 
 #endif // MENU_AUDIO_H

--- a/include/game/scenes/mainmenu/menu_configuration.h
+++ b/include/game/scenes/mainmenu/menu_configuration.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_configuration_create(scene *s);
+component *menu_configuration_create(scene *s);
 
 #endif // MENU_CONFIGURATION_H

--- a/include/game/scenes/mainmenu/menu_connect.h
+++ b/include/game/scenes/mainmenu/menu_connect.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_connect_create(scene *s);
+component *menu_connect_create(scene *s);
 
 #endif // MENU_CONNECT_H

--- a/include/game/scenes/mainmenu/menu_gameplay.h
+++ b/include/game/scenes/mainmenu/menu_gameplay.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_gameplay_create(scene *s);
+component *menu_gameplay_create(scene *s);
 
 #endif // MENU_GAMEPLAY_H

--- a/include/game/scenes/mainmenu/menu_input.h
+++ b/include/game/scenes/mainmenu/menu_input.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_input_create(scene *s, int player_id);
+component *menu_input_create(scene *s, int player_id);
 
 #endif // MENU_INPUT_H

--- a/include/game/scenes/mainmenu/menu_keyboard.h
+++ b/include/game/scenes/mainmenu/menu_keyboard.h
@@ -4,6 +4,6 @@
 #include "game/gui/frame.h"
 #include "game/protos/scene.h"
 
-guiframe* menu_keyboard_create(scene *s, int player_id);
+guiframe *menu_keyboard_create(scene *s, int player_id);
 
 #endif // MENU_KEYBOARD_H

--- a/include/game/scenes/mainmenu/menu_listen.h
+++ b/include/game/scenes/mainmenu/menu_listen.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_listen_create(scene *s);
+component *menu_listen_create(scene *s);
 
 #endif // MENU_LISTEN_H

--- a/include/game/scenes/mainmenu/menu_main.h
+++ b/include/game/scenes/mainmenu/menu_main.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_main_create(scene *s);
+component *menu_main_create(scene *s);
 
 #endif // MENU_MAIN_H

--- a/include/game/scenes/mainmenu/menu_net.h
+++ b/include/game/scenes/mainmenu/menu_net.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_net_create(scene *s);
+component *menu_net_create(scene *s);
 
 #endif // MENU_NET_H

--- a/include/game/scenes/mainmenu/menu_presskey.h
+++ b/include/game/scenes/mainmenu/menu_presskey.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_presskey_create(char **key);
+component *menu_presskey_create(char **key);
 
 #endif // MENU_PRESSKEY_H

--- a/include/game/scenes/mainmenu/menu_video.h
+++ b/include/game/scenes/mainmenu/menu_video.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* menu_video_create(scene *s);
+component *menu_video_create(scene *s);
 
 #endif // MENU_VIDEO_H

--- a/include/game/scenes/mainmenu/menu_video_confirm.h
+++ b/include/game/scenes/mainmenu/menu_video_confirm.h
@@ -5,6 +5,6 @@
 #include "game/protos/scene.h"
 #include "game/utils/settings.h"
 
-component* menu_video_confirm_create(scene *s, settings_video *old_settings);
+component *menu_video_confirm_create(scene *s, settings_video *old_settings);
 
 #endif // MENU_VIDEO_CONFIRM_H

--- a/include/game/scenes/mechlab/lab_dash_main.h
+++ b/include/game/scenes/mechlab/lab_dash_main.h
@@ -24,7 +24,7 @@ typedef struct {
     component *tournament;
 } dashboard_widgets;
 
-component* lab_dash_main_create(scene *s, dashboard_widgets *dw);
+component *lab_dash_main_create(scene *s, dashboard_widgets *dw);
 void lab_dash_main_update(scene *s, dashboard_widgets *dw);
 
 #endif // LAB_DASH_MAIN_H

--- a/include/game/scenes/mechlab/lab_dash_newplayer.h
+++ b/include/game/scenes/mechlab/lab_dash_newplayer.h
@@ -8,6 +8,6 @@ typedef struct {
     component *input;
 } newplayer_widgets;
 
-component* lab_dash_newplayer_create(scene *s, newplayer_widgets *nw);
+component *lab_dash_newplayer_create(scene *s, newplayer_widgets *nw);
 
 #endif // LAB_DASH_NEWPLAYER_H

--- a/include/game/scenes/mechlab/lab_menu_customize.h
+++ b/include/game/scenes/mechlab/lab_menu_customize.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* lab_menu_customize_create(scene *s);
+component *lab_menu_customize_create(scene *s);
 
 #endif // LAB_MENU_CUSTOMIZE_H

--- a/include/game/scenes/mechlab/lab_menu_main.h
+++ b/include/game/scenes/mechlab/lab_menu_main.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* lab_menu_main_create(scene *s);
+component *lab_menu_main_create(scene *s);
 
 #endif // LAB_MENU_MAIN_H

--- a/include/game/scenes/mechlab/lab_menu_pilotselect.h
+++ b/include/game/scenes/mechlab/lab_menu_pilotselect.h
@@ -5,6 +5,6 @@
 #include "game/protos/scene.h"
 #include "game/scenes/mechlab/lab_dash_main.h"
 
-component* lab_menu_pilotselect_create(scene *s, dashboard_widgets *nw);
+component *lab_menu_pilotselect_create(scene *s, dashboard_widgets *nw);
 
 #endif // LAB_MENU_PILOTSELECT_H

--- a/include/game/scenes/mechlab/lab_menu_training.h
+++ b/include/game/scenes/mechlab/lab_menu_training.h
@@ -4,6 +4,6 @@
 #include "game/gui/component.h"
 #include "game/protos/scene.h"
 
-component* lab_menu_training_create(scene *s);
+component *lab_menu_training_create(scene *s);
 
 #endif // LAB_MENU_TRAINING_H

--- a/include/game/scenes/newsroom.h
+++ b/include/game/scenes/newsroom.h
@@ -3,7 +3,8 @@
 
 #include "game/protos/scene.h"
 
-enum {
+enum
+{
     PILOT_SEX_MALE,
     PILOT_SEX_FEMALE
 };

--- a/include/game/utils/score.h
+++ b/include/game/utils/score.h
@@ -1,14 +1,15 @@
 #ifndef SCORE_H
 #define SCORE_H
 
-#include <string.h>
-#include <stdlib.h>
+#include "game/gui/text_render.h"
+#include "game/protos/object.h"
 #include "utils/list.h"
 #include "video/surface.h"
-#include "game/protos/object.h"
-#include "game/gui/text_render.h"
+#include <stdlib.h>
+#include <string.h>
 
-enum {
+enum
+{
     SCORE_EV_PUNCH = 0,
     SCORE_EV_KICK,
     SCORE_EV_ROUNDHOUSE,
@@ -21,7 +22,7 @@ typedef struct chr_score_t {
     int rounds;
     int wins;
     int health;
-    int x,y;
+    int x, y;
     int direction;
     int difficulty;
     list texts;

--- a/include/game/utils/serial.h
+++ b/include/game/utils/serial.h
@@ -28,6 +28,6 @@ int32_t serial_read_int32(serial *s);
 long serial_read_long(serial *s);
 float serial_read_float(serial *s);
 void serial_copy(serial *dst, const serial *src);
-serial* serial_calloc_copy(const serial *src);
+serial *serial_calloc_copy(const serial *src);
 
 #endif // SERIAL_H

--- a/include/game/utils/settings.h
+++ b/include/game/utils/settings.h
@@ -1,19 +1,22 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-typedef enum fight_mode_t {
+typedef enum fight_mode_t
+{
     FIGHT_MODE_NORMAL,
     FIGHT_MODE_HYPER
 } fight_mode;
 
-typedef enum knock_down_mode_t {
+typedef enum knock_down_mode_t
+{
     KNOCK_DOWN_NONE = 0,
     KNOCK_DOWN_PUNCHES,
     KNOCK_DOWN_KICKS,
     KNOCK_DOWN_BOTH
 } knock_down_mode;
 
-typedef enum difficulty_t {
+typedef enum difficulty_t
+{
     PUNCHING_BAG,
     ROOKIE,
     VETERAN,
@@ -116,7 +119,6 @@ typedef struct settings_network_t {
     int net_connect_port;
     int net_listen_port;
 } settings_network;
-
 
 typedef struct settings_t {
     settings_video video;

--- a/include/plugins/base_plugin.h
+++ b/include/plugins/base_plugin.h
@@ -3,11 +3,11 @@
 
 typedef struct {
     void *handle;
-    const char* (*get_name)();
-    const char* (*get_author)();
-    const char* (*get_license)();
-    const char* (*get_type)();
-    const char* (*get_version)();
+    const char *(*get_name)();
+    const char *(*get_author)();
+    const char *(*get_license)();
+    const char *(*get_type)();
+    const char *(*get_version)();
 } base_plugin;
 
 #endif // BASE_PLUGIN_H

--- a/include/plugins/plugins.h
+++ b/include/plugins/plugins.h
@@ -1,15 +1,15 @@
 #ifndef PLUGINS_H
 #define PLUGINS_H
 
-#include "utils/list.h"
 #include "plugins/base_plugin.h"
 #include "plugins/scaler_plugin.h"
+#include "utils/list.h"
 
 void plugins_init();
 void plugins_close();
 
-int plugins_get_scaler(scaler_plugin *scaler, const char* name);
+int plugins_get_scaler(scaler_plugin *scaler, const char *name);
 
-int plugins_get_list_by_type(list *tlist, const char* type);
+int plugins_get_list_by_type(list *tlist, const char *type);
 
 #endif // PLUGINS_H

--- a/include/plugins/scaler_plugin.h
+++ b/include/plugins/scaler_plugin.h
@@ -6,19 +6,15 @@
 typedef struct {
     base_plugin *base;
     int (*is_factor_available)(int factor);
-    int (*get_factors_list)(int** factors);
+    int (*get_factors_list)(int **factors);
     int (*get_color_format)();
-    int (*scale)(const char* in, char* out, int w, int h, int factor);
+    int (*scale)(const char *in, char *out, int w, int h, int factor);
 } scaler_plugin;
 
 void scaler_init(scaler_plugin *scaler);
 int scaler_is_factor_available(scaler_plugin *scaler, int factor);
-int scaler_get_factors_list(scaler_plugin *scaler, int** factors);
+int scaler_get_factors_list(scaler_plugin *scaler, int **factors);
 int scaler_get_color_format(scaler_plugin *scaler);
-int scaler_scale(scaler_plugin *scaler,
-                 const char* in,
-                 char* out,
-                 int w, int h,
-                 int factor);
+int scaler_scale(scaler_plugin *scaler, const char *in, char *out, int w, int h, int factor);
 
-# endif // SCALER_PLUGIN_H
+#endif // SCALER_PLUGIN_H

--- a/include/resources/af.h
+++ b/include/resources/af.h
@@ -16,7 +16,7 @@ typedef struct af_t {
 } af;
 
 void af_create(af *a, void *src);
-af_move* af_get_move(af *a, int id);
+af_move *af_get_move(af *a, int id);
 void af_free(af *a);
 
 #endif // AF_H

--- a/include/resources/animation.h
+++ b/include/resources/animation.h
@@ -2,13 +2,14 @@
 #define ANIMATION_H
 
 #include "resources/sprite.h"
+#include "utils/str.h"
 #include "utils/vec.h"
 #include "utils/vector.h"
-#include "utils/str.h"
 
 // All HARs have these predefined animations
-enum {
-    ANIM_JUMPING=1,
+enum
+{
+    ANIM_JUMPING = 1,
     ANIM_STANDUP,
     ANIM_STUNNED,
     ANIM_CROUCHING,
@@ -22,9 +23,9 @@ enum {
     ANIM_SCRAP_METAL,
     ANIM_BOLT,
     ANIM_SCREW,
-    ANIM_VICTORY=48,
+    ANIM_VICTORY = 48,
     ANIM_DEFEAT,
-    ANIM_BLAST1=55,
+    ANIM_BLAST1 = 55,
     ANIM_BLAST2,
     ANIM_BLAST3
 };
@@ -45,11 +46,11 @@ typedef struct animation_t {
 } animation;
 
 void animation_create(animation *ani, void *src, int id);
-sprite* animation_get_sprite(animation *ani, int sprite_id);
+sprite *animation_get_sprite(animation *ani, int sprite_id);
 void animation_free(animation *ani);
 
 int animation_get_sprite_count(animation *ani);
 
-animation* create_animation_from_single(sprite *sp, vec2i pos);
+animation *create_animation_from_single(sprite *sp, vec2i pos);
 
 #endif // ANIMATION_H

--- a/include/resources/bk.h
+++ b/include/resources/bk.h
@@ -14,9 +14,9 @@ typedef struct bk_t {
 } bk;
 
 void bk_create(bk *b, void *src);
-bk_info* bk_get_info(bk *b, int id);
+bk_info *bk_get_info(bk *b, int id);
 palette *bk_get_palette(bk *b, int id);
-char* bk_get_stl(bk *b);
+char *bk_get_stl(bk *b);
 void bk_free(bk *b);
 
 #endif // BK_H

--- a/include/resources/fonts.h
+++ b/include/resources/fonts.h
@@ -3,14 +3,15 @@
 
 #include "utils/vector.h"
 
-typedef enum {
+typedef enum
+{
     FONT_BIG,
     FONT_SMALL
 } font_size;
 
 typedef struct {
     font_size size;
-    int w,h;
+    int w, h;
     vector surfaces;
 } font;
 

--- a/include/resources/ids.h
+++ b/include/resources/ids.h
@@ -1,7 +1,8 @@
 #ifndef IDS_H
 #define IDS_H
 
-enum RESOURCE_ID {
+enum RESOURCE_ID
+{
     BK_INTRO = 0,
     BK_OPENOMF,
     BK_MENU,
@@ -53,8 +54,8 @@ enum RESOURCE_ID {
     NUMBER_OF_RESOURCES
 };
 
-const char* get_resource_file(unsigned int id);
-const char* get_resource_name(unsigned int id);
+const char *get_resource_file(unsigned int id);
+const char *get_resource_name(unsigned int id);
 
 int is_arena(unsigned int id);
 int is_scene(unsigned int id);

--- a/include/resources/languages.h
+++ b/include/resources/languages.h
@@ -2,15 +2,15 @@
 #define LANGUAGES_H
 
 /*
-* This file should handle loading language file(s)
-* and support getting text. Maybe some function to rendering text index on
-* texture with the help of text.h ?
-*/
+ * This file should handle loading language file(s)
+ * and support getting text. Maybe some function to rendering text index on
+ * texture with the help of text.h ?
+ */
 
 int lang_init();
 void lang_close();
 
 // Maybe something like this ?
-const char* lang_get(unsigned int id);
+const char *lang_get(unsigned int id);
 
 #endif // LANGUAGES_H

--- a/include/resources/pathmanager.h
+++ b/include/resources/pathmanager.h
@@ -3,7 +3,8 @@
 
 #include "resources/ids.h"
 
-enum {
+enum
+{
     PLUGIN_PATH,
     RESOURCE_PATH,
     LOG_PATH,
@@ -16,15 +17,15 @@ enum {
 int pm_init();
 void pm_free();
 void pm_log();
-const char* pm_get_errormsg();
+const char *pm_get_errormsg();
 int pm_validate_resources();
 int pm_in_portable_mode();
 int pm_in_release_mode();
 int pm_in_debug_mode();
-char* pm_get_local_base_dir();
-const char* pm_get_local_path_type_name(unsigned int path_id);
-const char* pm_get_local_path(unsigned int resource_id);
-const char* pm_get_resource_path(unsigned int local_id);
-int pm_create_dir(const char* dirname);
+char *pm_get_local_base_dir();
+const char *pm_get_local_path_type_name(unsigned int path_id);
+const char *pm_get_local_path(unsigned int resource_id);
+const char *pm_get_resource_path(unsigned int local_id);
+int pm_create_dir(const char *dirname);
 
 #endif // PATHMANAGER_H

--- a/include/resources/sgmanager.h
+++ b/include/resources/sgmanager.h
@@ -4,7 +4,7 @@
 #include "formats/pilot.h"
 
 int sg_init();
-int sg_load(sd_pilot *pilot, const char* pilotname);
-int sd_save(const sd_pilot *pilot, const char* pilotname);
+int sg_load(sd_pilot *pilot, const char *pilotname);
+int sd_save(const sd_pilot *pilot, const char *pilotname);
 
 #endif // SGMANAGER_H

--- a/include/resources/sprite.h
+++ b/include/resources/sprite.h
@@ -1,8 +1,8 @@
 #ifndef SPRITE_H
 #define SPRITE_H
 
-#include "video/surface.h"
 #include "utils/vec.h"
+#include "video/surface.h"
 
 typedef struct sprite_t {
     int id;
@@ -15,6 +15,6 @@ void sprite_create_custom(sprite *sp, vec2i pos, surface *sur);
 void sprite_free(sprite *sp);
 
 vec2i sprite_get_size(sprite *s);
-sprite* sprite_copy(sprite *src);
+sprite *sprite_copy(sprite *src);
 
 #endif // SPRITE_H

--- a/include/utils/allocator.h
+++ b/include/utils/allocator.h
@@ -3,17 +3,16 @@
 
 #include <stddef.h>
 
-#define omf_calloc(nmemb, size) \
-    omf_calloc_real((nmemb), (size), __FILE__, __LINE__)
+#define omf_calloc(nmemb, size) omf_calloc_real((nmemb), (size), __FILE__, __LINE__)
 void *omf_calloc_real(size_t nmemb, size_t size, const char *file, int line);
 
-#define omf_realloc(ptr, size) \
-    omf_realloc_real((ptr), (size), __FILE__, __LINE__)
+#define omf_realloc(ptr, size) omf_realloc_real((ptr), (size), __FILE__, __LINE__)
 void *omf_realloc_real(void *ptr, size_t size, const char *file, int line);
 
-#define omf_free(ptr) do { \
-    free(ptr);             \
-    (ptr) = NULL;          \
-} while(0)
+#define omf_free(ptr)                                                                                                  \
+    do {                                                                                                               \
+        free(ptr);                                                                                                     \
+        (ptr) = NULL;                                                                                                  \
+    } while(0)
 
 #endif // ALLOCATOR_H

--- a/include/utils/array.h
+++ b/include/utils/array.h
@@ -12,7 +12,7 @@ typedef struct array_t {
 void array_create(array *array);
 void array_free(array *array);
 void array_set(array *array, unsigned int key, const void *ptr);
-void* array_get(const array *array, unsigned int key);
+void *array_get(const array *array, unsigned int key);
 
 void array_iter_begin(const array *array, iterator *iterator);
 void array_iter_end(const array *arrat, iterator *iterator);

--- a/include/utils/compat.h
+++ b/include/utils/compat.h
@@ -1,8 +1,8 @@
 #ifndef COMPAT_H
 #define COMPAT_H
 
-#include <string.h>
 #include "platform.h"
+#include <string.h>
 
 #ifndef HAVE_STD_STRDUP
 char *strdup(const char *s1);

--- a/include/utils/config.h
+++ b/include/utils/config.h
@@ -13,7 +13,7 @@ void conf_close();
 int conf_int(const char *name);
 double conf_float(const char *name);
 int conf_bool(const char *name);
-const char* conf_string(const char *name);
+const char *conf_string(const char *name);
 
 void conf_setint(const char *name, int val);
 void conf_setfloat(const char *name, double val);

--- a/include/utils/hashmap.h
+++ b/include/utils/hashmap.h
@@ -3,7 +3,8 @@
 
 #include "utils/iterator.h"
 
-enum hashmap_flags {
+enum hashmap_flags
+{
     HASHMAP_AUTO_INC = 0x1,
     HASHMAP_AUTO_DEC = 0x2
 };
@@ -35,13 +36,14 @@ struct hashmap_t {
 
 void hashmap_create(hashmap *hashmap, int n_size); // actual size will be 2^n_size
 void hashmap_free(hashmap *hashmap);
-void hashmap_set_opts(hashmap *hm, unsigned int flags, float min_pressure, float max_pressure, int buckets_min, int buckets_max);
+void hashmap_set_opts(hashmap *hm, unsigned int flags, float min_pressure, float max_pressure, int buckets_min,
+                      int buckets_max);
 int hashmap_resize(hashmap *hm, int n_size);
 float hashmap_get_pressure(hashmap *hm);
 void hashmap_autoresize(hashmap *hm);
 unsigned int hashmap_size(const hashmap *hashmap);
 unsigned int hashmap_reserved(const hashmap *hashmap);
-void* hashmap_put(hashmap *hm, const void *key, unsigned int keylen, const void *val, unsigned int vallen);
+void *hashmap_put(hashmap *hm, const void *key, unsigned int keylen, const void *val, unsigned int vallen);
 void hashmap_sput(hashmap *hashmap, const char *key, void *value, unsigned int value_len);
 void hashmap_iput(hashmap *hashmap, unsigned int key, void *value, unsigned int value_len);
 int hashmap_get(hashmap *hm, const void *key, unsigned int keylen, void **val, unsigned int *vallen);

--- a/include/utils/iterator.h
+++ b/include/utils/iterator.h
@@ -8,11 +8,11 @@ struct iterator_t {
     void *vnow;
     int inow;
     int ended;
-    void* (*next)(iterator*);
-    void* (*prev)(iterator*);
+    void *(*next)(iterator *);
+    void *(*prev)(iterator *);
 };
 
-void* iter_next(iterator *iterator);
-void* iter_prev(iterator *iterator);
+void *iter_next(iterator *iterator);
+void *iter_prev(iterator *iterator);
 
 #endif // ITERATOR_H

--- a/include/utils/list.h
+++ b/include/utils/list.h
@@ -26,6 +26,6 @@ void list_delete(list *list, iterator *iter);
 unsigned int list_size(const list *list);
 void list_iter_begin(const list *list, iterator *iter);
 void list_iter_end(const list *list, iterator *iter);
-void* list_get(const list *list, unsigned int i);
+void *list_get(const list *list, unsigned int i);
 
 #endif // LIST_H

--- a/include/utils/log.h
+++ b/include/utils/log.h
@@ -4,19 +4,19 @@
 #include <stdlib.h>
 
 #ifdef DEBUGMODE
-#define DEBUG(...) log_print('D', __FUNCTION__, __VA_ARGS__ )
-#define PERROR(...) log_print('E', __FUNCTION__, __VA_ARGS__ )
-#define INFO(...) log_print('I', __FUNCTION__, __VA_ARGS__ )
+#define DEBUG(...) log_print('D', __FUNCTION__, __VA_ARGS__)
+#define PERROR(...) log_print('E', __FUNCTION__, __VA_ARGS__)
+#define INFO(...) log_print('I', __FUNCTION__, __VA_ARGS__)
 #else
 #define DEBUG(...)
-#define PERROR(...) log_print('E', NULL, __VA_ARGS__ )
-#define INFO(...) log_print('I', NULL, __VA_ARGS__ )
+#define PERROR(...) log_print('E', NULL, __VA_ARGS__)
+#define INFO(...) log_print('I', NULL, __VA_ARGS__)
 #endif
 
 #define LOGTICK(x) _log_tick = x;
 extern unsigned int _log_tick;
 
-void log_print(char mode, const char* fn, const char *fmt, ...);
+void log_print(char mode, const char *fn, const char *fmt, ...);
 int log_init(const char *filename);
 void log_close();
 

--- a/include/utils/random.h
+++ b/include/utils/random.h
@@ -21,10 +21,9 @@ uint32_t random_intmax(struct random_t *r);
 /* Return a random float in 0 <= r <= 1.0f */
 float random_float(struct random_t *r);
 
-
 /* Same as the above but keeps an internal state
  * Use as a replacement for rand()
-*/
+ */
 void rand_seed(uint32_t seed);
 uint32_t rand_get_seed(void);
 uint32_t rand_int(uint32_t upperbound);

--- a/include/utils/str.h
+++ b/include/utils/str.h
@@ -1,19 +1,19 @@
 #ifndef STR_H
 #define STR_H
 
-#include <stddef.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct {
     size_t len;
-    char* data;
+    char *data;
 } str;
 
 /**
  * @brief Create an empty string object.
  * @details Creates a new, empty string object. After creating the object, it must be freed
- *          using the str_free. 
+ *          using the str_free.
  * @param dst Target string object
  */
 void str_create(str *dst);
@@ -68,7 +68,7 @@ void str_from_slice(str *dst, const str *src, size_t start, size_t end);
  * @brief Free string object
  * @details Frees up any memory used by the string object. Usage of the string after freeing it
  *          is undefined behaviour.
- * 
+ *
  * @param string String to free
  */
 void str_free(str *string);
@@ -193,6 +193,6 @@ bool str_to_long(const str *string, long *m);
  * @param src String to convert
  * @return const char*
  */
-const char* str_c(const str *src);
+const char *str_c(const str *src);
 
 #endif // STR_H

--- a/include/utils/vector.h
+++ b/include/utils/vector.h
@@ -11,12 +11,12 @@ typedef struct vector_t {
     unsigned int inc_factor;
 } vector;
 
-typedef int (*vector_compare_func)(const void*, const void*);
+typedef int (*vector_compare_func)(const void *, const void *);
 
 void vector_create(vector *vector, unsigned int block_size);
 void vector_free(vector *vector);
 void vector_clear(vector *vector);
-void* vector_get(const vector *vector, unsigned int key);
+void *vector_get(const vector *vector, unsigned int key);
 int vector_append(vector *vector, const void *value);
 int vector_prepend(vector *vector, const void *value);
 void vector_sort(vector *vector, vector_compare_func cf);

--- a/include/video/color.h
+++ b/include/video/color.h
@@ -1,17 +1,17 @@
 #ifndef COLOR_H
 #define COLOR_H
 
-#define COLOR_RED color_create(255,0,0,255)
-#define COLOR_GREEN color_create(0,255,0,255)
-#define COLOR_BLUE color_create(0,0,255,255)
-#define COLOR_YELLOW color_create(255,255,0,255)
-#define COLOR_WHITE color_create(255,255,255,255)
-#define COLOR_BLACK color_create(0,0,0,255)
+#define COLOR_RED color_create(255, 0, 0, 255)
+#define COLOR_GREEN color_create(0, 255, 0, 255)
+#define COLOR_BLUE color_create(0, 0, 255, 255)
+#define COLOR_YELLOW color_create(255, 255, 0, 255)
+#define COLOR_WHITE color_create(255, 255, 255, 255)
+#define COLOR_BLACK color_create(0, 0, 0, 255)
 
 typedef struct color_t color;
 
 struct color_t {
-    unsigned char r,g,b,a;
+    unsigned char r, g, b, a;
 };
 
 color color_create(unsigned char r, unsigned char g, unsigned char b, unsigned char a);

--- a/include/video/image.h
+++ b/include/video/image.h
@@ -5,7 +5,7 @@
 #include "video/color.h"
 
 typedef struct image_t {
-    unsigned int w,h;
+    unsigned int w, h;
     char *data;
 } image;
 
@@ -17,11 +17,7 @@ void image_clear(image *img, color c);
 void image_line(image *img, int x0, int y0, int x1, int y1, color c);
 void image_set_pixel(image *img, int x, int y, color c);
 void image_rect(image *img, int x, int y, int w, int h, color c);
-void image_rect_bevel(image *img,
-                      int x, int y,
-                      int w, int h,
-                      color ctop, color cright,
-                      color cbottom, color left);
+void image_rect_bevel(image *img, int x, int y, int w, int h, color ctop, color cright, color cbottom, color left);
 void image_filled_rect(image *img, int x, int y, int w, int h, color c);
 int image_write_tga(image *img, const char *filename);
 

--- a/include/video/surface.h
+++ b/include/video/surface.h
@@ -1,10 +1,10 @@
 #ifndef SURFACE_H
 #define SURFACE_H
 
-#include <SDL.h>
+#include "formats/palette.h"
 #include "video/image.h"
 #include "video/screen_palette.h"
-#include "formats/palette.h"
+#include <SDL.h>
 
 typedef struct {
     int w;
@@ -15,12 +15,14 @@ typedef struct {
     uint8_t force_refresh;
 } surface;
 
-enum {
+enum
+{
     SURFACE_TYPE_RGBA,
     SURFACE_TYPE_PALETTE
 };
 
-enum {
+enum
+{
     SUB_METHOD_NONE,
     SUB_METHOD_MIRROR
 };
@@ -35,33 +37,13 @@ void surface_copy_ex(surface *dst, surface *src);
 void surface_free(surface *sur);
 void surface_clear(surface *sur);
 void surface_fill(surface *sur, color c);
-void surface_sub(surface *dst,
-                 surface *src,
-                 int dst_x, int dst_y,
-                 int src_x, int src_y,
-                 int w, int h,
-                 int method);
+void surface_sub(surface *dst, surface *src, int dst_x, int dst_y, int src_x, int src_y, int w, int h, int method);
 void surface_convert_to_rgba(surface *sur, screen_palette *pal, int pal_offset);
 int surface_get_type(surface *sur);
-void surface_to_rgba(surface *sur,
-                     char *dst,
-                     screen_palette *pal,
-                     char *remap_table,
-                     uint8_t pal_offset);
-void surface_additive_blit(surface *dst,
-                           surface *src,
-                           int dst_x, int dst_y,
-                           palette *remap_pal,
-                           SDL_RendererFlip flip);
+void surface_to_rgba(surface *sur, char *dst, screen_palette *pal, char *remap_table, uint8_t pal_offset);
+void surface_additive_blit(surface *dst, surface *src, int dst_x, int dst_y, palette *remap_pal, SDL_RendererFlip flip);
 void surface_rgba_blit(surface *dst, const surface *src, int dst_x, int dst_y);
-void surface_alpha_blit(surface *dst,
-                        surface *src,
-                        int dst_x, int dst_y,
-                        SDL_RendererFlip flip);
-int surface_to_texture(surface *src,
-                       SDL_Texture *tex,
-                       screen_palette *pal,
-                       char *remap_table,
-                       uint8_t pal_offset);
+void surface_alpha_blit(surface *dst, surface *src, int dst_x, int dst_y, SDL_RendererFlip flip);
+int surface_to_texture(surface *src, SDL_Texture *tex, screen_palette *pal, char *remap_table, uint8_t pal_offset);
 
 #endif // SURFACE_H

--- a/include/video/tcache.h
+++ b/include/video/tcache.h
@@ -1,19 +1,16 @@
 #ifndef TCACHE_H
 #define TCACHE_H
 
-#include <SDL.h>
-#include "video/surface.h"
-#include "video/screen_palette.h"
 #include "plugins/scaler_plugin.h"
+#include "video/screen_palette.h"
+#include "video/surface.h"
+#include <SDL.h>
 
 void tcache_init(SDL_Renderer *renderer, int scale_factor, scaler_plugin *scaler);
 void tcache_reinit(SDL_Renderer *renderer, int scale_factor, scaler_plugin *scaler);
 void tcache_close();
 void tcache_clear();
-SDL_Texture* tcache_get(surface *sur,
-                        screen_palette *pal,
-                        char *remap_table,
-                        uint8_t pal_offset);
+SDL_Texture *tcache_get(surface *sur, screen_palette *pal, char *remap_table, uint8_t pal_offset);
 void tcache_tick();
 
 #endif // TCACHE_H

--- a/include/video/video.h
+++ b/include/video/video.h
@@ -3,90 +3,48 @@
 
 #include <stdbool.h>
 
+#include "formats/palette.h"
 #include "video/color.h"
-#include "video/surface.h"
 #include "video/image.h"
 #include "video/screen_palette.h"
-#include "formats/palette.h"
+#include "video/surface.h"
 
 #define NATIVE_W 320
 #define NATIVE_H 200
 
-enum VIDEO_BLEND_MODE {
+enum VIDEO_BLEND_MODE
+{
     BLEND_ADDITIVE = 0,
     BLEND_ALPHA
 };
 
-enum VIDEO_FLIP_MODE {
+enum VIDEO_FLIP_MODE
+{
     FLIP_NONE = 0,
     FLIP_HORIZONTAL = 0x1,
     FLIP_VERTICAL = 0x2,
 };
 
-int video_init(int window_w,
-               int window_h,
-               int fullscreen,
-               int vsync,
-               const char* scaler_name,
-               int scale_factor);
-int video_reinit(int window_w,
-                 int window_h,
-                 int fullscreen,
-                 int vsync,
-                 const char* scaler_name,
-                 int scale_factor);
+int video_init(int window_w, int window_h, int fullscreen, int vsync, const char *scaler_name, int scale_factor);
+int video_reinit(int window_w, int window_h, int fullscreen, int vsync, const char *scaler_name, int scale_factor);
 void video_reinit_renderer();
 void video_get_state(int *w, int *h, int *fs, int *vsync);
 void video_move_target(int x, int y);
 
-void video_render_sprite(
-    surface *sur,
-    int x,
-    int y,
-    unsigned int render_mode,
-    int pal_offset);
+void video_render_sprite(surface *sur, int x, int y, unsigned int render_mode, int pal_offset);
 
-void video_render_sprite_size(
-        surface *sur,
-        int sx, int sy,
-        int sw, int sh);
+void video_render_sprite_size(surface *sur, int sx, int sy, int sw, int sh);
 
-void video_render_sprite_flip_scale(
-    surface *sur,
-    int x,
-    int y,
-    unsigned int render_mode,
-    int pal_offset,
-    unsigned int flip_mode,
-    float y_percent);
+void video_render_sprite_flip_scale(surface *sur, int x, int y, unsigned int render_mode, int pal_offset,
+                                    unsigned int flip_mode, float y_percent);
 
-void video_render_sprite_tint(
-    surface *sur,
-    int x,
-    int y,
-    color c,
-    int pal_offset);
+void video_render_sprite_tint(surface *sur, int x, int y, color c, int pal_offset);
 
-void video_render_sprite_flip_scale_opacity(
-    surface *sur,
-    int x,
-    int y,
-    unsigned int render_mode,
-    int pal_offset,
-    unsigned int flip_mode,
-    float y_percent,
-    uint8_t opacity);
+void video_render_sprite_flip_scale_opacity(surface *sur, int x, int y, unsigned int render_mode, int pal_offset,
+                                            unsigned int flip_mode, float y_percent, uint8_t opacity);
 
-void video_render_sprite_flip_scale_opacity_tint(
-    surface *sur,
-    int x,
-    int y,
-    unsigned int render_mode,
-    int pal_offset,
-    unsigned int flip_mode,
-    float y_percent,
-    uint8_t opacity,
-    color tint);
+void video_render_sprite_flip_scale_opacity_tint(surface *sur, int x, int y, unsigned int render_mode, int pal_offset,
+                                                 unsigned int flip_mode, float y_percent, uint8_t opacity, color tint);
 
 void video_tick();
 void video_render_background(surface *sur);
@@ -99,9 +57,9 @@ void video_set_fade(float fade);
 void video_render_bg_separately(bool separate);
 
 void video_set_base_palette(const palette *src);
-palette* video_get_base_palette();
+palette *video_get_base_palette();
 void video_force_pal_refresh();
 void video_copy_pal_range(const palette *src, int src_start, int dst_start, int amount);
-screen_palette* video_get_pal_ref();
+screen_palette *video_get_pal_ref();
 
 #endif // VIDEO_H

--- a/include/video/video_state.h
+++ b/include/video/video_state.h
@@ -3,10 +3,10 @@
 
 #include <stdbool.h>
 
-#include <SDL.h>
 #include "formats/palette.h"
-#include "video/screen_palette.h"
 #include "plugins/scaler_plugin.h"
+#include "video/screen_palette.h"
+#include <SDL.h>
 
 typedef struct video_state_t {
     SDL_Window *window;
@@ -29,8 +29,8 @@ typedef struct video_state_t {
     SDL_Texture *bg_target;
 
     // Palettes
-    palette *base_palette;  // Copy of the scenes base palette
-    screen_palette *screen_palette;  // Normal rendering palette
+    palette *base_palette;          // Copy of the scenes base palette
+    screen_palette *screen_palette; // Normal rendering palette
     screen_palette *extra_palette;  // Reflects base palette, used for additive blending
 } video_state;
 

--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -87,7 +87,8 @@ typedef struct ai_t {
     vector active_projectiles;
 } ai;
 
-enum {
+enum
+{
     TACTIC_ESCAPE = 1, // escape from enemy
     TACTIC_TURTLE,     // block attacks
     TACTIC_GRAB,       // charge and grab enemy
@@ -101,7 +102,8 @@ enum {
     TACTIC_COUNTER     // block then attack
 };
 
-enum {
+enum
+{
     MOVE_CLOSE = 1, // close distance
     MOVE_AVOID,     // gain distance
     MOVE_JUMP,      // jump towards
@@ -109,7 +111,8 @@ enum {
     MOVE_BLOCK      // hold block
 };
 
-enum {
+enum
+{
     ATTACK_ID = 1, // attack by id
     ATTACK_TRIP,   // trip attack
     ATTACK_GRAB,   // grab/throw attack
@@ -122,9 +125,20 @@ enum {
     ATTACK_RANDOM, // random attack
 };
 
-enum { RANGE_CRAMPED = 0, RANGE_CLOSE, RANGE_MID, RANGE_FAR };
+enum
+{
+    RANGE_CRAMPED = 0,
+    RANGE_CLOSE,
+    RANGE_MID,
+    RANGE_FAR
+};
 
-enum { MOVE_DIR_STILL, MOVE_DIR_FWD, MOVE_DIR_BACK };
+enum
+{
+    MOVE_DIR_STILL,
+    MOVE_DIR_FWD,
+    MOVE_DIR_BACK
+};
 
 int char_to_act(int ch, int direction) {
     switch(ch) {

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -37,7 +37,8 @@
 #define MS_PER_OMF_TICK 10
 #define MS_PER_OMF_TICK_SLOWEST 60
 
-enum {
+enum
+{
     TICK_DYNAMIC = 0,
     TICK_STATIC,
 };

--- a/src/game/scenes/mechlab.c
+++ b/src/game/scenes/mechlab.c
@@ -19,7 +19,8 @@
 #include "utils/log.h"
 #include "video/video.h"
 
-typedef enum {
+typedef enum
+{
     DASHBOARD_NONE,
     DASHBOARD_STATS,
     DASHBOARD_NEW,

--- a/src/game/utils/settings.c
+++ b/src/game/utils/settings.c
@@ -25,7 +25,13 @@
 static settings _settings;
 static const char *settings_path;
 
-typedef enum field_type_t { TYPE_INT, TYPE_FLOAT, TYPE_BOOL, TYPE_STRING } field_type;
+typedef enum field_type_t
+{
+    TYPE_INT,
+    TYPE_FLOAT,
+    TYPE_BOOL,
+    TYPE_STRING
+} field_type;
 
 typedef union field_default_u {
     char *s;

--- a/testing/misc/parser_test_strings.c
+++ b/testing/misc/parser_test_strings.c
@@ -1,6 +1,6 @@
 #include "parser_test_strings.h"
 
-const char* test_strings[] = {
+const char *test_strings[] = {
     "A120-B20-C10-D10-E10-F10-G10-rfE10-rfF10-rfG10-rfH10-D10-C10-B20-A120",
     "A5-B4-jn15C4-jgjn15D4",
     "A6-B6-C6-B6",
@@ -16,16 +16,23 @@ const char* test_strings[] = {
     "A2-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1-M1-N1-O1-P1-Q1-R1-S1-d1T2-U20-bf0bs255U40",
     "A2-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1-M1-N1-O1-P1-Q1-R1-S1-d1T2-U20-bf0bs255U40",
     "l50s01A1-vx-5y-5sas25sp15l50bl5B2-C3-L5-M300",
-    "zzA1-hx+1zzcps20l45sp9B1-hx+2k60C2-hx+5y-2k60D2-hx+7y-3k60E2-hx+9y-5k60F1-hx+9y-5k60cpF5-hx+7y-3k60cpF2-vx+3y-1nk60E1-nE2-D2",
+    "zzA1-hx+1zzcps20l45sp9B1-hx+2k60C2-hx+5y-2k60D2-hx+7y-3k60E2-hx+9y-5k60F1-hx+9y-5k60cpF5-hx+7y-3k60cpF2-vx+3y-"
+    "1nk60E1-nE2-D2",
     "A1",
-    "zzA1-hx+1zzcps20l45sp9B1-hx+2k60C2-hx+5y-2k60D2-hx+7y-3k60E2-hx+9y-5k60F1-hx+9y-5k60cpF5-hx+7y-3k60cpF2-vx+3y-1nk60E1-nE2-D2",
-    "zzA1-vx+1zzcps20l45sp9B1-vx+3k60jn39C2-vx+5y-2k60jn39D2-vx+7y-3k60jn39E2-vx+9y-5k60jn39F1-vx+9y-5k60cpjn39F5-vx+7y-3k60cpjn39F2-vx+3y-1nk60E1-nhE2-D2",
+    "zzA1-hx+1zzcps20l45sp9B1-hx+2k60C2-hx+5y-2k60D2-hx+7y-3k60E2-hx+9y-5k60F1-hx+9y-5k60cpF5-hx+7y-3k60cpF2-vx+3y-"
+    "1nk60E1-nE2-D2",
+    "zzA1-vx+1zzcps20l45sp9B1-vx+3k60jn39C2-vx+5y-2k60jn39D2-vx+7y-3k60jn39E2-vx+9y-5k60jn39F1-vx+9y-5k60cpjn39F5-vx+"
+    "7y-3k60cpjn39F2-vx+3y-1nk60E1-nhE2-D2",
     "l50s02zzx-2D1-zzx-2E2-zzx-1F2-F4-E3-D1",
-    "zzA1-hx+2zzcpubs20l60sp9B1-hx+4zpk60ubq2C2-hx+5y-2zpaik60ubD2-hx+8y-3zpaik60ubE2-hx+11y-6aik60cpubF7-hx+7y-3aik60cpF2-vx+3y-1naik60ubE2-naik60E3-naiD4-gnB9",
-    "zzA1-vx+2zzcpubs20l60sp9B1-vx+4zpk60ubq2C2-vx+5y-2zpaik60ubD2-vx+8y-3zpaik60ubjn43E2-vx+11y-6aik60jn43cpubF7-vx+7y-3aik60jn43cpF2-hx+3y-1naik60E2-naik60E3-naiubD4-gnB9",
+    "zzA1-hx+2zzcpubs20l60sp9B1-hx+4zpk60ubq2C2-hx+5y-2zpaik60ubD2-hx+8y-3zpaik60ubE2-hx+11y-6aik60cpubF7-hx+7y-"
+    "3aik60cpF2-vx+3y-1naik60ubE2-naik60E3-naiD4-gnB9",
+    "zzA1-vx+2zzcpubs20l60sp9B1-vx+4zpk60ubq2C2-vx+5y-2zpaik60ubD2-vx+8y-3zpaik60ubjn43E2-vx+11y-6aik60jn43cpubF7-vx+"
+    "7y-3aik60jn43cpF2-hx+3y-1naik60E2-naik60E3-naiubD4-gnB9",
     "l50s01A1-vx-5y-5s25sp15l50bl5B2-C3-L5-M300",
-    "zzA1-hx+1zzcpsas20l45sp9B1-hx+1k60C2-hx+3y-2k60D2-hx+5y-3k60E2-hx+7y-5k60cpF5-hx+8y-3k60cpF2-vx+3y-1nE1-nE2-nD3-gnB7",
-    "zzA1-hx+1zzcps20l45sp9B1-hx+1k60C2-hx+3y-2k60D2-hx+5y-3k60jn15E2-hx+7y-5k60jn15cpF5-hx+8y-3k60jn15cpF2-vx+3y-1njn15E1-njnjn15E2-njn15D3-gnB7",
+    "zzA1-hx+1zzcpsas20l45sp9B1-hx+1k60C2-hx+3y-2k60D2-hx+5y-3k60E2-hx+7y-5k60cpF5-hx+8y-3k60cpF2-vx+3y-1nE1-nE2-nD3-"
+    "gnB7",
+    "zzA1-hx+1zzcps20l45sp9B1-hx+1k60C2-hx+3y-2k60D2-hx+5y-3k60jn15E2-hx+7y-5k60jn15cpF5-hx+8y-3k60jn15cpF2-vx+3y-"
+    "1njn15E1-njnjn15E2-njn15D3-gnB7",
     "sp13s3l20sf0D1-E4-D3",
     "sp7sf10l20s5A1-B2-cpC2-nB2-nA1",
     "sp7sf10l20s5A1-B3-cpC3-nB2-nA1",
@@ -50,12 +57,14 @@ const char* test_strings[] = {
     "sp7sf-3l33s5A1-B2-cpC2-jhnB2-jhnA2",
     "sp7sf-3l33s5A1-B2-cpC2-jhnB1-jhnA1",
     "sp7sf-3l33s5A1-B1-cpC2-jhnB1-jhnA1",
-    "egx-35B4-egx-25y-20C4-fregx+7y-81M4-rfegx+32y-90L4-rfegx+35y-80m56my+80C1-rfl40s4egx+35y-80m12my+80C3-gy-1bs5M1-vx+4y-8M2-M200",
+    "egx-35B4-egx-25y-20C4-fregx+7y-81M4-rfegx+32y-90L4-rfegx+35y-80m56my+80C1-rfl40s4egx+35y-80m12my+80C3-gy-1bs5M1-"
+    "vx+4y-8M2-M200",
     "A4-B4-C4-pD4-bb5cpE4-D1-C2-B1",
     "s1l40A1-C3-B2-A1",
     "nA2-nB1-nC1-nD2-mx+60my-59m38mp13mn20nD1-nE5-mm21mu12jhnD4-jhC4",
     "nA2-nB1-nC1-cpD2-mx+60my-59m38mp13mn20D1-E5-mx+60my-59m38mp13mn20D1-E5-mm21mu12jhnD4-jhC4",
-    "nA2-nB1-nC1-cpD2-mx+60my-59m38mp13mn20D1-E5-mx+60my-59m38mp13mn20D1-E5-mx+60my-59m38mp13mn20D1-E5-mm21mu12jhnD4-jhC4",
+    "nA2-nB1-nC1-cpD2-mx+60my-59m38mp13mn20D1-E5-mx+60my-59m38mp13mn20D1-E5-mx+60my-59m38mp13mn20D1-E5-mm21mu12jhnD4-"
+    "jhC4",
     "ey+1x+58ubL2-ey-45x+60ubM2-fey-130x+35ubL2-rfey-55x-25oy-95ox+40ubP2-frvx-10y-5oy-60ubL2-arubM1-ubM200",
     "E1-l63sp20s26E1-F2-cpG2-H2-I6",
     "sp13s2l20sf0D1-E4-D3",
@@ -82,9 +91,11 @@ const char* test_strings[] = {
     "sp7sf-22l52s5A1-B1-cpC1-cpD1-cpE2-F2-G2-H1",
     "sp7sf-22l52s5A0-B1-cpC1-cpD1-cpE2-F2-G1-H1",
     "sp7sf-22l52s5A0-B1-cpC1-cpD1-cpE1-F1-G1-H1",
-    "uO30-ey-47uox+8X7-ey-82uox+3X30-ey-47uox-2X3-ey-30uox-20N1-ey-15uox-20N1-em56uox-20O1-ebpp64m12mi25s28l30uox-20O1-emx-30my+4m56uox-20y+5O1-emx+30my-2m56uox-20y+5sw40O1-ox-20oy+5O4000",
+    "uO30-ey-47uox+8X7-ey-82uox+3X30-ey-47uox-2X3-ey-30uox-20N1-ey-15uox-20N1-em56uox-20O1-ebpp64m12mi25s28l30uox-20O1-"
+    "emx-30my+4m56uox-20y+5O1-emx+30my-2m56uox-20y+5sw40O1-ox-20oy+5O4000",
     "bm10amebewA1-bebxwA3-bewB3-bewC3-bewusD20-uabewE7-uabejf2wF30-uabewG3-uabewH7",
-    "ey-47uox-2X4-ey-82uox-2X36-ey-47uox-2X3-ey-30uox-20s29l63sp20N1-ey-15uox-20m55mn60mx-30my+11b2N1-euox-20m55mn60mx+30my+4sw50N1-ebpp64m12mi40uox-20N1-Z4000",
+    "ey-47uox-2X4-ey-82uox-2X36-ey-47uox-2X3-ey-30uox-20s29l63sp20N1-ey-15uox-20m55mn60mx-30my+11b2N1-euox-20m55mn60mx+"
+    "30my+4sw50N1-ebpp64m12mi40uox-20N1-Z4000",
     "uabewE4-vy-17buuabewF3-uabewusI33-uabewG2-uabegjn28wH25",
     "sp13s1l33sf-6A1-B1-C4-B3-A2",
     "A1-sp7sf-3l33s5B2-C2-cpD3-jpjn21nC3-jpjn21nB2-jpjn21nA2",
@@ -139,8 +150,11 @@ const char* test_strings[] = {
     "sp13s2l20sf0D1-E4-D3",
     "abmn45A2-B2-C2-D2-E2-F2",
     "s01l50A1-sw20B1-C5-B4-A2",
-    "unbwq1A1-s22sp10l40vx+9unbwq1A1-cx+4cy+4unq1A5-s22sp10l32cx+3cy+3mn40unq1A5-cx+4cy+4unq1A5-s22sp10l32cx+3cy+3mn40unq1A5-cx+2cy+2unq1A5-s22sp10l25cx+1cy+1q1A4-cx+4cy+4unq1A6-s22sp10l15cx+4cy+4unA2-cx+4cy+4unq1A8-s22sp10l5cx+4cy+4unq1A2",
-    "unbwq1A1-s22sp10l40vx+9unbwq1A1-unA8-s22sp10l32unq1A2-unq1A8-s22sp10l32unq1A2-unq1A8-s22sp10l25unq1A2-unq1A8-s22sp10l15unq1A2-unq1q1A8-s22sp10l5unq1A2",
+    "unbwq1A1-s22sp10l40vx+9unbwq1A1-cx+4cy+4unq1A5-s22sp10l32cx+3cy+3mn40unq1A5-cx+4cy+4unq1A5-s22sp10l32cx+3cy+"
+    "3mn40unq1A5-cx+2cy+2unq1A5-s22sp10l25cx+1cy+1q1A4-cx+4cy+4unq1A6-s22sp10l15cx+4cy+4unA2-cx+4cy+4unq1A8-"
+    "s22sp10l5cx+4cy+4unq1A2",
+    "unbwq1A1-s22sp10l40vx+9unbwq1A1-unA8-s22sp10l32unq1A2-unq1A8-s22sp10l32unq1A2-unq1A8-s22sp10l25unq1A2-unq1A8-"
+    "s22sp10l15unq1A2-unq1q1A8-s22sp10l5unq1A2",
     "A2-B2-agurC2-agurD2-agurE2-agurF2-agurG2",
     "sp13s2l33sf-6D1-E1-F4-E3-D2",
     "A1-sp7sf-3l33s5B2-C2-cpD3-nC3-jmnB3-jmnA2",
@@ -190,9 +204,11 @@ const char* test_strings[] = {
     "beA3-beB3-beC3-beD3-beE3-jfbeF3-jfbeG3-jfH3-beI3-s27l63sp12jfJ1500",
     "sp13s1l20sf0A1-B4-A3",
     "A5-B6-C7-D7-E19-D1-C2-B2-A1400",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A120-B20-C10-D10-E10-F10-G10-H10-rfE10-rfF10-rfG10-rfH10-D10-C10-B20-A120",
     "A4-B3-jn16C2-jgjn16D3",
     "A6-B6-C6-B6",
@@ -256,7 +272,8 @@ const char* test_strings[] = {
     "A0-sp7sf-15l45s5B1-C2-cpD2-nE2-jmnF1-jmnG1",
     "A0-sp7sf-15l45s5B1-C2-cpD2-nE1-jmnF1-jmnG1",
     "A0-sp7sf-15l45s5B1-C1-cpD1-nE1-jmnF1-jmnG1",
-    "ex-53E2-ex-53F4-ex-48y-3J4-ex-45y-6K3-ex-3y-62rfM2-ex+35y-25rfoy-45L4-ex+48y-45oy-47frP4-vy-7x+8frox+15oy-50J1-frox+15oy-50J2-M400",
+    "ex-53E2-ex-53F4-ex-48y-3J4-ex-45y-6K3-ex-3y-62rfM2-ex+35y-25rfoy-45L4-ex+48y-45oy-47frP4-vy-7x+8frox+15oy-50J1-"
+    "frox+15oy-50J2-M400",
     "A5-A1-B4-C3-D2-E20-F4-G4-H4",
     "nbtA3-nbtB4-mp13mn30m22nbtmx+80B1-nbtA6",
     "vx-5y-7s03l50L1-L5-M300",
@@ -410,27 +427,40 @@ const char* test_strings[] = {
     "vx-5y-7s01l50bl6L1-L5-M300",
     "bthnA3-bf230btnA1-bf200btnA1-bf150btnA1-bf110btnA1-bf70btnA1-bf30btnxA1",
     "x+6nbtB3-x+4nbtB3-x+2nbtB3-bf230btnB1-bf200btnB1-bf150btnB1-bf110btnB1-bf70btnB1-bf30btnB1",
-    "nbtx+11B3-nbtx+11B3-nbtx+11B3-bf230btnx+11B1-bf200btnx+11B1-bf150btnx+11B1-bf110btnx+11B1-bf70btnx+11B1-bf30btnx+11B1",
-    "gx-8bzbpfbpp10bpd231mm23mu25mm16mu25A1-gx-6bzbpfbpp20bpd231mm23mu25mm16mu25A1-x-5bzbpfbpp30bpd231B1-x-3bzbpfbpp40bpd231mm23mu25mm16mu25B1-x-2bzbpfbpp50bpd231B1-bzbpfbpp60bpd231B1-bzbpfbpp100bpb60bpd231mm23mu25mm16mu25C20-bzbpfbpp100bpd231mm23mu25mm16mu25C30-bzbpfbpp30bpb100bpd231mm23mu25mm16mu25C10-bzbpfbpp1bpb30bpd231mm23mu25mm16mu25B4-A2",
+    "nbtx+11B3-nbtx+11B3-nbtx+11B3-bf230btnx+11B1-bf200btnx+11B1-bf150btnx+11B1-bf110btnx+11B1-bf70btnx+11B1-bf30btnx+"
+    "11B1",
+    "gx-8bzbpfbpp10bpd231mm23mu25mm16mu25A1-gx-6bzbpfbpp20bpd231mm23mu25mm16mu25A1-x-5bzbpfbpp30bpd231B1-x-"
+    "3bzbpfbpp40bpd231mm23mu25mm16mu25B1-x-2bzbpfbpp50bpd231B1-bzbpfbpp60bpd231B1-"
+    "bzbpfbpp100bpb60bpd231mm23mu25mm16mu25C20-bzbpfbpp100bpd231mm23mu25mm16mu25C30-"
+    "bzbpfbpp30bpb100bpd231mm23mu25mm16mu25C10-bzbpfbpp1bpb30bpd231mm23mu25mm16mu25B4-A2",
     "x+20A2-x+20B2-x+20d1A2",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "x+15A2-x+10B1-x+13bf200B1-x+10bf150B1-x+7bf100B1",
-    "O22-O7-R3-S25-m12ma10mi2my-65s1l40A1-m56my-65B1-C5-B2-A1-m12ma190mi2my-65s1l40D1-m56mx+5my-65E1-F4-E2-D1-m12ma10mi2my-65s1l40A1-m56my-65B1-C5-B2-A1-m12ma190mi2my-65s1l40D1-m56mx+5my-65E1-F4-E2-D1-m12ma10mi2my-65s1l40A1-m56my-65B1-C5-B2-A1-S10-bhm12ma10my-50mx-10mi5sw40A1-vx-2y-12m56my-50mx-10bhs1l60B1-bhC4-bhL4-bhM200",
+    "O22-O7-R3-S25-m12ma10mi2my-65s1l40A1-m56my-65B1-C5-B2-A1-m12ma190mi2my-65s1l40D1-m56mx+5my-65E1-F4-E2-D1-"
+    "m12ma10mi2my-65s1l40A1-m56my-65B1-C5-B2-A1-m12ma190mi2my-65s1l40D1-m56mx+5my-65E1-F4-E2-D1-m12ma10mi2my-65s1l40A1-"
+    "m56my-65B1-C5-B2-A1-S10-bhm12ma10my-50mx-10mi5sw40A1-vx-2y-12m56my-50mx-10bhs1l60B1-bhC4-bhL4-bhM200",
     "bm10ambewcfx+52gA1-bxbeA1-bebxA4-beB6-beC10-bem62mp20usC1-beuaC115-beufjf2C40-C400",
     "sp13s1l20sf0A1-B4-A3",
-    "ex-50bf40btafA1-ex-40bf80btafs20l60A1-bf120btA1-bf160btA1-bf200btB1-bf230btB1-btB1-btC3-btD6-btE2-btm63mp20E1-btF12-btG2-btH1-btI3-btH2-btG3-btF8-btG2-btH1-btI3-btH2-btG3-btF8-btG2-btH1-btI3-btJ2-btK3-btL10-btM2-btN1-btO1-btP2-btQ24-btbf220Q1-btbf190Q1-btbf160Q1-btbf130Q1-btbf100Q1-btbf70Q1-btbf40Q1",
+    "ex-50bf40btafA1-ex-40bf80btafs20l60A1-bf120btA1-bf160btA1-bf200btB1-bf230btB1-btB1-btC3-btD6-btE2-btm63mp20E1-"
+    "btF12-btG2-btH1-btI3-btH2-btG3-btF8-btG2-btH1-btI3-btH2-btG3-btF8-btG2-btH1-btI3-btJ2-btK3-btL10-btM2-btN1-btO1-"
+    "btP2-btQ24-btbf220Q1-btbf190Q1-btbf160Q1-btbf130Q1-btbf100Q1-btbf70Q1-btbf40Q1",
     "sp13s1l20sf0A1-B4-A3",
-    "afZ1-ex-49arafZ1-btbf40s20l60G1-btbf80G1-btbf120G1-btbf160G1-btbf200G1-btbf230G1-btG18-btH1-btI3-btH2-btG3-btF8-btG2-btH1-btI3-btH2-btG3-btF18-bf220btF1-bf190btF1-bf160btF1-bf130btF1-bf100btF1-bf70btF1-bf40btF1",
+    "afZ1-ex-49arafZ1-btbf40s20l60G1-btbf80G1-btbf120G1-btbf160G1-btbf200G1-btbf230G1-btG18-btH1-btI3-btH2-btG3-btF8-"
+    "btG2-btH1-btI3-btH2-btG3-btF18-bf220btF1-bf190btF1-bf160btF1-bf130btF1-bf100btF1-bf70btF1-bf40btF1",
     "uO44-s29l63m55mx+20uN1-m12mi30uM1-Z1000",
     "beC1-sf-10beC17-beC1-bem65mn20mp20C1-beuausC40-jn66uabeusC30-C400",
     "sp13s1l20sf0A1-B4-A3",
-    "Z1-eZ1-bf40btA1-bf70btA1-bf100bts20l65sf-15A1-bf130btA1-bf160btA1-bf190btA1-bf220btA1-btA10-btB2-btsw50C2-btD55-btbf220D1-btbf190D1-btbf160D1-btbf130D1-btbf100D1-btbf70D1-btbf40D1",
+    "Z1-eZ1-bf40btA1-bf70btA1-bf100bts20l65sf-15A1-bf130btA1-bf160btA1-bf190btA1-bf220btA1-btA10-btB2-btsw50C2-btD55-"
+    "btbf220D1-btbf190D1-btbf160D1-btbf130D1-btbf100D1-btbf70D1-btbf40D1",
     "Z1-bugZ1000",
     "beuaC40-beC1-bem67mn20mp20C1-uabeusC60-beB3-beA3-bj69beA2",
     "sp13s1l20sf0A1-B4-A3",
-    "eZ1-eZ1-bf40bteA1-bf70btA1-bf100btA1-bf130btA1-bf160btA1-bf190btA1-bf220btA1-btA10-btB2-btC2-btm55mp20b1s29l60D1-btb1b2D55-btbf220D1-btbf190D1-btbf160D1-btbf130D1-btbf100D1-btbf70D1-btbf40D1",
+    "eZ1-eZ1-bf40bteA1-bf70btA1-bf100btA1-bf130btA1-bf160btA1-bf190btA1-bf220btA1-btA10-btB2-btC2-btm55mp20b1s29l60D1-"
+    "btb1b2D55-btbf220D1-btbf190D1-btbf160D1-btbf130D1-btbf100D1-btbf70D1-btbf40D1",
     "sp13s1l37sf-8A1-B1-C4-B3-A2",
     "A1-sp7sf-7l37s5B1-cpC2-cpD10-nC2-nB2-nA1",
     "A2-sp7sf-7l37s5B2-cpC2-cpD6-nC3-nB2-nA1",
@@ -457,15 +487,21 @@ const char* test_strings[] = {
     "A2-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1-M1-N1-O1-P1-Q1-R1-S1-d1T2-U20-bf0bs255U40",
     "A2-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1-M1-N1-O1-P1-Q1-R1-S1-d1T2-U20-bf0bs255U40",
     "vx-7y-7bl6s02l50D1-E2-F2-L5-M200",
-    "hy-2x+1A1-hy-3x+1cpB2-hy-5x+1cpC3-hy-6x+1zjs21l60k50cpD3-hy-4x+3k50cpE1-hx+3y-1k50cpF2-hy+1x+4k50cpG1-vx+3y+5k50cpH2-vy+7x+5k50cpH12",
+    "hy-2x+1A1-hy-3x+1cpB2-hy-5x+1cpC3-hy-6x+1zjs21l60k50cpD3-hy-4x+3k50cpE1-hx+3y-1k50cpF2-hy+1x+4k50cpG1-vx+3y+"
+    "5k50cpH2-vy+7x+5k50cpH12",
     "A1",
-    "hy-2x+1A1-hy-3x+1cpB2-hy-5x+1cpC3-hy-6x+1zjs21l60k50cpD3-hy-4x+3k50cpE1-hx+3y-1k50cpF2-hy+1x+4k50cpG1-vx+3y+5k50cpH2-vy+7x+5k50cpH12",
+    "hy-2x+1A1-hy-3x+1cpB2-hy-5x+1cpC3-hy-6x+1zjs21l60k50cpD3-hy-4x+3k50cpE1-hx+3y-1k50cpF2-hy+1x+4k50cpG1-vx+3y+"
+    "5k50cpH2-vy+7x+5k50cpH12",
     "s01l50zzbl8A1-zzB2-zzC5-B4-A3",
-    "hy-2x+1zpA1-hy-4x+1zpcpubB2-hy-7x+1aizpcpubC2-hy-10x+1s21l60aik50zpcpubD2-hy-6x+3aik50cpubE2-hx+3y-1aiq2k50cpubF2-hy+1x+4aik50cpubG1-vx+3y+5aik50cpubH2-vy+8x+7aik50cpubH3-nk50cpubH1-gk50cpA11",
-    "hy-2x+1zpA1-hy-4x+1zpcpubB2-hy-7x+1aizpcpubC2-hy-10x+1s21l60aik50zpcpubD2-hy-6x+3aik50cpubjn50E2-hx+3y-1aiq2k50cpubjn50jn50F2-hy+1x+4aik50cpubjn50G1-vx+3y+5aik50cpubjn50H2-vy+8x+7aik50cpubjn50H3-nk50cpubH1-gk50cpA11",
+    "hy-2x+1zpA1-hy-4x+1zpcpubB2-hy-7x+1aizpcpubC2-hy-10x+1s21l60aik50zpcpubD2-hy-6x+3aik50cpubE2-hx+3y-1aiq2k50cpubF2-"
+    "hy+1x+4aik50cpubG1-vx+3y+5aik50cpubH2-vy+8x+7aik50cpubH3-nk50cpubH1-gk50cpA11",
+    "hy-2x+1zpA1-hy-4x+1zpcpubB2-hy-7x+1aizpcpubC2-hy-10x+1s21l60aik50zpcpubD2-hy-6x+3aik50cpubjn50E2-hx+3y-"
+    "1aiq2k50cpubjn50jn50F2-hy+1x+4aik50cpubjn50G1-vx+3y+5aik50cpubjn50H2-vy+8x+7aik50cpubjn50H3-nk50cpubH1-gk50cpA11",
     "vx-7y-7bl6s02l50D2-E2-F2-L5-M200",
-    "hy-2x+1A1-hy-4x+1cB1-hy-5x+1cpC2-hy-8x+1s21l60k50cpD2-hy-4x+3k50cpcpE2-hx+3y-1k50cpF2-hy+1x+3k50cpG2-vx+3y+4k50cpH2-vy+7x+5k50cpH2-nk50cpH1-gk50cpA6",
-    "hy-2x+1A1-hy-4x+1cB1-hy-5x+1cpjn15C2-hy-8x+1s21l60k50cpjn15D2-hy-4x+3k50cpcpjn15E2-hx+3y-1k50cpjn15F2-hy+1x+3k50cpG2-vx+3y+4k50cpjn15H2-vy+7x+5k50cpjn15H2-nk50cpH1-gk50cpA6",
+    "hy-2x+1A1-hy-4x+1cB1-hy-5x+1cpC2-hy-8x+1s21l60k50cpD2-hy-4x+3k50cpcpE2-hx+3y-1k50cpF2-hy+1x+3k50cpG2-vx+3y+"
+    "4k50cpH2-vy+7x+5k50cpH2-nk50cpH1-gk50cpA6",
+    "hy-2x+1A1-hy-4x+1cB1-hy-5x+1cpjn15C2-hy-8x+1s21l60k50cpjn15D2-hy-4x+3k50cpcpjn15E2-hx+3y-1k50cpjn15F2-hy+1x+"
+    "3k50cpG2-vx+3y+4k50cpjn15H2-vy+7x+5k50cpjn15H2-nk50cpH1-gk50cpA6",
     "sp13s3l20sf0D1-E4-D3",
     "A1-sp7sf10l20s5B1-C2-cpD2-nC2-njlB1-njlA1",
     "A1-sp7sf10l20s5B1-C3-cpD3-nC3-njlB1-njlA1",
@@ -490,7 +526,8 @@ const char* test_strings[] = {
     "A1-sp7sf-3l33s5B1-C2-cpD2-njlC2-njlB2-njlA1",
     "A0-sp7sf-3l33s5B1-C2-cpD2-njlC2-njlB1-njlA1",
     "A0-sp7sf-3l33s5B1-C1-cpD2-njlC1-njlB1-njlA1",
-    "ehx-70D7-ehx-60y-15E2-ehx-60y-35J2-ehx-10y-97frM2-x+35y-15hrfL1-hrfL3-vx+9y-5rfL1-oy-40ox-20frP4-oy-40ox-20x-10arfP1-oy-50ox-20frK3-M400",
+    "ehx-70D7-ehx-60y-15E2-ehx-60y-35J2-ehx-10y-97frM2-x+35y-15hrfL1-hrfL3-vx+9y-5rfL1-oy-40ox-20frP4-oy-40ox-20x-"
+    "10arfP1-oy-50ox-20frK3-M400",
     "A7-B2-C2-s26l60sp12D2-E8-D5-C4-B3",
     "sp13s2l20sf0D1-E4-D3",
     "A1-sp7sf10l20s5B1-C2-cpD2-jmnC2-jmnB1-jmnA1",
@@ -564,9 +601,12 @@ const char* test_strings[] = {
     "A1-B1-sp7sf-15l45s5C1-D2-E2-cpF3-nE2-nD2-nC1-nB1-nA1",
     "A1-B1-sp7sf-15l45s5C1-D1-E2-cpF3-nE1-nD1-nC1-nB1-nA1",
     "A1-B1-sp7sf-15l45s5C1-D1-E1-cpF1-nE1-nD1-nC1-nB1-nA1",
-    "l50x+1ulzpA1-x+2ulzpB1-x+3s23l60zpurulubC2-x+7urulzpubD3-x+7urulubE3-x+7s23l60urulubF3-x+7urulubG3-x+7purulubH3-x+7s23l60urulubC3-x+3nurulubC2-x+2urulB2-A1",
-    "l50x+1ulzpA1-x+3ulzpB1-x+5s23l60zpurulubC1-x+10urulzpubD3-x+9urulubE3-x+9s23l60urulubF3-x+9urulubG3-x+9purulubH3-x+9s23l60urulubC3-x+5nurulubC2-x+3urulB2-A1",
-    "l50x+1ulzpA1-x+4ulzpB1-x+6s23l60zpurulubC1-x+13urulzpubD3-x+12urulubE3-x+12s23l60urulubF3-x+12urulubG3-x+12purulubH3-x+12s23l60urulubC3-x+6nurulubC2-x+3urulB2-A1",
+    "l50x+1ulzpA1-x+2ulzpB1-x+3s23l60zpurulubC2-x+7urulzpubD3-x+7urulubE3-x+7s23l60urulubF3-x+7urulubG3-x+7purulubH3-x+"
+    "7s23l60urulubC3-x+3nurulubC2-x+2urulB2-A1",
+    "l50x+1ulzpA1-x+3ulzpB1-x+5s23l60zpurulubC1-x+10urulzpubD3-x+9urulubE3-x+9s23l60urulubF3-x+9urulubG3-x+9purulubH3-"
+    "x+9s23l60urulubC3-x+5nurulubC2-x+3urulB2-A1",
+    "l50x+1ulzpA1-x+4ulzpB1-x+6s23l60zpurulubC1-x+13urulzpubD3-x+12urulubE3-x+12s23l60urulubF3-x+12urulubG3-x+"
+    "12purulubH3-x+12s23l60urulubC3-x+6nurulubC2-x+3urulB2-A1",
     "sp13s1l20sf0A1-B4-A3",
     "A1-sp7sf10l20s5B1-C2-cpD2-jmnC2-jmnB1-jmnA1",
     "A1-sp7sf10l20s5B1-C3-cpD3-jmnC3-jmnB1-jmnA1",
@@ -579,17 +619,23 @@ const char* test_strings[] = {
     "A1-sp7sf10l20s5B1-C1-cpD1-jmnC1-jmnB1-jmnA0",
     "A1-sp7sf10l20s5B1-C1-cpD1-jmnC1-jmnB1-jmnA1",
     "A0-sp7sf10l20s5B1-C1-cpD1-jmnC1-jmnB0-jmnA0",
-    "uO27-ey-24uox-10N6-ey-46uox-13N3-ey-75uox-15N1-uox-15vy-30N1-uox-15boN27-gy-482bobpN1-buboN1-hboZ20-bofbpN28-ey-75x-15um12mi5ma270mx-20s28sp12l45X1-hm12mi5ma270mx+50my-16usw30X1-hbpp64uX1-hmx-30my+4m56uX1-hmx+30my-2m56uX1-hoX4000",
-    "bm10amebewA1-bebxwA3-bewB3-usbewC20-uabewD6-uabewE3-uabewF33-uabewG4-uabewH2-bm10amebewH1-uabewbxH31-uabewI2-uabewJ4-uabewK7-uabewjf2K30-uawK1000",
-    "ey-75x-15X10-ex-15y-50X3-ex-15y-30N2-ex-15y-30s29sp20l63N1-ey-5uox-15m55mn60mx-30my+1b2N1-euox-15m55mn60mx+30my+4sw45N1-ebpp64m12mi40uox-15N1-Z4000",
+    "uO27-ey-24uox-10N6-ey-46uox-13N3-ey-75uox-15N1-uox-15vy-30N1-uox-15boN27-gy-482bobpN1-buboN1-hboZ20-bofbpN28-ey-"
+    "75x-15um12mi5ma270mx-20s28sp12l45X1-hm12mi5ma270mx+50my-16usw30X1-hbpp64uX1-hmx-30my+4m56uX1-hmx+30my-2m56uX1-"
+    "hoX4000",
+    "bm10amebewA1-bebxwA3-bewB3-usbewC20-uabewD6-uabewE3-uabewF33-uabewG4-uabewH2-bm10amebewH1-uabewbxH31-uabewI2-"
+    "uabewJ4-uabewK7-uabewjf2K30-uawK1000",
+    "ey-75x-15X10-ex-15y-50X3-ex-15y-30N2-ex-15y-30s29sp20l63N1-ey-5uox-15m55mn60mx-30my+1b2N1-euox-15m55mn60mx+30my+"
+    "4sw45N1-ebpp64m12mi40uox-15N1-Z4000",
     "uabewK10-uabewL3-usuabewM3-uabewusjn38N40",
     "sp13s1l20sf0A1-B4-A3",
     "beA4-vy-10bubeb1B1-beB3-beaxC4-beaxD40-axZ200-d100axZ10",
     "vx-4y-7s1l60A1-s25l50sp12bl8B1-C1-L4-M500",
     "acx+30hA1-hzpA2-hizpB2-vx+8y+6izpcpC2-vx+8y+5izpcpD2-vx+8y+5izpcpE6-vx+10y+3izpcpF6-vx+11izpcpG6",
     "acx+30hA1-hzpA2-hizpB2-vx+8y+6izpcpC2-vx+8y+5izpjn15cpD2-vx+8y+5izpjn15cpE6-vx+10y+3izpjn15cpF6-vx+11izpjn15cpG6",
-    "acx+30hA1-hzpA2-hizpB2-vx+10y+6izpcpC2-vx+10y+5izpcpjn15D2-vx+10y+5izpcpjn15E6-vx+12y+3izpcpjn15F6-vx+14izpcpjn15G6",
-    "acx+30hA1-hzpA2-hizpB2-vx+12y+6izpcpC2-vx+12y+5izpcpjn15D2-vx+12y+5izpcpjn15E6-vx+14y+3izpcpjn15F6-vx+17izpcpjn15G6",
+    "acx+30hA1-hzpA2-hizpB2-vx+10y+6izpcpC2-vx+10y+5izpcpjn15D2-vx+10y+5izpcpjn15E6-vx+12y+3izpcpjn15F6-vx+"
+    "14izpcpjn15G6",
+    "acx+30hA1-hzpA2-hizpB2-vx+12y+6izpcpC2-vx+12y+5izpcpjn15D2-vx+12y+5izpcpjn15E6-vx+14y+3izpcpjn15F6-vx+"
+    "17izpcpjn15G6",
     "hnA3-nA2-nB3",
     "sp13s2l33sf-6D1-E1-F4-E3-D2",
     "l40A2-sp7sf-3l33s5B2-C3-cpD4-jmnC3-jmnB3-jmnA2",
@@ -642,9 +688,11 @@ const char* test_strings[] = {
     "vx-4y-7s1l60A1-s25l50sp12bl8B1-C1-L4-M500",
     "A1",
     "x+30hA1-hzpA2-hizpB2-vx+12y+6izpcpC2-vx+12y+5izpcpjn15D2-vx+12y+5izpcpjn15E6-vx+14y+3izpcpjn15F6-vx+17izpcpjn15G6",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A100-B40-C40-D40-C40-B40-A100",
     "A5-jn17B4-jgjn17C3",
     "A6-B6-C6-B6",
@@ -672,9 +720,12 @@ const char* test_strings[] = {
     "sp7sf10l20s5A0-B1-cpC2-jljmnB1-jljmnA1",
     "sp7sf10l20s5A0-B1-cpC1-jljmnB1-jljmnA1",
     "s01l40A1-B1-C5-B4-A3",
-    "aiA4-hy-1aicpB3-hy-2ais21l50C2-hy-2aiD2-hy-1aiq2cpE2-hy-2aiF1-hy-1aicpB1-hy-1aiC1-hy-1aiD1-hy-1q3cpaiE1-hy-1aiF1-hy-1aicpB1-hy+1aiC1-hy+1aiD1-hy+1nE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
-    "A4-hy-1cpB3-hy-2s21l50C2-hy-2D2-hy-1q2cpaiE2-hy-2aiF1-hy-1aicpB1-hy-1aiC1-hy-1aiD1-hy-1q3cpaiE1-hy-1aiF1-hy-1aicpB1-hy+1aiC1-hy+1aiD1-hy+1nE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
-    "A4-hy-1cpB3-hy-2s21l50C2-hy-2D2-hy-1q2cpE2-hy-2F1-hy-1cpB1-hy-1C1-hy-1D1-hy-1q3cpaiE1-hy-1aiF1-hy-1aicpB1-hy+1aiC1-hy+1aiD1-hy+1nE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
+    "aiA4-hy-1aicpB3-hy-2ais21l50C2-hy-2aiD2-hy-1aiq2cpE2-hy-2aiF1-hy-1aicpB1-hy-1aiC1-hy-1aiD1-hy-1q3cpaiE1-hy-1aiF1-"
+    "hy-1aicpB1-hy+1aiC1-hy+1aiD1-hy+1nE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
+    "A4-hy-1cpB3-hy-2s21l50C2-hy-2D2-hy-1q2cpaiE2-hy-2aiF1-hy-1aicpB1-hy-1aiC1-hy-1aiD1-hy-1q3cpaiE1-hy-1aiF1-hy-"
+    "1aicpB1-hy+1aiC1-hy+1aiD1-hy+1nE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
+    "A4-hy-1cpB3-hy-2s21l50C2-hy-2D2-hy-1q2cpE2-hy-2F1-hy-1cpB1-hy-1C1-hy-1D1-hy-1q3cpaiE1-hy-1aiF1-hy-1aicpB1-hy+"
+    "1aiC1-hy+1aiD1-hy+1nE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
     "pd240pp30ptp3ptd1ptr20sp13s3l20sf0D1-E4-D3",
     "A1-sp7sf10l20s5B2-cpC3-jlnB3-jlnA2",
     "A1-sp7sf10l20s5B3-cpC4-jlnB4-jlnA2",
@@ -716,7 +767,8 @@ const char* test_strings[] = {
     "sp7sf-3l33s5A1-B2-cpC2-jhnB1-jhnA1",
     "sp7sf-3l33s5A1-B1-cpC1-jhnB1-jhnA1",
     "vx-4y-5s02l45bl7A1-B2-C2-L5-M400",
-    "A4-hy-1s21l50B3-hy-2C2-hy-2D2-hy-1cpE2-hy-2F1-hy-1cpB1-hy-1C1-hy-1D1-hy-1cpE1-hy-1F1-hy-1cpB1-hy+1C1-hy+1D1-hy+1cpE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
+    "A4-hy-1s21l50B3-hy-2C2-hy-2D2-hy-1cpE2-hy-2F1-hy-1cpB1-hy-1C1-hy-1D1-hy-1cpE1-hy-1F1-hy-1cpB1-hy+1C1-hy+1D1-hy+"
+    "1cpE1-hy+1nF1-hy+1nB1-hy+1nC2-nD2-nE2-nF3-nA4",
     "A1",
     "vx-6y-7s1l60bl5A1-B2-C2-L5-M100",
     "x+2hA2-x+4hcs21l50B2-x+6hcpC13-x+4hnB3-x+2nA2-nA2",
@@ -782,14 +834,22 @@ const char* test_strings[] = {
     "beclC6-beclB4-beclA40",
     "uO1-ex-45usO3-wex-60R3-S3-S30",
     "bm10amebewx+40A1-uabebxA3-uabewB3-uabewC15-beuaD3-beuabj37D3",
-    "S4-pd240pp25ptp10ptd25ptr35A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-S8-boR5-boO1000",
-    "uabenusA4-hy-1benB2-hy-1benC1-hbenC1-hbenD3-hbenE3-hy+1benF3-hy-1benB3-hy-1benC1-hbenC2-hbenD3-hbenE3-hy+1jn38benF3-jn38benB3-nC2-nD2-nE2-nF3-A40",
-    "A1-ma330mi2m12my-58mx+2pd240pp40pb25ptp10ptd24ptr45s1l45B1-C3-B1-A1-ma330mi2m12my-58mx+2s1l45B1-C3-B1-A1-ma330mi2m12my-58mx+2s1l45B1-C3-B1-A1-ma330mi2m12my-58mx+2s1l45B1-C3-B1-A2-S8-boR5-boO1000",
-    "hy-1benuaB3-hy-1benuaC2-hbenuaD3-hy+1benuaE2-hy+1benuaF2-hy-1benB3-hy-1benC2-hbenD3-hy+1benE2-hy+1jn39benF2-jn39benB2-usnC2-nD2-nE2-nF3-clA40",
-    "A1-ma330mi2m12my-58mx+2pd240pp55ptp8ptd24ptr55pb40s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-mp10m57my-60wsw50C1-mi25m12my-60wC1-wT20-boU5-boV3-boW4000",
-    "hy-1benuausB2-hy-1benuaC1-hbenuaD2-hbenuaE1-hy+1benuaF2-hy-1benuaB2-hy-1benuaC1-hbenuaD2-hbenuaE1-hy+1benuaF2-hy-1benuaB2-hy-1benuaC1-hbenuaD2-hbenuaE1-hy+1benuaF2-uabenjn40B2-uanjn40C2-nuajn40D2-nuajn40E2-nuajn40F3-A40",
+    "S4-pd240pp25ptp10ptd25ptr35A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-"
+    "ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-ma330mi2m12my-58mx+2s1l30B1-C3-B2-A1-S8-boR5-boO1000",
+    "uabenusA4-hy-1benB2-hy-1benC1-hbenC1-hbenD3-hbenE3-hy+1benF3-hy-1benB3-hy-1benC1-hbenC2-hbenD3-hbenE3-hy+"
+    "1jn38benF3-jn38benB3-nC2-nD2-nE2-nF3-A40",
+    "A1-ma330mi2m12my-58mx+2pd240pp40pb25ptp10ptd24ptr45s1l45B1-C3-B1-A1-ma330mi2m12my-58mx+2s1l45B1-C3-B1-A1-"
+    "ma330mi2m12my-58mx+2s1l45B1-C3-B1-A1-ma330mi2m12my-58mx+2s1l45B1-C3-B1-A2-S8-boR5-boO1000",
+    "hy-1benuaB3-hy-1benuaC2-hbenuaD3-hy+1benuaE2-hy+1benuaF2-hy-1benB3-hy-1benC2-hbenD3-hy+1benE2-hy+1jn39benF2-"
+    "jn39benB2-usnC2-nD2-nE2-nF3-clA40",
+    "A1-ma330mi2m12my-58mx+2pd240pp55ptp8ptd24ptr55pb40s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-"
+    "58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+2s1l60A1-C2-B1-ma330mi2m12my-58mx+"
+    "2s1l60A1-C2-mp10m57my-60wsw50C1-mi25m12my-60wC1-wT20-boU5-boV3-boW4000",
+    "hy-1benuausB2-hy-1benuaC1-hbenuaD2-hbenuaE1-hy+1benuaF2-hy-1benuaB2-hy-1benuaC1-hbenuaD2-hbenuaE1-hy+1benuaF2-hy-"
+    "1benuaB2-hy-1benuaC1-hbenuaD2-hbenuaE1-hy+1benuaF2-uabenjn40B2-uanjn40C2-nuajn40D2-nuajn40E2-nuajn40F3-A40",
     "boW4000",
-    "behy-4A2-behy-6A2-behy-8A2-behy-10A2-behy-12A2-behy-14A2-behy-16A2-behy-18A2-behy-20A2-gy-420behbuZ3-axy+20behuafA14-axy+20behm55my+146mx-14b1uafA1-axy+20behm55mx+15my+130b1b2uafs28l60A1-axy+20behuafA10-uaZ2000",
+    "behy-4A2-behy-6A2-behy-8A2-behy-10A2-behy-12A2-behy-14A2-behy-16A2-behy-18A2-behy-20A2-gy-420behbuZ3-axy+"
+    "20behuafA14-axy+20behm55my+146mx-14b1uafA1-axy+20behm55mx+15my+130b1b2uafs28l60A1-axy+20behuafA10-uaZ2000",
     "pd240pp40ptp6ptd1ptr30sp13s2l30sf-5D1-E1-F3-E3-D2",
     "A3-sp7sf0l30s5B4-cpC4-nB4-njmA3",
     "A4-sp7sf0l30s5B5-cpC5-nB5-njmA4",
@@ -830,9 +890,11 @@ const char* test_strings[] = {
     "beA4-hy-1s27l60sp12bejfB4-hy-2jfB5-hy-3jfB4-hy-2jfC4-hy-1jfC4-hy+1jfC4-hy+2jfC4-hy+1jfC4-hy-1jfC4-d16hjfC400",
     "sp13s1l20sf0A1-B4-A3",
     "A3000",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A120-B20-C10-D10-E10-F10-G10-rfE10-rfF10-rfG10-rfH10-D10-C10-B20-A120",
     "A5-jn35B4-jn35jgC4",
     "A6-B6-C6-B6",
@@ -909,11 +971,17 @@ const char* test_strings[] = {
     "A0-sp7sf-22l52s5B1-C1-cpD1-cpE1-cpF1-G1",
     "A1-B2-C2-mx+36my-48mp15mn40m33D1-D4-F4-D3-mm22mu13E2-jhC1-jhB1-jhA1",
     "A1-B2-C2-mx+36my-48mp15mn40m33D1-D4-F4-mx+36my-48mp15mn40m33D1-D4-F4-D3-mm22mu13E2-jhC1-jhB1-jhA1",
-    "A1-B2-C2-mx+36my-48mp15mn40m33D1-D4-F4-mx+36my-48mp15mn40m33D1-D4-F4-mx+36my-48mp15mn40m33D1-D4-F4-D3-mm22mu13E2-jhC1-jhB1-jhA1",
+    "A1-B2-C2-mx+36my-48mp15mn40m33D1-D4-F4-mx+36my-48mp15mn40m33D1-D4-F4-mx+36my-48mp15mn40m33D1-D4-F4-D3-mm22mu13E2-"
+    "jhC1-jhB1-jhA1",
     "s01l40A1-C3-B2-A1",
-    "A1-mx-20my-75mp15mn40m38jn35D1-jn35B3-mx+36my-38mp15mn40m38jn35B1-jn35C3-mx+10my-54mp15mn40m38jn35C1-jn35D3-mx-20my-75mp15mn40m38jn35D1-jn35B3-mx+36my-38mp15mn40m38jn35B1-jn35C3-mx+10my-54mp15mn40m38jn35C1-jn35B4-jn35A8",
-    "A1-mx-20my-75mp15mn40m38jn35D1-jn35B2-mx+36my-38mp15mn40m38jn35B1-jn35C2-mx+10my-54mp15mn40m38jn35C1-jn35D2-mx-20my-75mp15mn40m38jn35D1-jn35B2-mx+36my-38mp15mn40m38jn35B1-jn35C2-mx-20my-75mp15mn40m38jn35D1-jn35B2-mx+36my-38mp15mn40m38jn35B1-mx+10my-54mp15mn40m38jn35C1-jn35B4-jn35A8",
-    "A1-mx-20my-75mp15mn40m38jn35D1-jn35B1-mx+36my-38mp15mn40m38jn35B1-jn35C1-mx+10my-54mp15mn40m38jn35C1-jn35D1-mx-20my-75mp15mn40m38jn35D1-jn35B1-mx+36my-38mp15mn40m38jn35B1-jn35C1-mx+10my-54mp15mn40m38jn35C1-jn35D1-mx-20my-75mp15mn40m38jn35D1-jn35B1-mx+36my-38mp15mn40m38jn35B1-jn35C1-mx+10my-54mp15mn40m38jn35C1-jn35B4-jn35A8",
+    "A1-mx-20my-75mp15mn40m38jn35D1-jn35B3-mx+36my-38mp15mn40m38jn35B1-jn35C3-mx+10my-54mp15mn40m38jn35C1-jn35D3-mx-"
+    "20my-75mp15mn40m38jn35D1-jn35B3-mx+36my-38mp15mn40m38jn35B1-jn35C3-mx+10my-54mp15mn40m38jn35C1-jn35B4-jn35A8",
+    "A1-mx-20my-75mp15mn40m38jn35D1-jn35B2-mx+36my-38mp15mn40m38jn35B1-jn35C2-mx+10my-54mp15mn40m38jn35C1-jn35D2-mx-"
+    "20my-75mp15mn40m38jn35D1-jn35B2-mx+36my-38mp15mn40m38jn35B1-jn35C2-mx-20my-75mp15mn40m38jn35D1-jn35B2-mx+36my-"
+    "38mp15mn40m38jn35B1-mx+10my-54mp15mn40m38jn35C1-jn35B4-jn35A8",
+    "A1-mx-20my-75mp15mn40m38jn35D1-jn35B1-mx+36my-38mp15mn40m38jn35B1-jn35C1-mx+10my-54mp15mn40m38jn35C1-jn35D1-mx-"
+    "20my-75mp15mn40m38jn35D1-jn35B1-mx+36my-38mp15mn40m38jn35B1-jn35C1-mx+10my-54mp15mn40m38jn35C1-jn35D1-mx-20my-"
+    "75mp15mn40m38jn35D1-jn35B1-mx+36my-38mp15mn40m38jn35B1-jn35C1-mx+10my-54mp15mn40m38jn35C1-jn35B4-jn35A8",
     "vx-4y-6D1-s2l40bl3E2-F2-L5-M500",
     "nvx+6y-5sp7sf0l30s5A2-vx+5y-4A1-vx+3y-2B2-vx+3cpB1-nvx+2y+1cpB1-nvx+2y+2cpB1-vx+1y+2ncpB1-nA3-gA3",
     "nvx+6y-5sp7sf0l30s5A3-vx+5y-4A1-vx+3y-2B3-vx+3cpB1-nvx+2y+1cpB1-nvx+2y+2cpB1-vx+1y+2ncpB1-nA4-gA4",
@@ -950,14 +1018,26 @@ const char* test_strings[] = {
     "A1-B1-sp7sf-15l45s5C2-cpD2-nC2-jhnB1-jhnA1",
     "A1-B1-sp7sf-15l45s5C2-cpD2-nC1-jhnB1-jhnA1",
     "A1-B1-sp7sf-15l45s5C1-cpD1-nC1-jhnB1-jhnA1",
-    "O9-ex-20N5-m12ma250mi2mx-30my-3s28l35N1-m56mx-30my-3N1-M3-bzbpp39bpd231bpfO4-M6-m12ma290mi3mx+24my+3M1-bzbpp32bpd231bpfO4-M3-m12ma270mi2mx+4my+0s28l25M1-m56mx+4my+0M1-bzbpp21bpb63bpd231bpfN6-O4-bzbpp83bpb20bpd231bpfM7-O4-m12ma260mi4mx-15my-7O1-bzbpp28bpd231bpfN8-M3-m12ma280mi3mx+15my-10s28l40M1-m56mx+15my-10M1-bzbpp76bpd231bpfO6-M2-bzbpp60bpd231bpfO5-m12ma270mi2mx+25my-1O1-bzbpp12bpd231bpfM4-N6-bzbpp22bpd231bpfO3-m12ma250mi4mx-25my-11s28l45O1-m56mx-25my-11O1-bpp0bpd0bpfM4-O1000",
-    "bm10amex+20bewA1-bebxwA8-usuabewB5-uabewC3-uabewB4-uabewjf2D7-uabewjf2C4-uabewjf2D6-uabewjf2B3-uabewjf2C4-uabewjf2B6-uabewjf2D4-uabewjf2C5-uabewjf2B4-uabewjf2D7-uabewjf2C4-uabewjf2D6-uabewjf2B3-uabewjf2C4-uabewjf2B6-uabewjf2D4-uabewjf2C5-uabewjf2B4-uabewjf2D6-uabewjf2B3-uabewjf2C4",
+    "O9-ex-20N5-m12ma250mi2mx-30my-3s28l35N1-m56mx-30my-3N1-M3-bzbpp39bpd231bpfO4-M6-m12ma290mi3mx+24my+3M1-"
+    "bzbpp32bpd231bpfO4-M3-m12ma270mi2mx+4my+0s28l25M1-m56mx+4my+0M1-bzbpp21bpb63bpd231bpfN6-O4-"
+    "bzbpp83bpb20bpd231bpfM7-O4-m12ma260mi4mx-15my-7O1-bzbpp28bpd231bpfN8-M3-m12ma280mi3mx+15my-10s28l40M1-m56mx+15my-"
+    "10M1-bzbpp76bpd231bpfO6-M2-bzbpp60bpd231bpfO5-m12ma270mi2mx+25my-1O1-bzbpp12bpd231bpfM4-N6-bzbpp22bpd231bpfO3-"
+    "m12ma250mi4mx-25my-11s28l45O1-m56mx-25my-11O1-bpp0bpd0bpfM4-O1000",
+    "bm10amex+20bewA1-bebxwA8-usuabewB5-uabewC3-uabewB4-uabewjf2D7-uabewjf2C4-uabewjf2D6-uabewjf2B3-uabewjf2C4-"
+    "uabewjf2B6-uabewjf2D4-uabewjf2C5-uabewjf2B4-uabewjf2D7-uabewjf2C4-uabewjf2D6-uabewjf2B3-uabewjf2C4-uabewjf2B6-"
+    "uabewjf2D4-uabewjf2C5-uabewjf2B4-uabewjf2D6-uabewjf2B3-uabewjf2C4",
     "O36-m55mx-19my-3N1-N1-M3-N2-O4-m55mx+44my+3N1-N1-M3-N2-O17-s29l63sp15m55mx+10sw40N1-m12mi30M1-Z1000",
-    "beE2-uabeF2-uabebzbpp20bpb0bpd231bpfG3-uabebzbpp50bpb20bpd231bpfH3-usuabebzbpp90bpb50bpd231bpfI4-uabebzbps96bpn159bpp70bpb0bpd231s24l70sb0se15sp28boJ5-uabebzbps96bpn159bpp0bpb70bpd231boJ5-uabebps96bpn159bpp0bpd0boJ1-uabebzbpp0bpb90bpd231bpfK10-uam29beK1-uabebpp0bpd0bpfK10-uabeA20-jn30uabeA40",
+    "beE2-uabeF2-uabebzbpp20bpb0bpd231bpfG3-uabebzbpp50bpb20bpd231bpfH3-usuabebzbpp90bpb50bpd231bpfI4-"
+    "uabebzbps96bpn159bpp70bpb0bpd231s24l70sb0se15sp28boJ5-uabebzbps96bpn159bpp0bpb70bpd231boJ5-"
+    "uabebps96bpn159bpp0bpd0boJ1-uabebzbpp0bpb90bpd231bpfK10-uam29beK1-uabebpp0bpd0bpfK10-uabeA20-jn30uabeA40",
     "sp13s1l20sf0A1-B4-A3",
-    "eZ1-ebzbpp50bpb0bpd231bps1bpn250ox+19s24l30sp29rA3-bzbpp0bpb50bpd231bps1bpn250Z3-Z5-bzbpp70bpb0bpd231bps1bpn250ox-44s24l40sp30A3-bzbpp0bpb70bpd231bps1bpn250Z3-Z14-bpp63bpb0bpd231bps1bpn250s24l63sp40ox-10B6-bpp0bpb63bpd231bps1bpn250Z6-bpp0bpd0bps1bpn250Z2",
+    "eZ1-ebzbpp50bpb0bpd231bps1bpn250ox+19s24l30sp29rA3-bzbpp0bpb50bpd231bps1bpn250Z3-Z5-bzbpp70bpb0bpd231bps1bpn250ox-"
+    "44s24l40sp30A3-bzbpp0bpb70bpd231bps1bpn250Z3-Z14-bpp63bpb0bpd231bps1bpn250s24l63sp40ox-10B6-"
+    "bpp0bpb63bpd231bps1bpn250Z6-bpp0bpd0bps1bpn250Z2",
     "Z60-buZ6-m55mx-09my-3Z1-Z1-Z3-Z2-Z4-m55mx+54my+3Z1-Z1-Z3-Z2-Z17-m55mx+20b2Z1-Z1000",
-    "beE16-uabeF6-uabebzbpp20bpb0bpd231bpfG7-uabebzbpp50bpb20bpd231bpfH7-usuabebzbpp90bpb50bpd231bpfI8-uabebzbps96bpn159bpp70bpb0bpd231s24l70sb0se15sp28boJ5-uabebzbps96bpn159bpp0bpb70bpd231boJ5-uabebps96bpn159bpp0bpd0boJ1-uabebzbpp0bpb90bpd231bpfK10-uam29beK1-uabebpp0bpd0bpfK10-uabeA40-uabebj50A10",
+    "beE16-uabeF6-uabebzbpp20bpb0bpd231bpfG7-uabebzbpp50bpb20bpd231bpfH7-usuabebzbpp90bpb50bpd231bpfI8-"
+    "uabebzbps96bpn159bpp70bpb0bpd231s24l70sb0se15sp28boJ5-uabebzbps96bpn159bpp0bpb70bpd231boJ5-"
+    "uabebps96bpn159bpp0bpd0boJ1-uabebzbpp0bpb90bpd231bpfK10-uam29beK1-uabebpp0bpd0bpfK10-uabeA40-uabebj50A10",
     "sp13s2l45bl3sf-12D1-E1-F5-E3-D2",
     "A1-sp7sf-15l45s5B2-C2-cpD3-nC3-jlnB2-jlnA1",
     "A1-sp7sf-15l45s5B3-C3-cpD4-nC4-jlnB2-jlnA1",
@@ -973,26 +1053,40 @@ const char* test_strings[] = {
     "sp13s2l20sf0D1-E4-D3",
     "abA3-fA1-B1-fB1-C1-fC1",
     "s02l50A1-B1-C4-B3-A3",
-    "vx+8y-2uncx+2cy+2q1A4-vx+6s20l50bwuncx+2cy+2q1B4-vx+4y+2uncx+2cy+2q1C4-vx+6s20l50uncx+2cy+2q1D4-vx+6y-2uncx+2cy+2q1A4-vx+6s20l50uncx+2cy+2q1B4-vx+4y+2uncx+2cy+2q1C4-vx+6s20l50uncx+2cy+2q1D4-vx+8y-2uncx+2cy+2q1A4-vx+6s20l50uncx+2cy+2q1B4-vx+4y+2uncx+2cy+2q1C4",
-    "vx+8y-2unA4-vx+6s20l50bwunq1B4-vx+4y+2unq1C4-vx+6s20l50unq1D4-vx+8y-2unq1A4-vx+6s20l50unq1B4-vx+4y+2unq1C4-vx+6s20l50unq1D4-vx+8y-2unq1A4-vx+6s20l50unq1B4-vx+4y+2unq1C4",
+    "vx+8y-2uncx+2cy+2q1A4-vx+6s20l50bwuncx+2cy+2q1B4-vx+4y+2uncx+2cy+2q1C4-vx+6s20l50uncx+2cy+2q1D4-vx+6y-2uncx+2cy+"
+    "2q1A4-vx+6s20l50uncx+2cy+2q1B4-vx+4y+2uncx+2cy+2q1C4-vx+6s20l50uncx+2cy+2q1D4-vx+8y-2uncx+2cy+2q1A4-vx+"
+    "6s20l50uncx+2cy+2q1B4-vx+4y+2uncx+2cy+2q1C4",
+    "vx+8y-2unA4-vx+6s20l50bwunq1B4-vx+4y+2unq1C4-vx+6s20l50unq1D4-vx+8y-2unq1A4-vx+6s20l50unq1B4-vx+4y+2unq1C4-vx+"
+    "6s20l50unq1D4-vx+8y-2unq1A4-vx+6s20l50unq1B4-vx+4y+2unq1C4",
     "vy-8x-8bl7A1-s2l63B2-C3-L5-M300",
-    "zpA1-iawugzpubB2-iawugzpubC1-x+11iawugzpubD1-s12x+11iawugzpubD1-x+11iawugzpubE2-x+11iawugzpubF1-s12x+11iawugubF1-x+11iawugubG2-x+11iawugubD1-s12x+11iawugubD1-x+11iawugubE2-x+11iawugubF1-s12x+11iawugubF1-x+11iawugubG2-ugubC1-B1-A1",
-    "zpA1-iawugzpubB2-iawugzpubC1-x+13iawugzpubD1-s12x+13iawugzpubD1-x+13iawugzpubE2-x+13iawugzpubF1-s12x+13iawugubF1-x+13iawugubG2-x+13iawugubD1-s12x+13iawugubD1-x+13iawugubE2-x+13iawugubF1-s12x+13iawugubF1-x+13iawugubG2-ugubC1-B1-A1",
-    "zpA1-iawugzpubB2-iawugzpubC1-x+15iawugzpubD1-s12x+15iawugzpubD1-x+15iawugzpubE2-x+15iawugzpubF1-s12x+15iawugubF1-x+15iawugubG2-x+15iawugubD1-s12x+15iawugubD1-x+15iawugubE2-x+15iawugubF1-s12x+15iawugubF1-x+15iawugubG2-ugubC1-B1-A1",
+    "zpA1-iawugzpubB2-iawugzpubC1-x+11iawugzpubD1-s12x+11iawugzpubD1-x+11iawugzpubE2-x+11iawugzpubF1-s12x+11iawugubF1-"
+    "x+11iawugubG2-x+11iawugubD1-s12x+11iawugubD1-x+11iawugubE2-x+11iawugubF1-s12x+11iawugubF1-x+11iawugubG2-ugubC1-B1-"
+    "A1",
+    "zpA1-iawugzpubB2-iawugzpubC1-x+13iawugzpubD1-s12x+13iawugzpubD1-x+13iawugzpubE2-x+13iawugzpubF1-s12x+13iawugubF1-"
+    "x+13iawugubG2-x+13iawugubD1-s12x+13iawugubD1-x+13iawugubE2-x+13iawugubF1-s12x+13iawugubF1-x+13iawugubG2-ugubC1-B1-"
+    "A1",
+    "zpA1-iawugzpubB2-iawugzpubC1-x+15iawugzpubD1-s12x+15iawugzpubD1-x+15iawugzpubE2-x+15iawugzpubF1-s12x+15iawugubF1-"
+    "x+15iawugubG2-x+15iawugubD1-s12x+15iawugubD1-x+15iawugubE2-x+15iawugubF1-s12x+15iawugubF1-x+15iawugubG2-ugubC1-B1-"
+    "A1",
     "s2l50bl7A1-B1-C4-B3-A2",
-    "A1-iawugB2-iawugC1-x+7iawugD1-s12x+7iawugD1-x+7iawugE2-x+7iawugF1-s12x+7iawugF1-x+7iawugG2-x+7iawugD1-s12x+7iawugD1-x+7iawugE2-x+7iawugF1-s12x+7iawugF1-x+7iawugG2-ugC1-B1-A1",
-    "A1-iawugB2-iawugC1-x+8iawugD1-s12x+8iawugD1-x+8iawugE2-x+8iawugF1-s12x+8iawugF1-x+8iawugG2-x+8iawugD1-s12x+8iawugD1-x+8iawugE2-x+8iawugF1-s12x+8iawugF1-x+8iawugG2-ugC1-B1-A1",
-    "A1-iawugB2-iawugC1-x+9iawugD1-s12x+9iawugD1-x+9iawugE2-x+9iawugF1-s12x+9iawugF1-x+9iawugG2-x+9iawugD1-s12x+9iawugD1-x+9iawugE2-x+9iawugF1-s12x+9iawugF1-x+9iawugG2-ugC1-B1-A1",
+    "A1-iawugB2-iawugC1-x+7iawugD1-s12x+7iawugD1-x+7iawugE2-x+7iawugF1-s12x+7iawugF1-x+7iawugG2-x+7iawugD1-s12x+"
+    "7iawugD1-x+7iawugE2-x+7iawugF1-s12x+7iawugF1-x+7iawugG2-ugC1-B1-A1",
+    "A1-iawugB2-iawugC1-x+8iawugD1-s12x+8iawugD1-x+8iawugE2-x+8iawugF1-s12x+8iawugF1-x+8iawugG2-x+8iawugD1-s12x+"
+    "8iawugD1-x+8iawugE2-x+8iawugF1-s12x+8iawugF1-x+8iawugG2-ugC1-B1-A1",
+    "A1-iawugB2-iawugC1-x+9iawugD1-s12x+9iawugD1-x+9iawugE2-x+9iawugF1-s12x+9iawugF1-x+9iawugG2-x+9iawugD1-s12x+"
+    "9iawugD1-x+9iawugE2-x+9iawugF1-s12x+9iawugF1-x+9iawugG2-ugC1-B1-A1",
     "ncpD1-vx-4y-10ncpD2-nE2-nF2-nG2-nD2-nE2-nF2-nG2-nD2-nE2-nF2-nG2-nD2-nE2-nF2-nG2-nD2-nE2-nF2-nG2-nD2-nE2-nF2-nG2",
     "s2l50bl7A1-B1-C5-B3-A2",
-    "A1-hB2-hC1-hx+8iawD1-hs12x+8iawD1-hx+8iawE2-hx+8iawF1-hs12x+8iawF1-hx+8iG2-hx+8iawD1-hs12x+8iawD1-hx+8iawE2-hx+8iawF1-hs12x+8iawF1-hx+8iawG2-C1-B1-A1",
+    "A1-hB2-hC1-hx+8iawD1-hs12x+8iawD1-hx+8iawE2-hx+8iawF1-hs12x+8iawF1-hx+8iG2-hx+8iawD1-hs12x+8iawD1-hx+8iawE2-hx+"
+    "8iawF1-hs12x+8iawF1-hx+8iawG2-C1-B1-A1",
     "A1",
     "s03l30s23l20A1-B1-C3-B2-A1",
     "vx+7y+1bws23l20A3-B3-C3-D3",
     "vx+8y+1bws23l20A4-B3-C3-D3",
     "vx+9y+1bws23l20A4-B4-C4-D3",
     "nD3",
-    "ncpubD1-vx-5y-14ncpubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nG2",
+    "ncpubD1-vx-5y-14ncpubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-"
+    "nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nubG2-nubD2-nubE2-nubF2-nG2",
     "sp13s2l21sf0D1-E3-F3-D2",
     "sp7sf9l21s5A2-cpB1-cpjn23B2-q2jn23C2-q2cpD4-nC1-njlC1-njlB2-njlA2",
     "sp7sf9l21s5A3-cpB1-cpjn23B3-q2jn23C3-q2cpD5-nC1-njlC1-njlB3-njlA2",
@@ -1040,15 +1134,21 @@ const char* test_strings[] = {
     "A0-sp7sf-7l37s5B1-cpC1-cpD9-nC1-nB1-nA0",
     "A0-sp7sf-7l37s5B0-cpC1-cpD10-nC1-nB0-nA0",
     "sp13s1l20sf0A1-B4-A3",
-    "bewA3-s27l60bewB3-wC4-wD5-wE5-s21l50jfwF3-jfwG5-jfwE3-s21l45jfwF6-jfwE4-jfwG5-jfwF3-s21l58jfwE6-jfwG4-jfwE5-jfwD5-s21l42jfwE5-jfwF3-jfwG5-jfwE3-s21l39jfwF6-jfwE4-jfwG5-jfwF3-s21l45jfwE6-jfwG4-jfwE5-jfwD5-s21l64jfwE5-jfwF3-jfwG5-jfwE3-s21l30jfwF6-jfwE4-jfwG5-jfwF3-jfwE6-s21l54jfwG4-jfwE5-d10jfwD5",
+    "bewA3-s27l60bewB3-wC4-wD5-wE5-s21l50jfwF3-jfwG5-jfwE3-s21l45jfwF6-jfwE4-jfwG5-jfwF3-s21l58jfwE6-jfwG4-jfwE5-jfwD5-"
+    "s21l42jfwE5-jfwF3-jfwG5-jfwE3-s21l39jfwF6-jfwE4-jfwG5-jfwF3-s21l45jfwE6-jfwG4-jfwE5-jfwD5-s21l64jfwE5-jfwF3-jfwG5-"
+    "jfwE3-s21l30jfwF6-jfwE4-jfwG5-jfwF3-jfwE6-s21l54jfwG4-jfwE5-d10jfwD5",
     "sp13s1l20sf0A1-B4-A3",
-    "A3-C3-B2-s21l50E3-B4-A3-C5-s21l57E2-D4-B2-D4-A3-s21l44C3-B2-E3-B4-s21l48A3-C5-E2-D4-B2-s21l31D4-A3-C3-B2-E3-s21l61B4-A3-C5-s21l45E2-D4-B2-d1D4",
+    "A3-C3-B2-s21l50E3-B4-A3-C5-s21l57E2-D4-B2-D4-A3-s21l44C3-B2-E3-B4-s21l48A3-C5-E2-D4-B2-s21l31D4-A3-C3-B2-E3-"
+    "s21l61B4-A3-C5-s21l45E2-D4-B2-d1D4",
     "sp13s1l20sf0A1-B4-A3",
     "beA4-vy-10bubeb1B1-beB3-beaxC4-beaxD40-axZ200-d100axZ10",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp15s29l40unbps1bpd183bpn254bpp10byum58my+10mp15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
-    "rwA1-rmp1wA1-bzbps96bpd231bpn159bpp40bpb0ws24l50sp20B3-bzbps96bpd231bpn159bpp70bpb40wA2-bzrbps96bpd231bpn159bpp30bpb70wA3-bzrbps96bpb30bpd231bpn159bpp0wB2-rbps96bpd0bpn159bpp0Z1",
+    "rhunmp20byump15A1-rhsp15s29l40unbps1bpd183bpn254bpp10byum58my+10mp15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rwA1-rmp1wA1-bzbps96bpd231bpn159bpp40bpb0ws24l50sp20B3-bzbps96bpd231bpn159bpp70bpb40wA2-"
+    "bzrbps96bpd231bpn159bpp30bpb70wA3-bzrbps96bpb30bpd231bpn159bpp0wB2-rbps96bpd0bpn159bpp0Z1",
     "A120-B20-C10-D10-E10-F10-G10-rfE10-rfF10-rfG10-rfH10-D10-C10-B20-A120",
     "A5-jn23B4-jgjn23C4",
     "A6-B6-C6-B6",
@@ -1127,14 +1227,29 @@ const char* test_strings[] = {
     "A1",
     "A2-B2-C3-D2-m50mx+58my-62D1-E5-F3",
     "l40s02x-1D1-x-1E1-F5-E4-D3",
-    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41kk40cpubB2-vx+3y-3zzts12sp11l41k40ubC1-zzk40ubD2-zznk40ubE2-aik40zzq3s11sp11l55ubF2-aik40zzq3vx+4y-7ts12sp11l55k40ubG1-zzk40q3aicpubH2-zzk40aicpubI3-zzk40aicpubJ4-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
-    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41k40cpubB2-vx+3y-3zzts12sp11l26k40cpubC1-zzk40ubD2-zzk40ubE4-vx+2y-2k40zzq3ubF1-zzs11sp11l41k40cpubB2-vx+3y-2zzts12sp11l41k40cpubC1-zzubD2-zznk40ubE4-aik40zzq4s11sp11l55ubF2-aik40zzq4vx+5y-7ts12sp11l55k40ubG1-zzk40aicpubH3-zzk40aicpubI3-zzk40aicpubJ4-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
-    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41k40cpubB2-vx+3y-3zzts12sp11l26k40cpubC1-zzk40ubD2-zzk40ubE4-vx+2y-3k40zzq3ubF1-zzs11sp11l41k40cpubB2-vx+2y-3zzts12sp11l26k40cpubC1-zzubD2-zzk40ubE4-vx+2y-2k40zzq4ubF1-zzs11sp11l41k40cpubB2-vx+2y-2zzts12sp11l41k40cpubC1-zzubD2-zznk40ubE4-aik40zzq5s11sp11l55ubF2-aik40zzvx+5y-7ts12sp11l55k40ubG1-zzk40aicpubH3-zzk40aicpubI3-zzk40aicpubJ3-ubK2-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
-    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41k40cpubB2-vx+3y-3zzts12sp11l26k40cpubC1-zzk40ubD2-zzk40ubE4-vx+2y-3k40zzq3ubF1-zzs11sp11l41k40cpubB2-vx+2y-3zzts12sp11l26k40cpubC1-zzubD2-zzk40ubE4-vx+2y-2k40zzq4ubF1-zzs11sp11l41k40cpubB2-vx+2y-2zzts12sp11l41k40cpubC1-zzubD2-zznk40ubE4-aik40zzq5s11sp11l55ubF2-aik40zzvx+6y-7ts12sp11l55k40ubG1-zzk40aicpubH3-zzk40aicpubI3-zzk40aicpubJ3-ubK2-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
+    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41kk40cpubB2-vx+"
+    "3y-3zzts12sp11l41k40ubC1-zzk40ubD2-zznk40ubE2-aik40zzq3s11sp11l55ubF2-aik40zzq3vx+4y-7ts12sp11l55k40ubG1-"
+    "zzk40q3aicpubH2-zzk40aicpubI3-zzk40aicpubJ4-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
+    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41k40cpubB2-vx+"
+    "3y-3zzts12sp11l26k40cpubC1-zzk40ubD2-zzk40ubE4-vx+2y-2k40zzq3ubF1-zzs11sp11l41k40cpubB2-vx+3y-"
+    "2zzts12sp11l41k40cpubC1-zzubD2-zznk40ubE4-aik40zzq4s11sp11l55ubF2-aik40zzq4vx+5y-7ts12sp11l55k40ubG1-"
+    "zzk40aicpubH3-zzk40aicpubI3-zzk40aicpubJ4-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
+    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41k40cpubB2-vx+"
+    "3y-3zzts12sp11l26k40cpubC1-zzk40ubD2-zzk40ubE4-vx+2y-3k40zzq3ubF1-zzs11sp11l41k40cpubB2-vx+2y-"
+    "3zzts12sp11l26k40cpubC1-zzubD2-zzk40ubE4-vx+2y-2k40zzq4ubF1-zzs11sp11l41k40cpubB2-vx+2y-2zzts12sp11l41k40cpubC1-"
+    "zzubD2-zznk40ubE4-aik40zzq5s11sp11l55ubF2-aik40zzvx+5y-7ts12sp11l55k40ubG1-zzk40aicpubH3-zzk40aicpubI3-"
+    "zzk40aicpubJ3-ubK2-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
+    "zzs11sp11l26ubA2-zzcpubB2-vx+2y-4zzts12sp11l26cpubC1-zzD2-zzk40ubE4-vx+2y-3k40zzq2ubF1-zzs11sp11l41k40cpubB2-vx+"
+    "3y-3zzts12sp11l26k40cpubC1-zzk40ubD2-zzk40ubE4-vx+2y-3k40zzq3ubF1-zzs11sp11l41k40cpubB2-vx+2y-"
+    "3zzts12sp11l26k40cpubC1-zzubD2-zzk40ubE4-vx+2y-2k40zzq4ubF1-zzs11sp11l41k40cpubB2-vx+2y-2zzts12sp11l41k40cpubC1-"
+    "zzubD2-zznk40ubE4-aik40zzq5s11sp11l55ubF2-aik40zzvx+6y-7ts12sp11l55k40ubG1-zzk40aicpubH3-zzk40aicpubI3-"
+    "zzk40aicpubJ3-ubK2-d-5cgk40K3-d-5cgL3-d-5cgM50-gN3-gO2",
     "l40s02x-1D1-x-1E1-F5-E3-D2",
-    "zzA2-zzcps11sp11l25B2-vx+2y-4zzcC1-zzD2-zznk40E4-vx+3y-6aik40zzq2s11sp11l35F1-aik40zzq2G1-zzk40q2aicpH2-zzk40aicpI2-zzk40aicpJ4-d-3cgK3-d-3cgL3-d-3cgM50-gO4",
+    "zzA2-zzcps11sp11l25B2-vx+2y-4zzcC1-zzD2-zznk40E4-vx+3y-6aik40zzq2s11sp11l35F1-aik40zzq2G1-zzk40q2aicpH2-"
+    "zzk40aicpI2-zzk40aicpJ4-d-3cgK3-d-3cgL3-d-3cgM50-gO4",
     "l40s02D1-E1-F5-E3-D2",
-    "zzA2-zzcps11sp11l25B2-vx+3y-4zzcC1-zzD2-zznk40E4-vx+2y-6aik40zzq2s11sp11l35F1-aik40zzq2G1-zzk40q2aicpH2-zzk40aicpI2-zzk40aicpJ3-K5-L10",
+    "zzA2-zzcps11sp11l25B2-vx+3y-4zzcC1-zzD2-zznk40E4-vx+2y-6aik40zzq2s11sp11l35F1-aik40zzq2G1-zzk40q2aicpH2-"
+    "zzk40aicpI2-zzk40aicpJ3-K5-L10",
     "A1",
     "s01l50A1-B1-C4-B3-A2",
     "A1-B1-C2-vx+12y-9D2-E2-aajjcx+9cy+5awF1000",
@@ -1195,7 +1310,8 @@ const char* test_strings[] = {
     "A1-sp7sf-18l48s5B2-x+2C3-x+3cpD3-x+4cpE2-x+5cpF2-x+1G2",
     "A1-sp7sf-18l48s5B2-x+2C3-x+3cpD3-x+4cpE2-x+5cpF2-x+1G2",
     "A1-sp7sf-18l48s5B2-x+2C3-x+3cpD3-x+4cpE2-x+5cpF2-x+1G2",
-    "ex-45A12-B3-ma180mi1m12my-30mx+10B1-y-2ma210mi1m12my-40mx+10C1-vx-3y-13ma235mi1m12my-50mx+10C1-ma250mi1m12my-50mx+10C1-ma270mi1m12my-50mx+10C1-s25l50sp12L5-M300",
+    "ex-45A12-B3-ma180mi1m12my-30mx+10B1-y-2ma210mi1m12my-40mx+10C1-vx-3y-13ma235mi1m12my-50mx+10C1-ma250mi1m12my-50mx+"
+    "10C1-ma270mi1m12my-50mx+10C1-s25l50sp12L5-M300",
     "wA12-wB2-wC2-ws20l60D2-wE6-wD1-wC1-wB1",
     "S2-mp10m57my-60wsw50C1-mi25m12my-60wC1-wT20-U5-V3-soW4000",
     "uabebxI2-uabewJ3-uabewK3-uabewusjn51L50",
@@ -1214,7 +1330,8 @@ const char* test_strings[] = {
     "A0-sp7sf10l20s5B1-cC1-cpD1-nC1-njmB0-njmA0",
     "A0-sp7sf10l20s5B1-cC1-cpD1-nC1-njmB0-njmA0",
     "A0-sp7sf10l20s5B1-cC1-cpD1-nC1-njmB0-njmA0",
-    "uO1-ex-40O3-wR3-S3-S10-S3-S10-ma1mi1m12my-30mx+10wsw40A1-ma340mi1m12my-37mx+8wA1-ma320mi1m12my-45mx+5wA1-ma300mi1m12my-52mx+2wB1-ma280mi1m12my-61mx-1wB1-ma275mi1m12my-70mx-4wB1-wC3-B5-A5-S19-R5-O4000",
+    "uO1-ex-40O3-wR3-S3-S10-S3-S10-ma1mi1m12my-30mx+10wsw40A1-ma340mi1m12my-37mx+8wA1-ma320mi1m12my-45mx+5wA1-"
+    "ma300mi1m12my-52mx+2wB1-ma280mi1m12my-61mx-1wB1-ma275mi1m12my-70mx-4wB1-wC3-B5-A5-S19-R5-O4000",
     "bm10amebewx+40A1-uabebxusA3-uabewB3-uabewC10-uabewD3-uabewE10-uabeF3-uabes20l67sf-5G3-uabeH3-uabewI10-uabewjf2I20",
     "sp13s2l33sf-6D1-E1-F4-E3-D2",
     "A1-B2-sp7sf-3l33s5C2-cpD3-jlnC3-jlnB3-jlnA2",
@@ -1266,10 +1383,14 @@ const char* test_strings[] = {
     "A3400",
     "pd240pp55ptp6ptd1ptr40s28l60B1-C5-B4-A3",
     "x+10sp7sf-22l52s5A3-x+13A3-x+16A3-x+20A40",
-    "bearC1-beC2-beD2-vy-15bebuE1-beaxE2-beaxF3-beaxG3-beaxH3-beaxE2-beaxF2-beaxG2-beaxH2-beaxE2-beaxF1-beaxG1-beaxH1-beaxE1-beaxF1-beaxG1-beaxH1-beaxE1-beaxF1-beaxG1-beaxm55my+30b1b2s28l60H1-beaxE1-beaxF1-beaxG1-beaxsoH1-beaxsoE1-beaxsoF1-beaxsoG1-beaxsoH1-axgsoZ500",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "bearC1-beC2-beD2-vy-15bebuE1-beaxE2-beaxF3-beaxG3-beaxH3-beaxE2-beaxF2-beaxG2-beaxH2-beaxE2-beaxF1-beaxG1-beaxH1-"
+    "beaxE1-beaxF1-beaxG1-beaxH1-beaxE1-beaxF1-beaxG1-beaxm55my+30b1b2s28l60H1-beaxE1-beaxF1-beaxG1-beaxsoH1-beaxsoE1-"
+    "beaxsoF1-beaxsoG1-beaxsoH1-axgsoZ500",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A120-B20-C10-D10-E10-F10-G10-rfE10-rfF10-rfG10-rfH10-D10-C10-B20-A120",
     "A5-jn22B4-jgjn22C3",
     "A6-B6-C6-B6",
@@ -1401,10 +1522,17 @@ const char* test_strings[] = {
     "J0-I1-H1-G1-cpF2-cpE2-sp7sf-22l52s5D2-C2-jlB1-jlA1",
     "J0-I0-H1-G1-cpF2-cpE2-sp7sf-22l52s5D2-C1-jlB1-jlA1",
     "J0-I0-H1-G1-cpF1-cpE1-sp7sf-22l52s5D1-C1-jlB1-jlA1",
-    "O22-m12ma200mi2mx-5my-7wM1-m56mx-5my-7s28l35wM1-wN2-wO5-m12ma340mi2mx-5my-7wN1-wM2-wN4-m56mx-2my-9s28l30wM1-m12ma200mi2mx-5my-7wO1-wN2-wO5-m12ma340mi2mx-5my-7wM2-wN2-m56mx-8my-3s28l40wM1-wO5-m12ma220mi2mx-5my-7wO1-wN2-wM5-m12ma330mi2mx-5my-7wO1-wM2-m56mx-5my-5s28l33wO1-wN5-m12ma230mi2mx-5my-7wN1-wM2-wO5-m12ma320mi2mx-5my-7wM1-wN2-wO5000",
-    "bm10amex+20beA1-usbebxA6-bes21l60B8-beC3-beuD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabeujf2jfD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabeujf2jfD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabeujf2jfD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabewjf2jfI5-uabewjf2jfJ7",
-    "uO27-ey-24uox-10N6-ey-56uox-13N3-ey-75uox-15N1-uox-15vy-30N1-uox-15boN27-gey-482bhboN1-boN1-hboZ20-bofox-30N29-m55mx+5my+30bofox-30sw40N1-m55mx-40my-10bofox-30N1-m12mi50ma270mx-20my-10s29sp20l64Z1-hgeZ1000",
-    "bewuaA3-bewB4-bewC4-usbewD16-uabewE6-uabewF3-uabewG15-uabewH3-uabewI4-uabewJ6-uabewK44-uabewL3-uabewM3-uabewN3-uabewO3-uabewjn29P30",
+    "O22-m12ma200mi2mx-5my-7wM1-m56mx-5my-7s28l35wM1-wN2-wO5-m12ma340mi2mx-5my-7wN1-wM2-wN4-m56mx-2my-9s28l30wM1-"
+    "m12ma200mi2mx-5my-7wO1-wN2-wO5-m12ma340mi2mx-5my-7wM2-wN2-m56mx-8my-3s28l40wM1-wO5-m12ma220mi2mx-5my-7wO1-wN2-wM5-"
+    "m12ma330mi2mx-5my-7wO1-wM2-m56mx-5my-5s28l33wO1-wN5-m12ma230mi2mx-5my-7wN1-wM2-wO5-m12ma320mi2mx-5my-7wM1-wN2-"
+    "wO5000",
+    "bm10amex+20beA1-usbebxA6-bes21l60B8-beC3-beuD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabeujf2jfD4-"
+    "uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabeujf2jfD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-"
+    "uabewjf2jfH4-uabeujf2jfD4-uabeujf2jfE3-uabeujf2jfF4-uabeujf2jfG4-uabewjf2jfH4-uabewjf2jfI5-uabewjf2jfJ7",
+    "uO27-ey-24uox-10N6-ey-56uox-13N3-ey-75uox-15N1-uox-15vy-30N1-uox-15boN27-gey-482bhboN1-boN1-hboZ20-bofox-30N29-"
+    "m55mx+5my+30bofox-30sw40N1-m55mx-40my-10bofox-30N1-m12mi50ma270mx-20my-10s29sp20l64Z1-hgeZ1000",
+    "bewuaA3-bewB4-bewC4-usbewD16-uabewE6-uabewF3-uabewG15-uabewH3-uabewI4-uabewJ6-uabewK44-uabewL3-uabewM3-uabewN3-"
+    "uabewO3-uabewjn29P30",
     "zzA1-s1l40zzB1-zzC4-B3-A2",
     "x+6unudA2-x+9unbwbo-60udB2-x+12unC2-x+9unudD2-x+7unudq2E2-unudA2-x-5unudB2-x-10unudC2-x-12unudD2-x-10unudE2",
     "x+7unudA2-x+11unbwbo-60udB2-x+14unC2-x+11unudD2-x+8unudq2E2-unudA2-x-6unudB2-x-12unudC2-x-14unudD2-x-12unudE2",
@@ -1457,9 +1585,11 @@ const char* test_strings[] = {
     "beA3-s27l60sp12beB3-beC3-pjfD3-jfE3-pjfF3-jfG3-pjfH3-jfI3-pjfJ3-jfK3-pjfL3-jfM3-d24jfI3",
     "sp13s1l20sf0A1-B4-A3",
     "A3-B3-C3-D3-E4-A4-B5-C6-D8-E9-A11-B13-C4400",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A50-B30-C20-D300",
     "A5-B4-jn26jgC3",
     "A6-B6-C6-B6",
@@ -1534,12 +1664,17 @@ const char* test_strings[] = {
     "x+2ursp7sf-15l45s5A1-x+3urB1-x+6urcpC1-x+6urcpD2-x+6urcpC2-x+7urcpD2-x+7urcpC2-x+5urcpD2-x+2nurB4-A4",
     "x+2ursp7sf-15l45s5A1-x+3urB1-x+6urcpC1-x+6urcpD2-x+6urcpC2-x+7urcpD2-x+7urcpC2-x+5urcpD2-x+2nurB4-A4",
     "x+2ursp7sf-15l45s5A1-x+3urB1-x+6urcpC1-x+6urcpD2-x+6urcpC2-x+7urcpD2-x+7urcpC2-x+5urcpD2-x+2nurB4-A4",
-    "ex-35C8-ewx-20C7-ewC6-erx+20wC5-erx+35wC4-erx+20C3-erC3-ex-20C3-ex-35C2-ex-20wC2-ewC2-erx+20wC2-erx+35wC2-erx+20C2-erC2-ex-20C2-ex-35C1-ex-20wC1-ewC1-erx+20wC1-erx+35wC1-erx+20C1-erC1-ex-20C1-ex-35C1-ex-20wC1-ewC1-erx+20wC1-erx+35wC1-erx+20C1-erC1-ex-20C1-ex-35C1-ex-20wC1-ewC1-erx+20wC1-erx+35wC1-erx+20C1-erC1-ex-20C1-ex-35C1-ex-20wC1-ewC1-erx+20wubC1-vx+13vy-8rwubL1-rwubL5-rubM300",
-    "bl5A1-A7-B7-C6-s5l50D5-E4-F3-G3-s5l50H3-A2-B2-C2-s5l50D2-E2-F2-G2-s5l50H2-A1-B1-C1-s5l50D1-E1-F1-G1-s5l50H1-A1-B1-C1-s5l50D1-E1-F1-G1-s5l50H1-A1-B1-C1-s5l50D1-E1-F1-G1-s5l50H1-A1-B1-C1-s5l50D1-rA2-rs26l60sp12I10-arI1",
+    "ex-35C8-ewx-20C7-ewC6-erx+20wC5-erx+35wC4-erx+20C3-erC3-ex-20C3-ex-35C2-ex-20wC2-ewC2-erx+20wC2-erx+35wC2-erx+"
+    "20C2-erC2-ex-20C2-ex-35C1-ex-20wC1-ewC1-erx+20wC1-erx+35wC1-erx+20C1-erC1-ex-20C1-ex-35C1-ex-20wC1-ewC1-erx+20wC1-"
+    "erx+35wC1-erx+20C1-erC1-ex-20C1-ex-35C1-ex-20wC1-ewC1-erx+20wC1-erx+35wC1-erx+20C1-erC1-ex-20C1-ex-35C1-ex-20wC1-"
+    "ewC1-erx+20wubC1-vx+13vy-8rwubL1-rwubL5-rubM300",
+    "bl5A1-A7-B7-C6-s5l50D5-E4-F3-G3-s5l50H3-A2-B2-C2-s5l50D2-E2-F2-G2-s5l50H2-A1-B1-C1-s5l50D1-E1-F1-G1-s5l50H1-A1-B1-"
+    "C1-s5l50D1-E1-F1-G1-s5l50H1-A1-B1-C1-s5l50D1-E1-F1-G1-s5l50H1-A1-B1-C1-s5l50D1-rA2-rs26l60sp12I10-arI1",
     "bnnA2-bnulA1-bnulB3-bnulC4-bnulD5-bnulE4",
     "nA3-B3-C4-D5-E4",
     "nA3-B3-C4-D5-E4",
-    "A2-ex-50A2-ex-47A1-ex-52A1-ex-48A1-ex-51A1-A11-A1-E1-s02l40F2-m12my-40E1-A2-E1-s02l40F2-m12my-45E1-A2-E1-s02l40F2-m12my-45E1-A2-E1-s02l40F2-m12my-40E1-A2-E1-s02l40F2-m12my-41E1-A1-B2-m12my-55s02l55bl5C1-vx-4y-9C3-L5-M400",
+    "A2-ex-50A2-ex-47A1-ex-52A1-ex-48A1-ex-51A1-A11-A1-E1-s02l40F2-m12my-40E1-A2-E1-s02l40F2-m12my-45E1-A2-E1-s02l40F2-"
+    "m12my-45E1-A2-E1-s02l40F2-m12my-40E1-A2-E1-s02l40F2-m12my-41E1-A1-B2-m12my-55s02l55bl5C1-vx-4y-9C3-L5-M400",
     "bb6A1-A1-B2-C12-D2-s20l60E3-F2-G1-H3-G1-F2-E3-F2-G1-H3-G1-F2-E3-F2-G1-H7-C2-B2-A2",
     "sp13s2l20sf0D1-E4-D3",
     "A2-sp7sf10l20s5B2-cpC3-cpD3-jmE2",
@@ -1600,9 +1735,12 @@ const char* test_strings[] = {
     "A1-sp7sf-15l45s5B1-C2-cpD2-C1-B1-A1",
     "A1-sp7sf-15l45s5B1-C1-cpD1-C1-B1-A1",
     "vx-6y-7s1l60bl7D1-E2-F2-L5-M300",
-    "A2-cB2-cx+40hcpC2-l45s20cx+40hD2-cx+40hE2-cx+40hq2cpF2-cx+40hcpG2-l45s20cx+40hH2-cx+40hI2-cx+40hq3cpB2-cx+40hcpC2-l45s20cx+40hD2-cx+40E2-cx+40hq4cpF2-cx+40hcpG2-l45s20cx+40hH3-I1-nI5-A4",
+    "A2-cB2-cx+40hcpC2-l45s20cx+40hD2-cx+40hE2-cx+40hq2cpF2-cx+40hcpG2-l45s20cx+40hH2-cx+40hI2-cx+40hq3cpB2-cx+40hcpC2-"
+    "l45s20cx+40hD2-cx+40E2-cx+40hq4cpF2-cx+40hcpG2-l45s20cx+40hH3-I1-nI5-A4",
     "A2-cB2-cC2-l45s20D2-E2-q2cpF2-cpG2-l45s20H2-I2-q3cpB2-cpC2-l45s20D2-E2-q4cpF2-cpG2-l45s20H3-I1-nI5-A4",
-    "A2-cB2-cx+40hcpC2-l45s20cx+40hjn27D2-cx+40hE2-cx+40hq2cpjn27F2-cx+40hcpjn27G2-l45s20cx+40hjn27H2-cx+40hjn27I2-cx+40hq3cpjn27B2-cx+40hcpjn27C2-l45s20cx+40hjn27D2-cx+40jn27E2-cx+40hq4cpjn27F2-cx+40hcpjn27G2-l45s20cx+40hH3-I1-nI5-A4",
+    "A2-cB2-cx+40hcpC2-l45s20cx+40hjn27D2-cx+40hE2-cx+40hq2cpjn27F2-cx+40hcpjn27G2-l45s20cx+40hjn27H2-cx+40hjn27I2-cx+"
+    "40hq3cpjn27B2-cx+40hcpjn27C2-l45s20cx+40hjn27D2-cx+40jn27E2-cx+40hq4cpjn27F2-cx+40hcpjn27G2-l45s20cx+40hH3-I1-nI5-"
+    "A4",
     "uO1-O4-ex-60O3-ex-60R3-ex-50S3-wS10-ex-50rwS10-ex-50rwS3-ex-50wrS100",
     "bm10amebewx+60A1-A4-uabebxB3-uabewC3-uabewD10-uabewE3-uabebj33E10-beE2",
     "wgS10-ex-50rwS10-ex-50rwS3-ex-50wrS100",
@@ -1610,7 +1748,8 @@ const char* test_strings[] = {
     "sp13s1l20sf0A1-B4-A3",
     "beusJ2-bejn35J2-bejn35K6-beL15",
     "wgS10-ex-50rwS10-ex-50rwS3-ex-50wrS100",
-    "uabeF10-acuabeF10-bex+3G3-jn37cwbex+4jf2H2-jn37cwbex+6jf2I2-jn37cwbex+7jf2H1-jn37cwbex+8jf2I1-jn37cwbex+9jf2H1-jn37cwbex+9jf2I1-jn37cwbex+9jf2H1-d30jn37cwbex+9jf2I1",
+    "uabeF10-acuabeF10-bex+3G3-jn37cwbex+4jf2H2-jn37cwbex+6jf2I2-jn37cwbex+7jf2H1-jn37cwbex+8jf2I1-jn37cwbex+9jf2H1-"
+    "jn37cwbex+9jf2I1-jn37cwbex+9jf2H1-d30jn37cwbex+9jf2I1",
     "ex-50wrS100",
     "jn38cwbex+12usH1-jn38cwbex+12usI1-jn38cwbex+12H1-jn38d1cwbex+12I1",
     "sp13s1l20sf0A1-B4-A3",
@@ -1618,9 +1757,12 @@ const char* test_strings[] = {
     "m55mn60mx-4my-6hQ1-m55mn60mx+3my-55hs29l65Q1-m55mn60my-36hQ1-m12mi35mx+3my-30hZ1-gd20hZ1000",
     "uabeJ5-beK8-bejn40L15",
     "s01l40sp15A1-B1-C5-B3-A2",
-    "A1-cB1-cx+40hcpC1-l45s20cx+40hD1-cx+40hE1-cx+40hq2cpF1-cx+40hcpG1-l45s20cx+40hH1-cx+40hI1-cx+40hq3cpB1-cx+40hcpC1-l45s20cx+40hD1-cx+40hE1-cx+40hcpF1-cx+40hcpG1-l45s20cx+40hH2-I1-nI5-A4",
+    "A1-cB1-cx+40hcpC1-l45s20cx+40hD1-cx+40hE1-cx+40hq2cpF1-cx+40hcpG1-l45s20cx+40hH1-cx+40hI1-cx+40hq3cpB1-cx+40hcpC1-"
+    "l45s20cx+40hD1-cx+40hE1-cx+40hcpF1-cx+40hcpG1-l45s20cx+40hH2-I1-nI5-A4",
     "A1-cB1-cC1-l45s20D2-E1-q2cpF1-cpG1-l45s20H1-I1-q3cpB1-cpC1-l45s20D1-E1-q4cpF1-cpG1-l45s20H2-I1-nI5-A4",
-    "A1-cB1-cx+40hcpC1-l45s20cx+40hD1-cx+40hjn27E1-cx+40hq2cpjn27F1-cx+40hcpjn27G1-l45s20cx+40hjn27H1-cx+40hjn27I1-cx+40hq3cpjn27B1-cx+40hcpjn27C1-l45s20cx+40hjn27D1-cx+40hjn27E1-cx+40hcpjn27F1-cx+40hcpjn27G1-l45s20cx+40hH2-I1-nI5-A4",
+    "A1-cB1-cx+40hcpC1-l45s20cx+40hD1-cx+40hjn27E1-cx+40hq2cpjn27F1-cx+40hcpjn27G1-l45s20cx+40hjn27H1-cx+40hjn27I1-cx+"
+    "40hq3cpjn27B1-cx+40hcpjn27C1-l45s20cx+40hjn27D1-cx+40hjn27E1-cx+40hcpjn27F1-cx+40hcpjn27G1-l45s20cx+40hH2-I1-nI5-"
+    "A4",
     "vy-12bebuacoy-60A1-beaxoy-60A2-beaxoy-60B10-beaxoy-60C10-beaxm55my+30b1b2oy-60s28l60C1-beaxoy-60C20-axZ1000",
     "sp13s2l30sf-5D1-E1-F3-E3-D2",
     "A2-sp7sf0l30s5B3-cC3-cpD3-jmE3",
@@ -1662,11 +1804,14 @@ const char* test_strings[] = {
     "s27l60sp12A1-A1-jfB12-jfC2-jfD3-jfE4-jfF6-jfE4-jfD2-jfC2-d2jfC2",
     "sp13s1l20sf0A1-B4-A3",
     "A5300",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A110-B20-C10-D10-E10-F20-G30-F20-E10-D10-C10-B20-A120",
-    "cx+4cy+4A110-cx+4cy+4B20-cx+4cy+4C10-cx+4cy+4D10-cx+4cy+4E10-cx+4cy+4F20-cx+4cy+4G30-cx+4cy+4F20-cx+4cy+4E10-cx+4cy+4D10-cx+4cy+4C10-cx+4cy+4B20-cx+4cy+4A120",
+    "cx+4cy+4A110-cx+4cy+4B20-cx+4cy+4C10-cx+4cy+4D10-cx+4cy+4E10-cx+4cy+4F20-cx+4cy+4G30-cx+4cy+4F20-cx+4cy+4E10-cx+"
+    "4cy+4D10-cx+4cy+4C10-cx+4cy+4B20-cx+4cy+4A120",
     "A4-B2-jn22B2-jgjn22C4",
     "A6-B6-C6-B6",
     "A1",
@@ -1803,9 +1948,13 @@ const char* test_strings[] = {
     "A0-sp7sf-6l36s5B1-C1-cpD2-jlnC1-jlnB1-jlnA1",
     "A0-sp7sf-6l36s5B1-C1-cpD1-jlnC1-jlnB1-jlnA1",
     "gO121-gm55mx+39my-3s28l60N1-gm55mx-6my+3sw40N1-gm12mx+20mi20N1-M3-N2-O2000",
-    "y-4hbeA3-vy-9beB1-beuB5-beC6-y+2axhbebouD4-y+4axhbebouE6-y+6axhbebouF4-y+8axhbebouF4-y+10axhbebouF4-y+12axhbebouF4-axhbeuZ15-y-20axhbebouG20-ex-20y-300axhbeuZ30-y+20axhbebowH14-y+20axhbebowuausH1-jn32gaxhbebowuaH30-beuaI5-beJ5-bebj48d5Z2",
-    "O5-O4-O4-O5-ey-26x-20bhM5-ey-61x-20bhM1-vy-25bhM1-bhboM20-bhfboM31-bhfm55mx+45my+51mp14s29l64sp20boM1-bhfm55mx-5my+30mp14sw50s29l60boM1-bhfm12mi45mx+20my+2hboM1-hgZ10000",
-    "bewA5-bewB4-uabewC4-uabewD5-uabewE5-uabewF48-bhuabehy-3wG2-bhuabehy-5H2-bhuabehy-7H2-bhuabehy-9H3-bhuabehy-11usH28-bhuabehjn33gy-200H20-bhuabehjn33gy-200I20-bebhI16-bebhJ20",
+    "y-4hbeA3-vy-9beB1-beuB5-beC6-y+2axhbebouD4-y+4axhbebouE6-y+6axhbebouF4-y+8axhbebouF4-y+10axhbebouF4-y+"
+    "12axhbebouF4-axhbeuZ15-y-20axhbebouG20-ex-20y-300axhbeuZ30-y+20axhbebowH14-y+20axhbebowuausH1-jn32gaxhbebowuaH30-"
+    "beuaI5-beJ5-bebj48d5Z2",
+    "O5-O4-O4-O5-ey-26x-20bhM5-ey-61x-20bhM1-vy-25bhM1-bhboM20-bhfboM31-bhfm55mx+45my+51mp14s29l64sp20boM1-bhfm55mx-"
+    "5my+30mp14sw50s29l60boM1-bhfm12mi45mx+20my+2hboM1-hgZ10000",
+    "bewA5-bewB4-uabewC4-uabewD5-uabewE5-uabewF48-bhuabehy-3wG2-bhuabehy-5H2-bhuabehy-7H2-bhuabehy-9H3-bhuabehy-"
+    "11usH28-bhuabehjn33gy-200H20-bhuabehjn33gy-200I20-bebhI16-bebhJ20",
     "gZ1000",
     "gy-300behbuuaZ3-axy+20behuaA14-axy+20behm55my+16mx-14b1uaA1-axy+20behm55mx+15b1b2uaA1-axy+20behuaA10-uaZ2000",
     "ex-40A20-ex-40y-20J3-eoy-90frM3-eoy-90x+30frL3-ex+40oy-82rfhA6-gvx-4y-10arfoy-82bb11l40s4A1-M500",
@@ -1861,9 +2010,11 @@ const char* test_strings[] = {
     "bewA4-s27l60sp12bewB20-bewC4-bewD4-bewE5-jfwF6-jfwG6000",
     "sp13s1l20sf0A1-B4-A3",
     "A5500",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A130-B30-C10-D10-E10-F10-rfC10-rfD10-rfE10-rff10-C10-B30-A130",
     "A5-jn20B4-jn20C4-jgjn20D4",
     "A6-B6-C6-B6",
@@ -1915,16 +2066,19 @@ const char* test_strings[] = {
     "A1-sp7sf0l30s5B2-C2-cpD3-jlnC2-jlnB2-jlnA1",
     "A1-sp7sf0l30s5B2-C2-cpD3-jlnC2-jlnB2-jlnA1",
     "A1-sp7sf0l30s5B2-C2-cpD3-jlnC2-jlnB2-jlnA1",
-    "A1-bf230s21l50sp15zpA1-bf200zpA1-bf150zpA1-bf120zpA1-bf80zpA1-bf60zpA1-atZ1-bf30s22l50sp15A2-bf60A2-bf80A2-bf120A1-bf150jhA1-bf200jhA1-bf230jhA1",
+    "A1-bf230s21l50sp15zpA1-bf200zpA1-bf150zpA1-bf120zpA1-bf80zpA1-bf60zpA1-atZ1-bf30s22l50sp15A2-bf60A2-bf80A2-"
+    "bf120A1-bf150jhA1-bf200jhA1-bf230jhA1",
     "sp13s3l20sf0D1-E4-D3",
     "A1-sp7sf10l20s5B1-C2-cpD2-jlnC2-jlnB1-jlnA1",
-    "ex-35B7-ex-28bf240C1-ex-28bf220C1-ex-28bf200C1-ex-28bf180s25l50sp20C1-ex-28bf165C1-ex-28bf150C1-ex-28bf130C1-ex-28bf110C1-ex-28bf95C1-ex-28bf80C1-ex-28bf110C1-ex-28bf150C1-ex-28bf190C1-ex-28bf220C1-vx-6y-9L1-L5-M500",
+    "ex-35B7-ex-28bf240C1-ex-28bf220C1-ex-28bf200C1-ex-28bf180s25l50sp20C1-ex-28bf165C1-ex-28bf150C1-ex-28bf130C1-ex-"
+    "28bf110C1-ex-28bf95C1-ex-28bf80C1-ex-28bf110C1-ex-28bf150C1-ex-28bf190C1-ex-28bf220C1-vx-6y-9L1-L5-M500",
     "A6-s22sf-10l60B12-A6",
     "A2-B2-C2-mx+5my-60mp12mn40m38D1-D4-mm23mu20momm18mu20moC3-jhB2-jhA1",
     "sp13s1l20sf0A1-B4-A3",
     "arA1-iA1-iawB2-vx+11y-13awC2-cy+6awD200",
     "vx-5y-7s01l50bl6A1-s25l50sp20B2-C2-L5-M500",
-    "abbf220D1-abbf190s21l50sp14D1-abbf140D1-abbf110D1-abbf75E1-abbf30E1-bhx-435abbf50E1-abbf80ags22l50sp14E1-abbf120agF1-abbf160agcpF1-abbf200agcpF1-abagcpG200",
+    "abbf220D1-abbf190s21l50sp14D1-abbf140D1-abbf110D1-abbf75E1-abbf30E1-bhx-435abbf50E1-abbf80ags22l50sp14E1-"
+    "abbf120agF1-abbf160agcpF1-abbf200agcpF1-abagcpG200",
     "x-1D1-l45s1x-1E1-x-1F4-E3-D2",
     "x+2A1-x+3nsp7sf-3l33s5B2-x+4cpC2-x+3nD3-x+4nE2-q2x+2aiE2-x+1aicpF2-nF2-nG3",
     "l50s01bl5A1-B1-C5-B3-A2",
@@ -1976,8 +2130,11 @@ const char* test_strings[] = {
     "aisp7sf0l30s5A1-vx+5y-7aiB1-aicpC3-naiC1-nB2-gnA2",
     "aisp7sf0l30s5A1-vx+5y-7aiB1-aicpC3-naiC1-nB2-gnA1",
     "aisp7sf0l30s5A1-vx+5y-7aiB1-aicpC2-naiC1-nB1-gnA1",
-    "O1-ex-40O3-R3-S3-S10-S3-S20-D1-D1-ma200mi1m12my-40mx+5sw40D1-s28sp12l35m56my-40mx+5E1-ma220mi1m12my-44mx+6E1-ma230mi1m12my-47mx-3E1-ma235mi1m12my-50mx-4E1-F3-D24-ma360mi1m12my-40mx+5A1-ma20mi1m12my-45mx+5B1-m56my-45mx-5s28sp12l40B1-ma40mi1m12my-50mx+5C1-B2-wA3-R5-O4000",
-    "bm10amebewx+40A1-uabebxusA3-uabewB3-uabewC10-uabewD3-uabebf100bs255ws21l40sp14E10-uabebf100wE10-uabebf100F3-uabebf100G4-uabewbf100jf2H30-uabewbf100I2-uabewbf100J2-uabewbf255bs100s22l40sp14K15",
+    "O1-ex-40O3-R3-S3-S10-S3-S20-D1-D1-ma200mi1m12my-40mx+5sw40D1-s28sp12l35m56my-40mx+5E1-ma220mi1m12my-44mx+6E1-"
+    "ma230mi1m12my-47mx-3E1-ma235mi1m12my-50mx-4E1-F3-D24-ma360mi1m12my-40mx+5A1-ma20mi1m12my-45mx+5B1-m56my-45mx-"
+    "5s28sp12l40B1-ma40mi1m12my-50mx+5C1-B2-wA3-R5-O4000",
+    "bm10amebewx+40A1-uabebxusA3-uabewB3-uabewC10-uabewD3-uabebf100bs255ws21l40sp14E10-uabebf100wE10-uabebf100F3-"
+    "uabebf100G4-uabewbf100jf2H30-uabewbf100I2-uabewbf100J2-uabewbf255bs100s22l40sp14K15",
     "D30-mp10m57my-60sw50C1-ma1mi25m12my-60C1-T20-U5-V3-W4000",
     "uabebf255bs100ws22l55sp14H20-uabeuswH10-uabewI2-uabewJ2-uabewjn36K25",
     "sp13s1l20sf0A1-B4-A3",
@@ -1986,8 +2143,10 @@ const char* test_strings[] = {
     "abA1-ts23l60A1-rA2-B2-rB2-C2-rC2",
     "nafvx+5unudA3-nafvx+7unB3-afvx+9unC3-afvx+11unA3-afvx+13unB3-afvx+15unC3",
     "nafvx+5unudA2-nafcx+30cy+30vx+5unA1-nafvx+7unB3-afvx+9unC3-afvx+11unA3-afvx+13unB3-afvx+15unC3",
-    "nafvx+11unudA3-nafvx+9unA3-nafvx+7unB3-afvx+6unC3-afvx+4unA3-afvx+3unB3-afvx+2unC3-afvx+1unA3-hafunB3-afunC3-afunA3-afunB3-afunC3-afunA3",
-    "nafvx+11unudA3-nafvx+9unA3-nafvx+7unB3-afvx+6unC3-afvx+4unA3-afvx+3unB3-afvx+2unC3-afvx+1hunA3-cx+14cy+14afunB3-afunC3-afunA3-afunB3-afunC3-afunA3",
+    "nafvx+11unudA3-nafvx+9unA3-nafvx+7unB3-afvx+6unC3-afvx+4unA3-afvx+3unB3-afvx+2unC3-afvx+1unA3-hafunB3-afunC3-"
+    "afunA3-afunB3-afunC3-afunA3",
+    "nafvx+11unudA3-nafvx+9unA3-nafvx+7unB3-afvx+6unC3-afvx+4unA3-afvx+3unB3-afvx+2unC3-afvx+1hunA3-cx+14cy+14afunB3-"
+    "afunC3-afunA3-afunB3-afunC3-afunA3",
     "sp13s2l37sf-8D1-E1-F4-E3-D2",
     "A1-sp7sf-7l37s5B2-C2-cpD3-jmnC2-jmnB2-jmnA1",
     "A1-sp7sf-7l37s5B2-C3-cpD4-jmnC2-jmnB2-jmnA1",
@@ -2033,12 +2192,15 @@ const char* test_strings[] = {
     "A0-cpsp7sf-3l33s5B1-cpC10-nB1-nA0",
     "A0-cpsp7sf-3l33s5B0-cpC11-nB1-nA0",
     "sp13s1l20sf0A1-B4-A3",
-    "beA3-B3-jfC3-jfD3-jfE3-jfF3-jfG3-jfC3-jfD3-jfE3-jfF3-jfG3-s27l63sp12jfC3-jfD3-jfE3-jfF3-jfG3-jfC3-jfD3-jfE3-jfF3-jfG3-jfd51G3",
+    "beA3-B3-jfC3-jfD3-jfE3-jfF3-jfG3-jfC3-jfD3-jfE3-jfF3-jfG3-s27l63sp12jfC3-jfD3-jfE3-jfF3-jfG3-jfC3-jfD3-jfE3-jfF3-"
+    "jfG3-jfd51G3",
     "sp13s1l20sf0A1-B4-A3",
     "bf230A2-bf200A3-bf170A5-bf130A4-bf110A6-bf230A4-bf110A3-bf153A2-bf78A3-bf240A5-bf186A4-bf120d4A2",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A60-B40-C40-D60-D60-C40-B40-A120",
     "A5-B4-jgC4",
     "A6-B6-C6-B6",
@@ -2175,9 +2337,11 @@ const char* test_strings[] = {
     "s01l60A1-s25l50sp12L4-M15",
     "A2-B2-y+1C3-y+2C3-y+3C3-y+4C3-y+5C300",
     "zpD1-s2l50zpE1-zpF3-zpE2-D2",
-    "y-2unbwA5-x+2mn40s20l60unB2-x+4unC2-x+6unB2-x+8unC2-x+8unB2-x+10unC2-x+10unB2-x+12unC2-x+12unB2-x+12unC2-x+12unB2-x+14unC2-x+14unB2-x+14unC2-x+14unB2",
+    "y-2unbwA5-x+2mn40s20l60unB2-x+4unC2-x+6unB2-x+8unC2-x+8unB2-x+10unC2-x+10unB2-x+12unC2-x+12unB2-x+12unC2-x+12unB2-"
+    "x+14unC2-x+14unB2-x+14unC2-x+14unB2",
     "zpA1-s2l50zpB1-zpC3-zpB2-A2",
-    "y-2unbwx+1A5-x+2y+1mn40s20l60unC2-x+4y+2unB2-x+6y+3unC2-x+8y+4unB2-x+8y+4unC2-x+10y+5unB2-x+10y+5unC2-x+12y+6unB2-x+12y+6unC2-x+12y+6unB2-x+12y+6unC2-x+14y+7unB2-x+14y+7unC2-x+14y+7unB2-x+14y+7unC2-x+14y+7unB2",
+    "y-2unbwx+1A5-x+2y+1mn40s20l60unC2-x+4y+2unB2-x+6y+3unC2-x+8y+4unB2-x+8y+4unC2-x+10y+5unB2-x+10y+5unC2-x+12y+6unB2-"
+    "x+12y+6unC2-x+12y+6unB2-x+12y+6unC2-x+14y+7unB2-x+14y+7unC2-x+14y+7unB2-x+14y+7unC2-x+14y+7unB2",
     "vx-6y-7D2-E2-s2l30F2-L5-M400",
     "rhunA1-rhs23l60unB1-rhunC1-rhunD1-rhunE1-rhunF1",
     "vx-6y-7zpD2-zpE2-s2l30zpF3-L5-M400",
@@ -2243,25 +2407,40 @@ const char* test_strings[] = {
     "A0-B1-cpsp7sf-7l37s5C1-cpD9-nC1-nB1-nA0",
     "A0-B0-cpsp7sf-7l37s5C1-cpD10-nC1-nB0-nA0",
     "sp13s1l20sf0A1-B4-A3",
-    "beA24-beB7-beC8-beD6-beE6-beF7-beG6-x-1beG2-x+1beG3-x-2beG2-x+2beG2-bps1bpd183bpn255bpp64bpb0x-2s29l100sb0se15beG5-bps1bpd183bpn255bpp64m12mi25s3l100beG1-bps1bpd183bpn255bpp64mn1mp12m25my-50mx+30mg80beG1-bps1bpd183bpn255bpp64m27mn1mp12my-60mg45beG1-bps1bpd183bpn255bpp64mn1mp12m29my-50mx-30mg60beG1-bps1bpd183bpn255bpp0bpb64beH10-bps1bpd0bpn255bpp0beH5-H25-I8-J4-K5000",
+    "beA24-beB7-beC8-beD6-beE6-beF7-beG6-x-1beG2-x+1beG3-x-2beG2-x+2beG2-bps1bpd183bpn255bpp64bpb0x-"
+    "2s29l100sb0se15beG5-bps1bpd183bpn255bpp64m12mi25s3l100beG1-bps1bpd183bpn255bpp64mn1mp12m25my-50mx+30mg80beG1-"
+    "bps1bpd183bpn255bpp64m27mn1mp12my-60mg45beG1-bps1bpd183bpn255bpp64mn1mp12m29my-50mx-30mg60beG1-"
+    "bps1bpd183bpn255bpp0bpb64beH10-bps1bpd0bpn255bpp0beH5-H25-I8-J4-K5000",
     "sp13s1l20sf0A1-B4-A3",
     "beA3-beB5-beC5-jfbeD5-C2-s24l60jfC5-jfD8-jfC5-jfD7-jfC5-jfD6-jfC4-jfD6-jfC5-jfD5-jfC5-jfD5-jfB20-d14jfD1",
     "sp13s1l20sf0A1-B4-A3",
     "A10-d1A10",
-    "uO1-O3-ex-60O3-ex-73y-11R3-ex-72y-20hS3-ex-54y-30hS5-hex-54y-29S2-hex-54y-27S1-hex-54y-26S2-s1l50m56my-60hs28l25sp12A1-m12ma320mi4my-60hB1-hB1-hC1-hex-54y-27B1-hA1-hexhx-54y-29S1-hex-54y-30S7-hd14S1-hS91-ex-67gS7-x-20ox-20L1-ox-20L2-x-20M1-M2-O5000",
-    "bm10amebewx+60A1-uabebxA3-uabebxB3-uabebxC3-uabebxD3-uabewE6-uabewF2-uabewG1-uabewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-bewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-bewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-bewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-bewH1-bewjf2I10-bewjf2H2-bewjf2G2-bewusjf2F3-uabewusjf2J5",
+    "uO1-O3-ex-60O3-ex-73y-11R3-ex-72y-20hS3-ex-54y-30hS5-hex-54y-29S2-hex-54y-27S1-hex-54y-26S2-s1l50m56my-"
+    "60hs28l25sp12A1-m12ma320mi4my-60hB1-hB1-hC1-hex-54y-27B1-hA1-hexhx-54y-29S1-hex-54y-30S7-hd14S1-hS91-ex-67gS7-x-"
+    "20ox-20L1-ox-20L2-x-20M1-M2-O5000",
+    "bm10amebewx+60A1-uabebxA3-uabebxB3-uabebxC3-uabebxD3-uabewE6-uabewF2-uabewG1-uabewH1-bewI5-bewH2-bewG2-bewF3-"
+    "bewE6-bewF2-bewG1-bewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-bewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-"
+    "bewH1-bewI5-bewH2-bewG2-bewF3-bewE6-bewF2-bewG1-bewH1-bewjf2I10-bewjf2H2-bewjf2G2-bewusjf2F3-uabewusjf2J5",
     "ex-58y-5S5-ex-52gS7-S3-S2-S20-S2-S2-S2-mp10m57my-60sw50C1-mi25m12my-60C1-T20-uU5-uV3-uW4000",
     "uabeA5-usbewB7-bewC3-bewD2-bewE20-bewF2-bewG2-bewH2-bewI2-bewJ2-bewK50-bewJ5",
-    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhunbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-"
+    "rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "byump14A1-byump14B1-C1-D1-E1-F1",
-    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "rhunmp20byump15A1-rhsp20s29l63unbps1bpd183bpn254bpp10byump15B1-rhunbps1bpd183bpn254bpp20C1-"
+    "rhunbps1bpd183bpn254bpp10D1-rhunbps1bpd184bpn254bpp5E1-rhunbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A1-B1-A1-B1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-"
+    "x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2",
@@ -2272,12 +2451,18 @@ const char* test_strings[] = {
     "E10-s20sb-50l60D10-C10-B10-A14-B10-C10-D10-E10",
     "E10-s20sb50l60D10-C10-B10-A14-B10-C10-D10-E10",
     "E10-s20sb0l60D10-C10-B10-A14-B10-C10-D10-E10",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-"
+    "x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2",
@@ -2288,24 +2473,38 @@ const char* test_strings[] = {
     "A3-bzbps96bpd231bpn64bpp70s23l50sp13sf-2sb-50se10B3-bps96bpn64bpp0C2",
     "A3-bzbps96bpd231bpn64bpp50s23l30sf4sp12sb100se-100B3-bps96bpn64bpp0C2",
     "A3-bzbps96bpd231bpn64bpp30s23l20sf7sp11sb50se-100B3-bps96bpn64bpp0C2",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-"
+    "x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
     "Z1-bzbps96bpd231bpn64bpp80s23l30sp12sf3A3-bps96bpn64bpp0A2",
-    "wA2-bzbps96bpd231bpn64bpp70s20l60sp14sb-100se-50sp14wC3-bps96bpn64bpp0wB3-wA2-bzbps96bpd231bpn64bpp50sb-100se-50s20l40sp15wC3-bps96bpn64bpp0wB2-Z1-wC1-Z2-wA1",
-    "wA2-bzbps96bpd231bpn64bpp70sb100se50l60s20sp14wC3-bps96bpn64bpp0wB3-wA2-bzbps96bpd231bpn64bpp50sb100se50s20l40sp15wC3-bps96bpn64bpp0wB2-Z1-wC1-Z2-wA1",
+    "wA2-bzbps96bpd231bpn64bpp70s20l60sp14sb-100se-50sp14wC3-bps96bpn64bpp0wB3-wA2-bzbps96bpd231bpn64bpp50sb-100se-"
+    "50s20l40sp15wC3-bps96bpn64bpp0wB2-Z1-wC1-Z2-wA1",
+    "wA2-bzbps96bpd231bpn64bpp70sb100se50l60s20sp14wC3-bps96bpn64bpp0wB3-wA2-"
+    "bzbps96bpd231bpn64bpp50sb100se50s20l40sp15wC3-bps96bpn64bpp0wB2-Z1-wC1-Z2-wA1",
     "A1-D1-A2-D1-A2-D2-A1-B1-E1-B2-E1-B2-E2-B1-C1-F1-C2-F1-C2-F2-C3",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2",
     "B8-d1B2-A8-d11A2",
     "Z3-mx+152my+160mp-1m15Z1-mx+160my+100m15mp10Z1-Z300",
-    "bzbps104bpn32bpb0bpp2bpd183A5-bzbps104bpn32bpb2bpp4bpd183B6-bzbps104bpn32bpp3bpd183C4-bzbps104bpn32bpb3bpp6bpd183D6-bzbps104bpn32bpb6bpp8bpd183A7-bzbps104bpn32bpp9bpd183B6-bzbps104bpn32bpp7bpb9bpd183C8-bzbps104bpn32bpp3bpb7bpd183D5-bzbps104bpn32bpp8bpb3bpd183A7-bzbps104bpn32bpp6bpb8bpd183B5-bzbps104bpn32bpp3bpb6bpd183C6-bzbps104bpn32bpp0bpb3bpd183D8",
+    "bzbps104bpn32bpb0bpp2bpd183A5-bzbps104bpn32bpb2bpp4bpd183B6-bzbps104bpn32bpp3bpd183C4-"
+    "bzbps104bpn32bpb3bpp6bpd183D6-bzbps104bpn32bpb6bpp8bpd183A7-bzbps104bpn32bpp9bpd183B6-"
+    "bzbps104bpn32bpp7bpb9bpd183C8-bzbps104bpn32bpp3bpb7bpd183D5-bzbps104bpn32bpp8bpb3bpd183A7-"
+    "bzbps104bpn32bpp6bpb8bpd183B5-bzbps104bpn32bpp3bpb6bpd183C6-bzbps104bpn32bpp0bpb3bpd183D8",
     "E3-F3-G3-H3-I3-J3-K3-L3-M3-N3-M3-L3-K3-J3-I3-H3-G3-F3-d1E3",
-    "bzbps104bpn32bpp5bpb0bpd151A5-bzbps104bpn32bpp7bpb5bpd151B7-bzbps104bpn32bpp5bpb7bpd151C5-bzbps104bpn32bpp3bpb5bpd151D8-bzbps104bpn32bpp5bpb3bpd151A7-bzbps104bpn32bpp7bpb5bpd151B6-bzbps104bpn32bpp9bpb7bpd151C8-bzbps104bpn32bpp6bpb9bpd151D5-bzbps104bpn32bpp3bpb6bpd151A6-bzbps104bpn32bpp1bpb3bpd151B4-bzbps104bpn32bpp4bpb1bpd151C7-bzbps104bpn32bpp6bpb4bpd151D6",
+    "bzbps104bpn32bpp5bpb0bpd151A5-bzbps104bpn32bpp7bpb5bpd151B7-bzbps104bpn32bpp5bpb7bpd151C5-"
+    "bzbps104bpn32bpp3bpb5bpd151D8-bzbps104bpn32bpp5bpb3bpd151A7-bzbps104bpn32bpp7bpb5bpd151B6-"
+    "bzbps104bpn32bpp9bpb7bpd151C8-bzbps104bpn32bpp6bpb9bpd151D5-bzbps104bpn32bpp3bpb6bpd151A6-"
+    "bzbps104bpn32bpp1bpb3bpd151B4-bzbps104bpn32bpp4bpb1bpd151C7-bzbps104bpn32bpp6bpb4bpd151D6",
     "E3-F3-G3-H3-I3-J3-K3-L3-M3-N3-M3-L3-K3-J3-I3-H3-G3-F3-d1E3",
     "A6-B7-C5-D6-A4-B7-C4-D6-A8-B4-C5-D6",
     "E3-F3-G3-H3-I3-J3-K3-L3-M3-N3-M3-L3-K3-J3-I3-H3-G3-F3-d1E3",
@@ -2313,17 +2512,24 @@ const char* test_strings[] = {
     "E3-F3-G3-H3-I3-J3-K3-L3-M3-N3-M3-L3-K3-J3-I3-H3-G3-F3-d1E3",
     "A1",
     "bzbps96bpn40bpp22bpb0bpd224Z27-bzbps96bpn40bpp0bpb22bpd224Z27-d1Z5",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-"
+    "x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
     "mn1wA5000",
     "mn20mp12bf10asA2-bf60asA2-bf120asA2-bf180asA3-bf220asA3-asA250-bf220asA3-bf180asA3-bf120asA2-bf60asA2-bf10asA2",
     "bf220ass20l50A3-bf180asA3-bf120asA3-bf60asA3-bf10asA3",
     "gey+20Z2-y-10A35",
-    "runmp20byump15vy-8A1-rsp10s21l55unbps1bpd183bpn254bpp10byump15B2-runbps1bpd183bpn254bpp20C2-runbps1bpd183bpn254bpp10D1-runbps1bpd184bpn254bpp5E1-runbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
+    "runmp20byump15vy-8A1-rsp10s21l55unbps1bpd183bpn254bpp10byump15B2-runbps1bpd183bpn254bpp20C2-"
+    "runbps1bpd183bpn254bpp10D1-runbps1bpd184bpn254bpp5E1-runbps1bpd0bpn254bpp0F1-bps1bpd0bpn254bpp0Z1",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2-E2-F2-G2",
     "A2-B2-C2-D2",
@@ -2336,19 +2542,49 @@ const char* test_strings[] = {
     "Z10-m12mn1mp20mx80Z1-Z10-m17mn1mp20mx120Z1-m16mn1mp20mx40Z1-Z110",
     "Z10-m12mn1mp20mx240Z1-Z10-m17mn1mp20mx280Z1-m16mn1mp20mx200Z1-Z110",
     "Z10-m18mn1mp20mx180Z1-m12mn1mp20mx140Z1-Z15-m17mn1mp20mx220Z1-m16mn1mp20mx100Z1-Z110",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
-    "x=0y=1wA3-x=0y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150ws21l14sp8G1-m13mx+5my+152ws21l16sp8F1-m13mx-6my+154ws21l18sp8G1-m13mx+6my+156ws21l20sp8F1-m13mx-7my+159ws21l22sp8G1-m13mx+7my+161ws21l24sp8F1-m13mx-8my+164ws21l26sp8G1-m13mx+8my+166ws21l28sp8F1-m13mx-9my+169ws21l30sp8G1-m13mx+9my+171ws21l32sp8F1-m13mx-10my+174ws21l34sp8G1-m13mx+10my+176wy=54s21l36sp8F1-m13mx-11my+179ws21l38sp8G1-m13mx+11my+181ws21l40sp8F1-m13mx-12my+184ws21l42sp8G1-m13mx+12my+186ws21l44sp8F1-m13mx-13my+189ws21l46sp8G1-m13mx+13my+191ws21l48sp8F1-m13mx-14my+194ws21l51sp8G1-m13mx+14my+197ws21l53sp8F1-m13mx-15my+200ws21l55sp8G1-m13mx+15my+203ws21l57sp8F1-m13mx+16my+206ws21l60sp8F1-m13mx-16my+209ws21l63sp8G1-y=58wI5-y=61wJ5-y=62wK5-y=56wL5-y=47wM5-y=37wN5-y=24wO5-y=8wO5-y=-10Z5",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s15sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-A14-l63s03sp21A1-x90y90A1-"
+    "x80y80A1-x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s13sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s12sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s11sp22A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x10y10A1-x20y20A1-x30y30A1-x40y40A1-x50y50A1-x60y60A1-x70y70A1-x80y80A1-x90y90A1-l63s14sp20A15-x90y90A1-x80y80A1-"
+    "x70y70A1-x60y60A1-x50y50A1-x40y40A1-x30y30A1-x20y20A1-x10y10A1",
+    "x=0y=1wA3-x=0y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150ws21l14sp8G1-m13mx+5my+152ws21l16sp8F1-"
+    "m13mx-6my+154ws21l18sp8G1-m13mx+6my+156ws21l20sp8F1-m13mx-7my+159ws21l22sp8G1-m13mx+7my+161ws21l24sp8F1-m13mx-8my+"
+    "164ws21l26sp8G1-m13mx+8my+166ws21l28sp8F1-m13mx-9my+169ws21l30sp8G1-m13mx+9my+171ws21l32sp8F1-m13mx-10my+"
+    "174ws21l34sp8G1-m13mx+10my+176wy=54s21l36sp8F1-m13mx-11my+179ws21l38sp8G1-m13mx+11my+181ws21l40sp8F1-m13mx-12my+"
+    "184ws21l42sp8G1-m13mx+12my+186ws21l44sp8F1-m13mx-13my+189ws21l46sp8G1-m13mx+13my+191ws21l48sp8F1-m13mx-14my+"
+    "194ws21l51sp8G1-m13mx+14my+197ws21l53sp8F1-m13mx-15my+200ws21l55sp8G1-m13mx+15my+203ws21l57sp8F1-m13mx+16my+"
+    "206ws21l60sp8F1-m13mx-16my+209ws21l63sp8G1-y=58wI5-y=61wJ5-y=62wK5-y=56wL5-y=47wM5-y=37wN5-y=24wO5-y=8wO5-y=-10Z5",
     "wmn1mp8brZ1-wbfm14mp10msA1-wbrA1-wbrB2-wbrC2-wbrD2-Z1",
     "A2",
     "brwZ1-brwmn1mp8s20l50sp20A3-brwB3-brwC2-brwD2-Z1",
-    "x=1Z2-x=0y=1wA3-x=0y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150ws21l14sp8G1-m13mx+5my+152ws21l16sp8F1-m13mx-6my+154ws21l18sp8G1-m13mx+6my+156ws21l20sp8F1-m13mx-7my+159ws21l22sp8G1-m13mx+7my+161ws21l24sp8F1-m13mx-8my+164ws21l26sp8G1-m13mx+8my+166ws21l28sp8F1-m13mx-9my+169ws21l30sp8G1-m13mx+9my+171ws21l32sp8F1-m13mx-10my+174ws21l34sp8G1-m13mx+10my+176wy=54s21l36sp8F1-m13mx-11my+179ws21l38sp8G1-m13mx+11my+181ws21l40sp8F1-m13mx-12my+184ws21l42sp8G1-m13mx+12my+186ws21l44sp8F1-m13mx-13my+189ws21l46sp8G1-m13mx+13my+191ws21l48sp8F1-m13mx-14my+194ws21l51sp8G1-m13mx+14my+197ws21l53sp8F1-m13mx-15my+200ws21l55sp8G1-m13mx+15my+203ws21l57sp8F1-m13mx+16my+206ws21l60sp8F1-m13mx-16my+209ws21l63sp8G1-y=58wI5-y=61wx=-4J5-y=62wx=-10K5-y=56wx=-18L5-y=47wx=-30M5-y=37x=-45wN5-y=24x=-65wO5-y=8wx=-85O5-y=-10x=-110Z5",
-    "x=1Z2-x=0y=1wA3-x=0y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150ws21l14sp8G1-m13mx+5my+152ws21l16sp8F1-m13mx-6my+154ws21l18sp8G1-m13mx+6my+156ws21l20sp8F1-m13mx-7my+159ws21l22sp8G1-m13mx+7my+161ws21l24sp8F1-m13mx-8my+164ws21l26sp8G1-m13mx+8my+166ws21l28sp8F1-m13mx-9my+169ws21l30sp8G1-m13mx+9my+171ws21l32sp8F1-m13mx-10my+174ws21l34sp8G1-m13mx+10my+176wy=54s21l36sp8F1-m13mx-11my+179ws21l38sp8G1-m13mx+11my+181ws21l40sp8F1-m13mx-12my+184ws21l42sp8G1-m13mx+12my+186ws21l44sp8F1-m13mx-13my+189ws21l46sp8G1-m13mx+13my+191ws21l48sp8F1-m13mx-14my+194ws21l51sp8G1-m13mx+14my+197ws21l53sp8F1-m13mx-15my+200ws21l55sp8G1-m13mx+15my+203ws21l57sp8F1-m13mx+16my+206ws21l60sp8F1-m13mx-16my+209ws21l63sp8G1-y=58wI5-y=61wx=4J5-y=62wx=10K5-y=56wx=18L5-y=47wx=30M5-y=37x=45wN5-y=24x=65wO5-y=8wx=85O5-y=-10x=110Z5",
-    "Z1-y=1wA3-y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150wG1-m13mx+5my+152wF1-m13mx-6my+154wG1-m13mx+6my+156wF1-m13mx-7my+159wG1-m13mx+7my+161wF1-m13mx-8my+164wG1-m13mx+8my+166wF1-m13mx-9my+169wG1-m13mx+9my+171wF1-m13mx-10my+174wG1-m13mx+10my+176wy=54F1-m13mx-11my+179wG1-m13mx+11my+181wF1-m13mx-12my+184wG1-m13mx+12my+186wF1-m13mx-13my+189wG1-m13mx+13my+191wF1-m13mx-14my+194wG1-m13mx+14my+197wF1-m13mx-15my+200wG1-m13mx+15my+203wF1-y=58wI5-y=61wJ5-y=62wK5-y=56wL5-y=47wM5-y=37wN5-y=24wO5-y=8wO5-y=-10Z5",
+    "x=1Z2-x=0y=1wA3-x=0y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150ws21l14sp8G1-m13mx+5my+"
+    "152ws21l16sp8F1-m13mx-6my+154ws21l18sp8G1-m13mx+6my+156ws21l20sp8F1-m13mx-7my+159ws21l22sp8G1-m13mx+7my+"
+    "161ws21l24sp8F1-m13mx-8my+164ws21l26sp8G1-m13mx+8my+166ws21l28sp8F1-m13mx-9my+169ws21l30sp8G1-m13mx+9my+"
+    "171ws21l32sp8F1-m13mx-10my+174ws21l34sp8G1-m13mx+10my+176wy=54s21l36sp8F1-m13mx-11my+179ws21l38sp8G1-m13mx+11my+"
+    "181ws21l40sp8F1-m13mx-12my+184ws21l42sp8G1-m13mx+12my+186ws21l44sp8F1-m13mx-13my+189ws21l46sp8G1-m13mx+13my+"
+    "191ws21l48sp8F1-m13mx-14my+194ws21l51sp8G1-m13mx+14my+197ws21l53sp8F1-m13mx-15my+200ws21l55sp8G1-m13mx+15my+"
+    "203ws21l57sp8F1-m13mx+16my+206ws21l60sp8F1-m13mx-16my+209ws21l63sp8G1-y=58wI5-y=61wx=-4J5-y=62wx=-10K5-y=56wx=-"
+    "18L5-y=47wx=-30M5-y=37x=-45wN5-y=24x=-65wO5-y=8wx=-85O5-y=-10x=-110Z5",
+    "x=1Z2-x=0y=1wA3-x=0y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150ws21l14sp8G1-m13mx+5my+"
+    "152ws21l16sp8F1-m13mx-6my+154ws21l18sp8G1-m13mx+6my+156ws21l20sp8F1-m13mx-7my+159ws21l22sp8G1-m13mx+7my+"
+    "161ws21l24sp8F1-m13mx-8my+164ws21l26sp8G1-m13mx+8my+166ws21l28sp8F1-m13mx-9my+169ws21l30sp8G1-m13mx+9my+"
+    "171ws21l32sp8F1-m13mx-10my+174ws21l34sp8G1-m13mx+10my+176wy=54s21l36sp8F1-m13mx-11my+179ws21l38sp8G1-m13mx+11my+"
+    "181ws21l40sp8F1-m13mx-12my+184ws21l42sp8G1-m13mx+12my+186ws21l44sp8F1-m13mx-13my+189ws21l46sp8G1-m13mx+13my+"
+    "191ws21l48sp8F1-m13mx-14my+194ws21l51sp8G1-m13mx+14my+197ws21l53sp8F1-m13mx-15my+200ws21l55sp8G1-m13mx+15my+"
+    "203ws21l57sp8F1-m13mx+16my+206ws21l60sp8F1-m13mx-16my+209ws21l63sp8G1-y=58wI5-y=61wx=4J5-y=62wx=10K5-y=56wx=18L5-"
+    "y=47wx=30M5-y=37x=45wN5-y=24x=65wO5-y=8wx=85O5-y=-10x=110Z5",
+    "Z1-y=1wA3-y=5wA9-y=10wB8-y=16wC7-y=23wD7-y=31wE7-y=41wF1-m13mx-5my+150wG1-m13mx+5my+152wF1-m13mx-6my+154wG1-m13mx+"
+    "6my+156wF1-m13mx-7my+159wG1-m13mx+7my+161wF1-m13mx-8my+164wG1-m13mx+8my+166wF1-m13mx-9my+169wG1-m13mx+9my+171wF1-"
+    "m13mx-10my+174wG1-m13mx+10my+176wy=54F1-m13mx-11my+179wG1-m13mx+11my+181wF1-m13mx-12my+184wG1-m13mx+12my+186wF1-"
+    "m13mx-13my+189wG1-m13mx+13my+191wF1-m13mx-14my+194wG1-m13mx+14my+197wF1-m13mx-15my+200wG1-m13mx+15my+203wF1-y="
+    "58wI5-y=61wJ5-y=62wK5-y=56wL5-y=47wM5-y=37wN5-y=24wO5-y=8wO5-y=-10Z5",
     "brwA1-brwB1-brwD1-brwE22-brwD4-brwC2-brwB2-brwA2",
     "brwA1-brwB1-brwD1-brwE22-brwD4-brwC2-brwB2-brwA2",
     "A2-B2-C2-D2-E2-F2-G2",
@@ -2357,23 +2593,34 @@ const char* test_strings[] = {
     "B8-d1B2-A8-d11A2",
     "A2000",
     "md5A2000",
-    "bps0bpd63bpn255bpp64bpb0s1sc1sdsb-100se1sf14l25sp10mp101mn30m16mx118my125A10-bps0bpd63bpn255bpp64A10-bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0B10-B10-B5000",
-    "bps0bpd63bpn255bpp64bpb0s1sc2sdl35sb-30se30sf7sp11mp101mn30m16mx146my125A10-bps0bpd63bpn255bpp64A10-bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0B10-B10-B5000",
-    "bps0bpd63bpn255bpp64bpb0s1sc3sdl50sb30se-30sp12mp101mn30m16mx174my125A10-bps0bpd63bpn255bpp64A10-bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0B10-B10-B5000",
-    "bps0bpd63bpn255bpp64bpb0s1sc4sdl63sb100se-100sf-7sp13mp101mn30m16mx202my125A10-bps0bpd63bpn255bpp64A10-bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0m17mp100mn30my0B30-smo2B100-B5000",
+    "bps0bpd63bpn255bpp64bpb0s1sc1sdsb-100se1sf14l25sp10mp101mn30m16mx118my125A10-bps0bpd63bpn255bpp64A10-"
+    "bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0B10-B10-B5000",
+    "bps0bpd63bpn255bpp64bpb0s1sc2sdl35sb-30se30sf7sp11mp101mn30m16mx146my125A10-bps0bpd63bpn255bpp64A10-"
+    "bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0B10-B10-B5000",
+    "bps0bpd63bpn255bpp64bpb0s1sc3sdl50sb30se-30sp12mp101mn30m16mx174my125A10-bps0bpd63bpn255bpp64A10-"
+    "bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0B10-B10-B5000",
+    "bps0bpd63bpn255bpp64bpb0s1sc4sdl63sb100se-100sf-7sp13mp101mn30m16mx202my125A10-bps0bpd63bpn255bpp64A10-"
+    "bps0bpd63bpn255bpp0bpb64A10-bps0bpd0bpn255bpp0m17mp100mn30my0B30-smo2B100-B5000",
     "md6Z10-A200-m11mp100mn10A10-A40-m12mp100mn10A10-A40-m13mp100mn10A10-A40-m14mp100mn10A10-A40-A5000",
     "mn30brH10-brE10-brC10-brA22-brB18-brC14-brD12-brE10-brF10-brG10-brH10-brI10-brJ10",
     "x=-250Z120-x=-250brA10-brA150-x=250brA10-Z10",
-    "Z10-bps0bpd63bpn255bpp64bpb0s1sdsc1l60sp10rB10-bps0bpd63bpn144bpp64m5mp100mn10rB10-bps0bpd63bpn144bpp0bpb64rB10-bps0bpd0bpn144bpp0Z10-Z400-bps0bpd63bpn144bpp64bpb0s1sc1sdl60sp10A10-bps0bpd63bpn144bpp64m6mp100mn10md5A10-bps0bpd63bpn144bpp0bpb64A10-bps0bpd0bpn144bpp0Z400-bps0bpd63bpn144bpp64bpb0s1sdsc1l60sp10m15mp100mn1B10-bps0bpd63bpn255bpp64B10-bps0bpd63bpn255bpp0bpb64B10-bps0bpd0bpn255bpp0Z10-Z1600",
-    "A25-B22-C20-D18-E20-F22-G25-H27-I30-H25-G22-F25-G22-H25-I30-H27-G25-F22-E20-D22-C25-B27-A22-B20-C20-D25-C22-B22-A25-d1A25",
-    "H27-I30-H25-G22-F25-G22-H25-I30-H27-G25-F22-E20-D22-C25-B27-A22-B20-C20-D25-C22-B22-A25-A15-B22-C20-D18-E20-F22-G25-d1G25",
+    "Z10-bps0bpd63bpn255bpp64bpb0s1sdsc1l60sp10rB10-bps0bpd63bpn144bpp64m5mp100mn10rB10-bps0bpd63bpn144bpp0bpb64rB10-"
+    "bps0bpd0bpn144bpp0Z10-Z400-bps0bpd63bpn144bpp64bpb0s1sc1sdl60sp10A10-bps0bpd63bpn144bpp64m6mp100mn10md5A10-"
+    "bps0bpd63bpn144bpp0bpb64A10-bps0bpd0bpn144bpp0Z400-bps0bpd63bpn144bpp64bpb0s1sdsc1l60sp10m15mp100mn1B10-"
+    "bps0bpd63bpn255bpp64B10-bps0bpd63bpn255bpp0bpb64B10-bps0bpd0bpn255bpp0Z10-Z1600",
+    "A25-B22-C20-D18-E20-F22-G25-H27-I30-H25-G22-F25-G22-H25-I30-H27-G25-F22-E20-D22-C25-B27-A22-B20-C20-D25-C22-B22-"
+    "A25-d1A25",
+    "H27-I30-H25-G22-F25-G22-H25-I30-H27-G25-F22-E20-D22-C25-B27-A22-B20-C20-D25-C22-B22-A25-A15-B22-C20-D18-E20-F22-"
+    "G25-d1G25",
     "d1A100",
     "A1-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1",
     "A1-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1",
     "A1-B1-C1-D1-E1-F1-G1-H1-I1-J1-K1-L1",
     "mn1brC4-brB6-brA9-brB6-brC4-Z10-brC2-brB5-brA6-brB2-brC1-Z18-brC4-brB5-bfC3",
-    "mn10A70-B60-m6mp100A10-A100-B40-m6mp100A30-B200-D40-C20-D20-m6mp100B10-B50-A100-D40-C30-D20-C70-D20-m6mp100B10-B50-A70-D20-C100-D40-d1C100",
-    "x=70B40-A120-B60-x=70C45-D45-E45-D45-C45-x=48D45-B78-A100-B40-x=48D45-E45-D45-C45-D45-E45-D45-x=18C60-rF160-rB200-rA40-x=18rD45-rE45-rD45-rC45-rD45-rx=45rF100-rB150-rF50-rB100-rA50-rx=45D45-rE45-rD45-rC45-x=70E45-d1rD100",
+    "mn10A70-B60-m6mp100A10-A100-B40-m6mp100A30-B200-D40-C20-D20-m6mp100B10-B50-A100-D40-C30-D20-C70-D20-m6mp100B10-"
+    "B50-A70-D20-C100-D40-d1C100",
+    "x=70B40-A120-B60-x=70C45-D45-E45-D45-C45-x=48D45-B78-A100-B40-x=48D45-E45-D45-C45-D45-E45-D45-x=18C60-rF160-rB200-"
+    "rA40-x=18rD45-rE45-rD45-rC45-rD45-rx=45rF100-rB150-rF50-rB100-rA50-rx=45D45-rE45-rD45-rC45-x=70E45-d1rD100",
     "mn1brC4-brB6-brA9-brB6-brC4-Z10-brC2-brB5-brA6-brB2-brC1-Z18-brC4-brB5-bfC3",
     "A1000-d1A100",
     "A1-B1-C1-D1-E1-F1",
@@ -2404,7 +2651,8 @@ const char* test_strings[] = {
     "mn1A20-B20-C20-D20-E20-F20-G20-H20-I20-J20-K20-L20-M20-N20-O20-P20-Q20-R20-S20-T20-m5mn1mp100Z10-d2000Z5000",
     "mn1A20-B20-C20-D20-E20-F20-G20-H20-I20-J20-K20-L20-M20-N20-O20-P20-Q20-R20-S20-T20-d2000Z5000",
     "Z120-A20-B20-C18-D15-E14-F13-G12-H12-I11-J11-K12-L12-m3mp100Z10-d1000Z1000",
-    "x=240A80-x=220A20-x=200A20-x=180A20-x=160A24-x=140A30-x=120A40-x=100A55-x=80A75-x=60A100-x=40A140-x=20A200-x=1A10-d1000A3000",
+    "x=240A80-x=220A20-x=200A20-x=180A20-x=160A24-x=140A30-x=120A40-x=100A55-x=80A75-x=60A100-x=40A140-x=20A200-x=1A10-"
+    "d1000A3000",
     "U12-T12-S12-R12-Q12-P12-O12-N12-M12-L12-K12-J12-I12-H12-G12-F12-E12-D12-C12-B12-A12-d1Z100",
     "Z10-bps0bpd0bpn255bpp0bpb64Z90",
     "A10",
@@ -2419,13 +2667,18 @@ const char* test_strings[] = {
     "U12-T12-S12-R12-Q12-P12-O12-N12-M12-L12-K12-J12-I12-H12-G12-F12-E12-D12-C12-B12-A12-d1Z100",
     "U12-T12-S12-R12-Q12-P12-O12-N12-M12-L12-K12-J12-I12-H12-G12-F12-E12-D12-C12-B12-A12-d1Z100",
     "Z10-bps0bpd0bpn255bpp0bpb64Z100-Z4000-d2000Z40",
-    "bzbps96bpd191bpn96bpp20bpb0s23l60sp10A5-bzbps96bpd191bpn96bpp20A10-bzbps96bpd191bpn96bpp0bpb20Z5-bps96bpd0bpn96bpp0Z10",
-    "Z100-bzbps1bpd191bpn95bpp50bpb0s23l60sp10Z5-bzbps1bpd191bpn95bpp50Z10-bzbps1bpd191bpn95bpp0bpb50Z5-bps1bpd191bpn95bpp0Z10",
+    "bzbps96bpd191bpn96bpp20bpb0s23l60sp10A5-bzbps96bpd191bpn96bpp20A10-bzbps96bpd191bpn96bpp0bpb20Z5-"
+    "bps96bpd0bpn96bpp0Z10",
+    "Z100-bzbps1bpd191bpn95bpp50bpb0s23l60sp10Z5-bzbps1bpd191bpn95bpp50Z10-bzbps1bpd191bpn95bpp0bpb50Z5-"
+    "bps1bpd191bpn95bpp0Z10",
     "A140-B14-C16-D25-E20-d1000F2000",
     "A35-B20-C120-D20-E20-d500F5000",
     "A140-B14-C16-D25-E20-d1000F2000",
     "A12-B12-C15-D18-E20-F22-E16-D14-C12-B10-A10-d1A20",
-    "A240-bzbps1bpd191bpn191bpp80bpb0s23l63sp10A5-bzbps1bpd191bpn191bpp80B10-bzbps1bpd191bpn191bpp0bpb80A5-bps1bpd191bpn191bpp0A10-A950-bzbps1bpd191bpn191bpp45bpb0s23l30sp10A5-bzbps1bpd191bpn191bpp45B10-bzbps1bpd191bpn191bpp0bpb45A5-bps1bpd191bpn191bpp0A10-A369-bzbps1bpd191bpn191bpp65bpb0s23l50sp10A5-bzbps1bpd191bpn191bpp65B10-bzbps1bpd191bpn191bpp0bpb65A5-bps1bpd191bpn191bpp0A10-d1A1000",
+    "A240-bzbps1bpd191bpn191bpp80bpb0s23l63sp10A5-bzbps1bpd191bpn191bpp80B10-bzbps1bpd191bpn191bpp0bpb80A5-"
+    "bps1bpd191bpn191bpp0A10-A950-bzbps1bpd191bpn191bpp45bpb0s23l30sp10A5-bzbps1bpd191bpn191bpp45B10-"
+    "bzbps1bpd191bpn191bpp0bpb45A5-bps1bpd191bpn191bpp0A10-A369-bzbps1bpd191bpn191bpp65bpb0s23l50sp10A5-"
+    "bzbps1bpd191bpn191bpp65B10-bzbps1bpd191bpn191bpp0bpb65A5-bps1bpd191bpn191bpp0A10-d1A1000",
     "A140-B14-C16-D25-E20-d1000F2000",
     "A22-B22-C22-D22-E22-d1E20",
     "A12-B12-C12-D13-E14-F15-E16-D14-C12-B10-A6-d1A20",
@@ -2461,21 +2714,58 @@ const char* test_strings[] = {
     "x=140A200-x=140A2000-x=0A200-d5000A20000",
     "d5000A20000",
     "Z10-bps0bpd0bpn255bpp1bpb64Z100-Z4000-d2000Z40",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
-    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
+    "x=170A7-x=170B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-"
+    "O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-"
+    "M7-N7-O7-P7-Q7-R7-S7-T7-A7-B7-C7-D7-E7-F7-G7-H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-x=0T7-x=0A7-x=0B7-C7-D7-E7-F7-G7-"
+    "H7-I7-J7-K7-L7-M7-N7-O7-P7-Q7-R7-S7-T7-d701T1000",
     "A1",
     "Z230-A10-B10-A8-Z120-B8-A12-B6-Z213-B9-A11-B6-d1Z999",
-    "Z50-A50-Z60-A40-B40-Z80-A50-B40-A30-B30-A50-Z40-A30-Z40-B30-Z100-A40-B20-Z80-A50-B20-A30-B50-A40-B40-A50-Z240-A50-B40-A30-B40-Z130-B40-A60-Z100-B30-A50-d1Z1000",
+    "Z50-A50-Z60-A40-B40-Z80-A50-B40-A30-B30-A50-Z40-A30-Z40-B30-Z100-A40-B20-Z80-A50-B20-A30-B50-A40-B40-A50-Z240-A50-"
+    "B40-A30-B40-Z130-B40-A60-Z100-B30-A50-d1Z1000",
     "d1A10000",
     "d1A10000",
     "A1",

--- a/testing/misc/parser_test_strings.h
+++ b/testing/misc/parser_test_strings.h
@@ -3,6 +3,6 @@
 
 #define TEST_STRING_COUNT 2490
 
-extern const char* test_strings[];
+extern const char *test_strings[];
 
 #endif // PARSER_TEST_STRINGS_H

--- a/testing/test_af.c
+++ b/testing/test_af.c
@@ -1,7 +1,7 @@
-#include <CUnit/CUnit.h>
-#include <CUnit/Basic.h>
 #include "formats/af.h"
 #include "formats/error.h"
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 
 sd_af_file af;
 
@@ -99,7 +99,13 @@ void test_af_roundtrip(void) {
 }
 
 void af_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "test of sd_af_create", test_sd_af_create) == NULL) { return; }
-    if(CU_add_test(suite, "test of AF empty roundtripping", test_af_roundtrip) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_af_free", test_sd_af_free) == NULL) { return; }
+    if(CU_add_test(suite, "test of sd_af_create", test_sd_af_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of AF empty roundtripping", test_af_roundtrip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_af_free", test_sd_af_free) == NULL) {
+        return;
+    }
 }

--- a/testing/test_array.c
+++ b/testing/test_array.c
@@ -1,9 +1,9 @@
-#include <CUnit/CUnit.h>
+#include "utils/allocator.h"
 #include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
+#include <stdlib.h>
 #include <utils/array.h>
 #include <utils/iterator.h>
-#include <stdlib.h>
-#include "utils/allocator.h"
 
 array test_array;
 void *test_ptr;
@@ -43,8 +43,16 @@ void test_array_get(void) {
 
 void array_test_suite(CU_pSuite suite) {
     // Add tests
-    if(CU_add_test(suite, "Test for array create", test_array_create) == NULL) { return; }
-    if(CU_add_test(suite, "Test for array set", test_array_set) == NULL) { return; }
-    if(CU_add_test(suite, "Test for array get", test_array_get) == NULL) { return; }
-    if(CU_add_test(suite, "Test for array free", test_array_free) == NULL) { return; }
+    if(CU_add_test(suite, "Test for array create", test_array_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for array set", test_array_set) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for array get", test_array_get) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for array free", test_array_free) == NULL) {
+        return;
+    }
 }

--- a/testing/test_bk.c
+++ b/testing/test_bk.c
@@ -1,7 +1,7 @@
-#include <CUnit/CUnit.h>
-#include <CUnit/Basic.h>
 #include "formats/bk.h"
 #include "formats/error.h"
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 
 sd_bk_file bk;
 
@@ -50,7 +50,13 @@ void test_bk_roundtrip(void) {
 }
 
 void bk_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "test of sd_bk_create", test_sd_bk_create) == NULL) { return; }
-    if(CU_add_test(suite, "test of BK empty roundtripping", test_bk_roundtrip) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_bk_free", test_sd_bk_free) == NULL) { return; }
+    if(CU_add_test(suite, "test of sd_bk_create", test_sd_bk_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of BK empty roundtripping", test_bk_roundtrip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_bk_free", test_sd_bk_free) == NULL) {
+        return;
+    }
 }

--- a/testing/test_hashmap.c
+++ b/testing/test_hashmap.c
@@ -1,8 +1,8 @@
-#include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
+#include <stdio.h>
 #include <utils/hashmap.h>
 #include <utils/iterator.h>
-#include <stdio.h>
 
 #define TEST_VAL_COUNT 1000
 
@@ -29,10 +29,10 @@ void test_hashmap_delete(void) {
     unsigned int *val;
     unsigned int vlen;
     int removed = 0;
-    for(unsigned int i = 0; i < TEST_VAL_COUNT; i+=10) {
+    for(unsigned int i = 0; i < TEST_VAL_COUNT; i += 10) {
         CU_ASSERT(hashmap_del(&test_map, &i, sizeof(int)) == 0);
         test_values[i] = 0;
-        CU_ASSERT(hashmap_get(&test_map, &i, sizeof(int), (void**)&val, &vlen) == 1);
+        CU_ASSERT(hashmap_get(&test_map, &i, sizeof(int), (void **)&val, &vlen) == 1);
         CU_ASSERT(val == NULL);
         CU_ASSERT(vlen == 0);
         removed++;
@@ -80,8 +80,8 @@ void test_hashmap_get(void) {
     unsigned int *val;
     unsigned int vlen;
 
-    for(unsigned int i = 0; i < TEST_VAL_COUNT; i ++) {
-        int ret = hashmap_get(&test_map, &i, sizeof(int), (void**)&val, &vlen);
+    for(unsigned int i = 0; i < TEST_VAL_COUNT; i++) {
+        int ret = hashmap_get(&test_map, &i, sizeof(int), (void **)&val, &vlen);
         CU_ASSERT_FATAL(ret == 0);
         CU_ASSERT(*val == test_values[i]);
         CU_ASSERT(vlen == sizeof(int));
@@ -139,7 +139,7 @@ void test_hashmap_clear(void) {
 void hashmap_test_autoresize(void) {
     hashmap_create(&test_map, 2);
 
-    hashmap_set_opts(&test_map, HASHMAP_AUTO_INC|HASHMAP_AUTO_DEC, 0.25, 0.75, 2, 8);
+    hashmap_set_opts(&test_map, HASHMAP_AUTO_INC | HASHMAP_AUTO_DEC, 0.25, 0.75, 2, 8);
     CU_ASSERT(test_map.buckets_x_max == 8);
     CU_ASSERT(test_map.buckets_x_min == 2);
     CU_ASSERT(test_map.flags & HASHMAP_AUTO_INC);
@@ -171,7 +171,6 @@ void hashmap_test_autoresize(void) {
     CU_ASSERT_DOUBLE_EQUAL(hashmap_get_pressure(&test_map), 0.5, 0.01);
     CU_ASSERT(test_map.buckets_x == 3);
 
-
     hashmap_del(&test_map, &c_key, sizeof(int));
     c_key--;
     hashmap_del(&test_map, &c_key, sizeof(int));
@@ -186,15 +185,37 @@ void hashmap_test_autoresize(void) {
 
 void hashmap_test_suite(CU_pSuite suite) {
     // Add tests
-    if(CU_add_test(suite, "Test for hashmap create", test_hashmap_create) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap insert operation", test_hashmap_insert) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap get pressure operation", test_hashmap_get_pressure) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap resize operation", test_hashmap_resize) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap get operation", test_hashmap_get) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap delete operation", test_hashmap_delete) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap iterator ", test_hashmap_iterator) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap iterator delete operation", test_hashmap_iter_del) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap clear operation", test_hashmap_clear) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap free operation", test_hashmap_free) == NULL) { return; }
-    if(CU_add_test(suite, "Test for hashmap auto resize", hashmap_test_autoresize) == NULL) { return; }
+    if(CU_add_test(suite, "Test for hashmap create", test_hashmap_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap insert operation", test_hashmap_insert) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap get pressure operation", test_hashmap_get_pressure) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap resize operation", test_hashmap_resize) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap get operation", test_hashmap_get) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap delete operation", test_hashmap_delete) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap iterator ", test_hashmap_iterator) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap iterator delete operation", test_hashmap_iter_del) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap clear operation", test_hashmap_clear) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap free operation", test_hashmap_free) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for hashmap auto resize", hashmap_test_autoresize) == NULL) {
+        return;
+    }
 }

--- a/testing/test_list.c
+++ b/testing/test_list.c
@@ -1,7 +1,7 @@
-#include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
-#include <utils/list.h>
+#include <CUnit/CUnit.h>
 #include <utils/iterator.h>
+#include <utils/list.h>
 
 list test_list;
 const char *test_str = "abcdefgh";
@@ -20,7 +20,7 @@ void test_list_free(void) {
 }
 
 void test_list_append(void) {
-    list_append(&test_list, test_str, strlen(test_str)+1);
+    list_append(&test_list, test_str, strlen(test_str) + 1);
     CU_ASSERT(test_list.size == 1);
     CU_ASSERT(test_list.first != NULL);
     CU_ASSERT(test_list.last != NULL);
@@ -28,7 +28,7 @@ void test_list_append(void) {
 }
 
 void test_list_prepend(void) {
-    list_prepend(&test_list, test_str_b, strlen(test_str_b)+1);
+    list_prepend(&test_list, test_str_b, strlen(test_str_b) + 1);
     CU_ASSERT(test_list.size == 2);
     CU_ASSERT(test_list.first != NULL);
     CU_ASSERT(test_list.last != NULL);
@@ -47,9 +47,19 @@ void test_list_get(void) {
 
 void list_test_suite(CU_pSuite suite) {
     // Add tests
-    if(CU_add_test(suite, "Test for list create", test_list_create) == NULL) { return; }
-    if(CU_add_test(suite, "Test for list append", test_list_append) == NULL) { return; }
-    if(CU_add_test(suite, "Test for list prepend", test_list_prepend) == NULL) { return; }
-    if(CU_add_test(suite, "Test for list get", test_list_get) == NULL) { return; }
-    if(CU_add_test(suite, "Test for list free", test_list_free) == NULL) { return; }
+    if(CU_add_test(suite, "Test for list create", test_list_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for list append", test_list_append) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for list prepend", test_list_prepend) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for list get", test_list_get) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for list free", test_list_free) == NULL) {
+        return;
+    }
 }

--- a/testing/test_main.c
+++ b/testing/test_main.c
@@ -1,5 +1,5 @@
-#include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 
 void af_test_suite(CU_pSuite suite);
 void bk_test_suite(CU_pSuite suite);
@@ -23,52 +23,64 @@ int main(int argc, char **argv) {
     }
 
     suite = CU_add_suite("AF files", NULL, NULL);
-    if(suite == NULL) goto end;
+    if(suite == NULL)
+        goto end;
     af_test_suite(suite);
 
     suite = CU_add_suite("BK files", NULL, NULL);
-    if(suite == NULL) goto end;
+    if(suite == NULL)
+        goto end;
     bk_test_suite(suite);
 
     suite = CU_add_suite("Palettes", NULL, NULL);
-    if(suite == NULL) goto end;
+    if(suite == NULL)
+        goto end;
     palette_test_suite(suite);
 
     suite = CU_add_suite("REC files", NULL, NULL);
-    if(suite == NULL) goto end;
+    if(suite == NULL)
+        goto end;
     rec_test_suite(suite);
 
     suite = CU_add_suite("TRN files", NULL, NULL);
-    if(suite == NULL) goto end;
+    if(suite == NULL)
+        goto end;
     trn_test_suite(suite);
 
     suite = CU_add_suite("Script", NULL, NULL);
-    if(suite == NULL) goto end;
+    if(suite == NULL)
+        goto end;
     script_test_suite(suite);
 
     // Init suites
     CU_pSuite str_suite = CU_add_suite("String", NULL, NULL);
-    if(str_suite == NULL) goto end;
+    if(str_suite == NULL)
+        goto end;
     str_test_suite(str_suite);
 
     CU_pSuite hashmap_suite = CU_add_suite("Hashmap", NULL, NULL);
-    if(hashmap_suite == NULL) goto end;
+    if(hashmap_suite == NULL)
+        goto end;
     hashmap_test_suite(hashmap_suite);
 
     CU_pSuite vector_suite = CU_add_suite("Vector", NULL, NULL);
-    if(vector_suite == NULL) goto end;
+    if(vector_suite == NULL)
+        goto end;
     vector_test_suite(vector_suite);
 
     CU_pSuite list_suite = CU_add_suite("List", NULL, NULL);
-    if(list_suite == NULL) goto end;
+    if(list_suite == NULL)
+        goto end;
     list_test_suite(list_suite);
 
     CU_pSuite array_suite = CU_add_suite("Array", NULL, NULL);
-    if(array_suite == NULL) goto end;
+    if(array_suite == NULL)
+        goto end;
     array_test_suite(array_suite);
 
     CU_pSuite text_render_suite = CU_add_suite("Text Renderer", NULL, NULL);
-    if(text_render_suite == NULL) goto end;
+    if(text_render_suite == NULL)
+        goto end;
     text_render_test_suite(text_render_suite);
 
     // Run tests
@@ -76,10 +88,10 @@ int main(int argc, char **argv) {
     CU_basic_run_tests();
 
 end:
-    if (CU_get_number_of_tests_failed() != 0)
+    if(CU_get_number_of_tests_failed() != 0)
         ret = 1;
     CU_ErrorCode cu_err = CU_get_error();
-    if (cu_err != CUE_SUCCESS) {
+    if(cu_err != CUE_SUCCESS) {
         fprintf(stderr, "CUnit error: %s\n", CU_get_error_msg());
         ret = 1;
     }

--- a/testing/test_palette.c
+++ b/testing/test_palette.c
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include <CUnit/CUnit.h>
-#include <CUnit/Basic.h>
-#include "formats/palette.h"
 #include "formats/error.h"
+#include "formats/palette.h"
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
+#include <stdio.h>
 
 #define TESTFILE "test.gpl"
 #define TESTFILE2 "test2.gpl"
@@ -19,7 +19,7 @@ void test_palette_create(void) {
     // Fill with data
     for(int i = 0; i < 256; i++) {
         pal.data[i][0] = i;
-        pal.data[i][1] = 256-i;
+        pal.data[i][1] = 256 - i;
         pal.data[i][2] = 128;
     }
 }
@@ -82,16 +82,26 @@ void test_gimp_roundtrip(void) {
     CU_ASSERT(ret == SD_SUCCESS);
 
     // Match
-    CU_ASSERT_NSTRING_EQUAL(pal.data, new.data, 256*3);
+    CU_ASSERT_NSTRING_EQUAL(pal.data, new.data, 256 * 3);
 
     // Free up
     palette_free(&new);
 }
 
 void palette_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "test of palette_create", test_palette_create) == NULL) { return; }
-    if(CU_add_test(suite, "test of palette_to_gimp_palette", test_palette_gimp_save) == NULL) { return; }
-    if(CU_add_test(suite, "test of palette_from_gimp_palette", test_palette_gimp_load) == NULL) { return; }
-    if(CU_add_test(suite, "test of palette roundtripping", test_gimp_roundtrip) == NULL) { return; }
-    if(CU_add_test(suite, "test of palette_free", test_palette_free) == NULL) { return; }
+    if(CU_add_test(suite, "test of palette_create", test_palette_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of palette_to_gimp_palette", test_palette_gimp_save) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of palette_from_gimp_palette", test_palette_gimp_load) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of palette roundtripping", test_gimp_roundtrip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of palette_free", test_palette_free) == NULL) {
+        return;
+    }
 }

--- a/testing/test_rec.c
+++ b/testing/test_rec.c
@@ -1,9 +1,9 @@
+#include "formats/error.h"
+#include "formats/rec.h"
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <CUnit/CUnit.h>
-#include <CUnit/Basic.h>
-#include "formats/rec.h"
-#include "formats/error.h"
 
 sd_rec_file rec;
 
@@ -21,9 +21,9 @@ void test_sd_rec_create(void) {
     // Set some values
     for(int i = 0; i < 10; i++) {
         sd_rec_move mv;
-        fill((char*)&mv, sizeof(sd_rec_move));
+        fill((char *)&mv, sizeof(sd_rec_move));
         mv.lookup_id = 2;
-        mv.action = SD_ACT_KICK|SD_ACT_PUNCH|SD_ACT_LEFT|SD_ACT_DOWN;
+        mv.action = SD_ACT_KICK | SD_ACT_PUNCH | SD_ACT_LEFT | SD_ACT_DOWN;
         mv.extra_data = NULL;
         sd_rec_insert_action(&rec, i, &mv);
     }
@@ -50,20 +50,15 @@ void test_rec_roundtrip(void) {
 
         if(rec.moves[i].lookup_id > 2) {
             CU_ASSERT(rec.moves[i].raw_action == loaded.moves[i].raw_action);
-            CU_ASSERT_NSTRING_EQUAL(
-                rec.moves[i].extra_data,
-                loaded.moves[i].extra_data,
-                7);
+            CU_ASSERT_NSTRING_EQUAL(rec.moves[i].extra_data, loaded.moves[i].extra_data, 7);
         } else {
             CU_ASSERT(rec.moves[i].action == loaded.moves[i].action);
         }
     }
 
     // Test pilot data
-    CU_ASSERT_NSTRING_EQUAL(
-        (char*)&rec.pilots[0], (char*)&loaded.pilots[0], sizeof(loaded.pilots[0]));
-    CU_ASSERT_NSTRING_EQUAL(
-        (char*)&rec.pilots[1], (char*)&loaded.pilots[1], sizeof(loaded.pilots[1]));
+    CU_ASSERT_NSTRING_EQUAL((char *)&rec.pilots[0], (char *)&loaded.pilots[0], sizeof(loaded.pilots[0]));
+    CU_ASSERT_NSTRING_EQUAL((char *)&rec.pilots[1], (char *)&loaded.pilots[1], sizeof(loaded.pilots[1]));
 
     // Free the loaded struct
     sd_rec_free(&loaded);
@@ -71,14 +66,21 @@ void test_rec_roundtrip(void) {
 
 void test_crystal_shirro_load(void) {
     CU_ASSERT(sd_rec_create(&rec) == SD_SUCCESS);
-    CU_ASSERT(sd_rec_load(&rec, TESTS_ROOT_DIR
-                          "/recs/crystal-shirro.rec") == SD_SUCCESS);
+    CU_ASSERT(sd_rec_load(&rec, TESTS_ROOT_DIR "/recs/crystal-shirro.rec") == SD_SUCCESS);
     sd_rec_free(&rec);
 }
 
 void rec_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "test of sd_rec_create", test_sd_rec_create) == NULL) { return; }
-    if(CU_add_test(suite, "test of REC roundtripping", test_rec_roundtrip) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_rec_free", test_sd_rec_free) == NULL) { return; }
-    if(CU_add_test(suite, "test loading crystal-shirro.rec", test_crystal_shirro_load) == NULL) { return; }
+    if(CU_add_test(suite, "test of sd_rec_create", test_sd_rec_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of REC roundtripping", test_rec_roundtrip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_rec_free", test_sd_rec_free) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test loading crystal-shirro.rec", test_crystal_shirro_load) == NULL) {
+        return;
+    }
 }

--- a/testing/test_script.c
+++ b/testing/test_script.c
@@ -1,8 +1,8 @@
-#include <CUnit/CUnit.h>
-#include <CUnit/Basic.h>
-#include "formats/script.h"
 #include "formats/error.h"
+#include "formats/script.h"
 #include "misc/parser_test_strings.h"
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 
 sd_script script;
 
@@ -91,8 +91,8 @@ void test_script_get_tag(void) {
 
 void test_script_frame_changed(void) {
     CU_ASSERT(sd_script_frame_changed(&script, -1, 0) == 1);
-    CU_ASSERT(sd_script_frame_changed(&script,  0, 0) == 0);
-    CU_ASSERT(sd_script_frame_changed(&script,  0, 1) == 0);
+    CU_ASSERT(sd_script_frame_changed(&script, 0, 0) == 0);
+    CU_ASSERT(sd_script_frame_changed(&script, 0, 1) == 0);
     CU_ASSERT(sd_script_frame_changed(&script, 143, 144) == 1);
     CU_ASSERT(sd_script_frame_changed(&script, 99, 100) == 1);
     CU_ASSERT(sd_script_frame_changed(&script, 98, 99) == 0);
@@ -193,28 +193,28 @@ void test_script_all(void) {
 }
 
 void test_next_frame_with_sprite(void) {
-    CU_ASSERT(sd_script_next_frame_with_sprite(NULL, 0, 0) == -1); // script NULL
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, -1, 0) == -1); // nonexistent frame id
+    CU_ASSERT(sd_script_next_frame_with_sprite(NULL, 0, 0) == -1);       // script NULL
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, -1, 0) == -1);   // nonexistent frame id
     CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 1000) == -1); // Tick does not exist
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 2, 0) == 2); // C
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 1, 0) == 1); // B
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 100) == -1); // A
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 3, 0) == -1); // D (does not exist)
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 0) == -1); // A, exists but should not be found
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, -1) == 0); // A, test negative tick
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 99) == -1); // A, exists but should not be found
-    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 1, 99) == 1); // B
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 2, 0) == 2);     // C
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 1, 0) == 1);     // B
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 100) == -1);  // A
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 3, 0) == -1);    // D (does not exist)
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 0) == -1);    // A, exists but should not be found
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, -1) == 0);    // A, test negative tick
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 0, 99) == -1);   // A, exists but should not be found
+    CU_ASSERT(sd_script_next_frame_with_sprite(&script, 1, 99) == 1);    // B
 }
 
 void test_next_frame_with_tag(void) {
-    CU_ASSERT(sd_script_next_frame_with_tag(NULL, "s", 0) == -1); // script NULL
-    CU_ASSERT(sd_script_next_frame_with_tag(&script, "xxx", 0) == -1); // nonexistent tag
+    CU_ASSERT(sd_script_next_frame_with_tag(NULL, "s", 0) == -1);       // script NULL
+    CU_ASSERT(sd_script_next_frame_with_tag(&script, "xxx", 0) == -1);  // nonexistent tag
     CU_ASSERT(sd_script_next_frame_with_tag(&script, "s", 1000) == -1); // tick does not exist
-    CU_ASSERT(sd_script_next_frame_with_tag(&script, "s", 0) == 1); // Should be in frame 1
-    CU_ASSERT(sd_script_next_frame_with_tag(&script, "bpd", 0) == -1); // should be in frame 0, but should not be found
-    CU_ASSERT(sd_script_next_frame_with_tag(&script, "bpd", -1) == 0); // test negative tick
-    CU_ASSERT(sd_script_next_frame_with_tag(&script, "sf", 0) == 1); // Just test any tag
-    CU_ASSERT(sd_script_next_frame_with_tag(&script, "sf", 99) == 1); // Border case 1
+    CU_ASSERT(sd_script_next_frame_with_tag(&script, "s", 0) == 1);     // Should be in frame 1
+    CU_ASSERT(sd_script_next_frame_with_tag(&script, "bpd", 0) == -1);  // should be in frame 0, but should not be found
+    CU_ASSERT(sd_script_next_frame_with_tag(&script, "bpd", -1) == 0);  // test negative tick
+    CU_ASSERT(sd_script_next_frame_with_tag(&script, "sf", 0) == 1);    // Just test any tag
+    CU_ASSERT(sd_script_next_frame_with_tag(&script, "sf", 99) == 1);   // Border case 1
     CU_ASSERT(sd_script_next_frame_with_tag(&script, "sf", 100) == -1); // Border case 2
 }
 
@@ -348,36 +348,100 @@ void test_frame_to_letter(void) {
 }
 
 void script_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "test of sd_script_create", test_script_create) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_decode", test_script_decode) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_total_ticks", test_total_ticks) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_tick_pos_at_frame", test_tick_pos_at_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_tick_len_at_frame", test_tick_len_at_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_encoded_length", test_script_encoded_length) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_encode", test_script_encode) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_frame", test_script_get_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_frame_at", test_script_get_frame_at) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_tag", test_script_get_tag) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_frame_changed", test_script_frame_changed) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_frame_index", test_script_get_frame_index) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get_frame_index_at", test_script_get_frame_index_at) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_is_last_frame", test_is_last_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_is_last_frame_at", test_is_last_frame_at) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_is_first_frame", test_is_first_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_is_first_frame_at", test_is_first_frame_at) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_isset", test_script_isset) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_get", test_script_get) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_next_frame_with_sprite", test_next_frame_with_sprite) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_next_frame_with_tag", test_next_frame_with_tag) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_set_tag", test_set_tag) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_delete_tag", test_delete_tag) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_append_frame", test_append_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_clear_tags", test_clear_tags) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_set_tick_len_at_frame", test_set_tick_len_at_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_set_sprite_at_frame", test_set_sprite_at_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_letter_to_frame", test_letter_to_frame) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_frame_to_letter", test_frame_to_letter) == NULL) { return; }
-    if(CU_add_test(suite, "testing odd tags", test_script_tag_vars) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_script_free", test_script_free) == NULL) { return; }
-    if(CU_add_test(suite, "test of all OMF strings", test_script_all) == NULL) { return; }
+    if(CU_add_test(suite, "test of sd_script_create", test_script_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_decode", test_script_decode) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_total_ticks", test_total_ticks) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_tick_pos_at_frame", test_tick_pos_at_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_tick_len_at_frame", test_tick_len_at_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_encoded_length", test_script_encoded_length) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_encode", test_script_encode) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_frame", test_script_get_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_frame_at", test_script_get_frame_at) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_tag", test_script_get_tag) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_frame_changed", test_script_frame_changed) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_frame_index", test_script_get_frame_index) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get_frame_index_at", test_script_get_frame_index_at) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_is_last_frame", test_is_last_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_is_last_frame_at", test_is_last_frame_at) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_is_first_frame", test_is_first_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_is_first_frame_at", test_is_first_frame_at) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_isset", test_script_isset) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_get", test_script_get) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_next_frame_with_sprite", test_next_frame_with_sprite) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_next_frame_with_tag", test_next_frame_with_tag) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_set_tag", test_set_tag) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_delete_tag", test_delete_tag) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_append_frame", test_append_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_clear_tags", test_clear_tags) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_set_tick_len_at_frame", test_set_tick_len_at_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_set_sprite_at_frame", test_set_sprite_at_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_letter_to_frame", test_letter_to_frame) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_frame_to_letter", test_frame_to_letter) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "testing odd tags", test_script_tag_vars) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_script_free", test_script_free) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of all OMF strings", test_script_all) == NULL) {
+        return;
+    }
 }

--- a/testing/test_str.c
+++ b/testing/test_str.c
@@ -1,5 +1,5 @@
-#include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 #include <utils/str.h>
 
 void test_str_create(void) {
@@ -87,7 +87,6 @@ void test_str_toupper(void) {
     str_free(&d);
 }
 
-
 void test_str_tolower(void) {
     str d;
     str_from_c(&d, "TEST-STRING");
@@ -141,7 +140,7 @@ void test_str_append(void) {
     CU_ASSERT(str_size(&dst) == 26);
     CU_ASSERT_PTR_NOT_NULL(dst.data);
     CU_ASSERT_NSTRING_EQUAL(dst.data, "base_string", 11);
-    CU_ASSERT_NSTRING_EQUAL(dst.data+11, "appended_string", 15);
+    CU_ASSERT_NSTRING_EQUAL(dst.data + 11, "appended_string", 15);
     CU_ASSERT(dst.data[dst.len] == 0);
     str_free(&src);
     str_free(&dst);
@@ -154,7 +153,7 @@ void test_str_append_c(void) {
     CU_ASSERT(str_size(&dst) == 26);
     CU_ASSERT_PTR_NOT_NULL(dst.data);
     CU_ASSERT_NSTRING_EQUAL(dst.data, "base_string", 11);
-    CU_ASSERT_NSTRING_EQUAL(dst.data+11, "appended_string", 15);
+    CU_ASSERT_NSTRING_EQUAL(dst.data + 11, "appended_string", 15);
     CU_ASSERT(dst.data[dst.len] == 0);
     str_free(&dst);
 }
@@ -166,7 +165,7 @@ void test_str_append_buf(void) {
     CU_ASSERT(str_size(&dst) == 26);
     CU_ASSERT_PTR_NOT_NULL(dst.data);
     CU_ASSERT_NSTRING_EQUAL(dst.data, "base_string", 11);
-    CU_ASSERT_NSTRING_EQUAL(dst.data+11, "appended_string", 15);
+    CU_ASSERT_NSTRING_EQUAL(dst.data + 11, "appended_string", 15);
     CU_ASSERT(dst.data[dst.len] == 0);
     str_free(&dst);
 }
@@ -285,33 +284,85 @@ void test_str_replace_multi_limit(void) {
 }
 
 void str_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "Test for str_create", test_str_create) == NULL) { return; }
-    if(CU_add_test(suite, "Test for string free operation", test_str_free) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_from", test_str_from) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_from_c", test_str_from_c) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_from_buf", test_str_from_buf) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_from_slice", test_str_from_slice) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_from_format", test_str_from_format) == NULL) { return; }
-    
-    if(CU_add_test(suite, "Test for str_toupper", test_str_toupper) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_tolower", test_str_tolower) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_rstrip", test_str_rstrip) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_lstrip", test_str_lstrip) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_strip", test_str_strip) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_append", test_str_append) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_append_c", test_str_append_c) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_append_buf", test_str_append_buf) == NULL) { return; }
+    if(CU_add_test(suite, "Test for str_create", test_str_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for string free operation", test_str_free) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from", test_str_from) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from_c", test_str_from_c) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from_buf", test_str_from_buf) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from_slice", test_str_from_slice) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from_format", test_str_from_format) == NULL) {
+        return;
+    }
 
-    if(CU_add_test(suite, "Test for str_replace (longer replacement)", test_str_replace_lg) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_replace (equal replacement)", test_str_replace_eq) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_replace (shorter replacement)", test_str_replace_sm) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_replace (multiple hits)", test_str_replace_multi) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_replace (multiple hits w/limit)", test_str_replace_multi_limit) == NULL) { return; }
+    if(CU_add_test(suite, "Test for str_toupper", test_str_toupper) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_tolower", test_str_tolower) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_rstrip", test_str_rstrip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_lstrip", test_str_lstrip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_strip", test_str_strip) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_append", test_str_append) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_append_c", test_str_append_c) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_append_buf", test_str_append_buf) == NULL) {
+        return;
+    }
 
-    if(CU_add_test(suite, "Test for str_first_of", test_str_first_of) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_last_of (near)", test_str_last_of_near) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_last_of (far)", test_str_last_of_far) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_equal", test_str_equal) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_equal_c", test_str_equal_c) == NULL) { return; }
-    if(CU_add_test(suite, "Test for str_equal_buf", test_str_equal_buf) == NULL) { return; }
+    if(CU_add_test(suite, "Test for str_replace (longer replacement)", test_str_replace_lg) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (equal replacement)", test_str_replace_eq) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (shorter replacement)", test_str_replace_sm) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (multiple hits)", test_str_replace_multi) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (multiple hits w/limit)", test_str_replace_multi_limit) == NULL) {
+        return;
+    }
+
+    if(CU_add_test(suite, "Test for str_first_of", test_str_first_of) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_last_of (near)", test_str_last_of_near) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_last_of (far)", test_str_last_of_far) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_equal", test_str_equal) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_equal_c", test_str_equal_c) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_equal_buf", test_str_equal_buf) == NULL) {
+        return;
+    }
 }

--- a/testing/test_text_render.c
+++ b/testing/test_text_render.c
@@ -1,15 +1,20 @@
-#include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 #include <game/gui/text_render.h>
 
 void test_text_find_max_strlen(void) {
-    CU_ASSERT(text_find_max_strlen(10, "          AAAAAAAAAA") == 20); // Space should be disregarded and only 10 accepted. Advance should be 20.
+    CU_ASSERT(text_find_max_strlen(10, "          AAAAAAAAAA") ==
+              20); // Space should be disregarded and only 10 accepted. Advance should be 20.
     CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAA") == 10); // This should go on one line
-    CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAAA") == 11); // This should go on one line, too, even though it's too long
-    CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAA BBBB") == 10); // Only first string should be taken into account (10). Space should be disregarded.
-    CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAAA BBBB") == 11); // Only first string should be taken into account (11)
+    CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAAA") ==
+              11); // This should go on one line, too, even though it's too long
+    CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAA BBBB") ==
+              10); // Only first string should be taken into account (10). Space should be disregarded.
+    CU_ASSERT(text_find_max_strlen(10, "AAAAAAAAAAA BBBB") ==
+              11);                                    // Only first string should be taken into account (11)
     CU_ASSERT(text_find_max_strlen(10, "AA\n") == 3); // Should advance 2 chars + line ending (3)
-    CU_ASSERT(text_find_max_strlen(14, "I CAN HAS CHEESEBURGER") == 9); // Should wordwrap. Skip spaces to next line. (9)
+    CU_ASSERT(text_find_max_strlen(14, "I CAN HAS CHEESEBURGER") ==
+              9); // Should wordwrap. Skip spaces to next line. (9)
 }
 
 void test_text_find_line_count(void) {
@@ -19,6 +24,10 @@ void test_text_find_line_count(void) {
 
 void text_render_test_suite(CU_pSuite suite) {
     // Add tests
-    if(CU_add_test(suite, "Test for text_find_max_strlen", test_text_find_max_strlen) == NULL) { return; }
-    if(CU_add_test(suite, "Test for text_find_line_count", test_text_find_line_count) == NULL) { return; }
+    if(CU_add_test(suite, "Test for text_find_max_strlen", test_text_find_max_strlen) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for text_find_line_count", test_text_find_line_count) == NULL) {
+        return;
+    }
 }

--- a/testing/test_trn.c
+++ b/testing/test_trn.c
@@ -1,10 +1,10 @@
+#include "formats/error.h"
+#include "formats/tournament.h"
+#include "utils/allocator.h"
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <CUnit/CUnit.h>
-#include <CUnit/Basic.h>
-#include "formats/tournament.h"
-#include "formats/error.h"
-#include "utils/allocator.h"
 
 sd_tournament_file trn;
 
@@ -14,45 +14,45 @@ void test_sd_trn_create(void) {
 }
 
 void test_sd_trn_roundtripping(void) {
-	sd_tournament_file n_trn;
-	sd_tournament_file l_trn;
+    sd_tournament_file n_trn;
+    sd_tournament_file l_trn;
 
-	CU_ASSERT(sd_tournament_create(&n_trn) == SD_SUCCESS);
-	CU_ASSERT(sd_tournament_create(&l_trn) == SD_SUCCESS);
+    CU_ASSERT(sd_tournament_create(&n_trn) == SD_SUCCESS);
+    CU_ASSERT(sd_tournament_create(&l_trn) == SD_SUCCESS);
 
-	// Set values
-	n_trn.enemy_count = 0;
-	n_trn.winnings_multiplier = 0;
-	n_trn.unknown_a = 0;
-	n_trn.registration_fee = 1000;
-	n_trn.assumed_initial_value = 2000;
-	n_trn.tournament_id = 1;
-	sd_tournament_set_bk_name(&n_trn, "test.bk");
-	sd_tournament_set_pic_name(&n_trn, "pilots.pic");
+    // Set values
+    n_trn.enemy_count = 0;
+    n_trn.winnings_multiplier = 0;
+    n_trn.unknown_a = 0;
+    n_trn.registration_fee = 1000;
+    n_trn.assumed_initial_value = 2000;
+    n_trn.tournament_id = 1;
+    sd_tournament_set_bk_name(&n_trn, "test.bk");
+    sd_tournament_set_pic_name(&n_trn, "pilots.pic");
 
-	memset(&n_trn.pal, 64, sizeof(n_trn.pal));
+    memset(&n_trn.pal, 64, sizeof(n_trn.pal));
 
-	n_trn.enemies[0] = omf_calloc(1, sizeof(sd_pilot));
-	n_trn.enemy_count = 1;
-	snprintf(n_trn.enemies[0]->name, 18, "test_pilot");
+    n_trn.enemies[0] = omf_calloc(1, sizeof(sd_pilot));
+    n_trn.enemy_count = 1;
+    snprintf(n_trn.enemies[0]->name, 18, "test_pilot");
 
-	CU_ASSERT(sd_tournament_save(&n_trn, "test.trn") == SD_SUCCESS);
-	CU_ASSERT(sd_tournament_load(&l_trn, "test.trn") == SD_SUCCESS);
+    CU_ASSERT(sd_tournament_save(&n_trn, "test.trn") == SD_SUCCESS);
+    CU_ASSERT(sd_tournament_load(&l_trn, "test.trn") == SD_SUCCESS);
 
-	CU_ASSERT(n_trn.enemy_count == l_trn.enemy_count);
-	CU_ASSERT(n_trn.winnings_multiplier == l_trn.winnings_multiplier);
-	CU_ASSERT(n_trn.unknown_a == l_trn.unknown_a);
-	CU_ASSERT(n_trn.registration_fee == l_trn.registration_fee);
-	CU_ASSERT(n_trn.assumed_initial_value == l_trn.assumed_initial_value);
-	CU_ASSERT(n_trn.tournament_id == l_trn.tournament_id);
+    CU_ASSERT(n_trn.enemy_count == l_trn.enemy_count);
+    CU_ASSERT(n_trn.winnings_multiplier == l_trn.winnings_multiplier);
+    CU_ASSERT(n_trn.unknown_a == l_trn.unknown_a);
+    CU_ASSERT(n_trn.registration_fee == l_trn.registration_fee);
+    CU_ASSERT(n_trn.assumed_initial_value == l_trn.assumed_initial_value);
+    CU_ASSERT(n_trn.tournament_id == l_trn.tournament_id);
 
-	CU_ASSERT_STRING_EQUAL(n_trn.bk_name, l_trn.bk_name);
-	CU_ASSERT_STRING_EQUAL(n_trn.pic_file, l_trn.pic_file);
+    CU_ASSERT_STRING_EQUAL(n_trn.bk_name, l_trn.bk_name);
+    CU_ASSERT_STRING_EQUAL(n_trn.pic_file, l_trn.pic_file);
 
-	CU_ASSERT_STRING_EQUAL(n_trn.enemies[0]->name, l_trn.enemies[0]->name);
+    CU_ASSERT_STRING_EQUAL(n_trn.enemies[0]->name, l_trn.enemies[0]->name);
 
-	sd_tournament_free(&n_trn);
-	sd_tournament_free(&l_trn);
+    sd_tournament_free(&n_trn);
+    sd_tournament_free(&l_trn);
 }
 
 void test_sd_trn_free(void) {
@@ -60,7 +60,13 @@ void test_sd_trn_free(void) {
 }
 
 void trn_test_suite(CU_pSuite suite) {
-    if(CU_add_test(suite, "test of sd_trn_create", test_sd_trn_create) == NULL) { return; }
-    if(CU_add_test(suite, "test roundtripping", test_sd_trn_roundtripping) == NULL) { return; }
-    if(CU_add_test(suite, "test of sd_trn_free", test_sd_trn_free) == NULL) { return; }
+    if(CU_add_test(suite, "test of sd_trn_create", test_sd_trn_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test roundtripping", test_sd_trn_roundtripping) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "test of sd_trn_free", test_sd_trn_free) == NULL) {
+        return;
+    }
 }

--- a/testing/test_vector.c
+++ b/testing/test_vector.c
@@ -1,7 +1,7 @@
-#include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
-#include <utils/vector.h>
+#include <CUnit/CUnit.h>
 #include <utils/iterator.h>
+#include <utils/vector.h>
 
 #define TEST_VAL_COUNT 1000
 
@@ -22,18 +22,18 @@ void test_vector_free(void) {
 }
 
 void test_vector_append(void) {
-    for(int i = 0; i < TEST_VAL_COUNT/2; i++) {
-        CU_ASSERT(vector_append(&test_vector, (void*)&i) == 0);
-        test_values[i] = TEST_VAL_COUNT-i;
-        CU_ASSERT(vector_size(&test_vector) == i+1);
+    for(int i = 0; i < TEST_VAL_COUNT / 2; i++) {
+        CU_ASSERT(vector_append(&test_vector, (void *)&i) == 0);
+        test_values[i] = TEST_VAL_COUNT - i;
+        CU_ASSERT(vector_size(&test_vector) == i + 1);
     }
 }
 
 void test_vector_prepend(void) {
-    for(int i = TEST_VAL_COUNT/2; i < TEST_VAL_COUNT; i++) {
-        CU_ASSERT(vector_prepend(&test_vector, (void*)&i) == 0);
-        test_values[i] = TEST_VAL_COUNT-i;
-        CU_ASSERT(vector_size(&test_vector) == i+1);
+    for(int i = TEST_VAL_COUNT / 2; i < TEST_VAL_COUNT; i++) {
+        CU_ASSERT(vector_prepend(&test_vector, (void *)&i) == 0);
+        test_values[i] = TEST_VAL_COUNT - i;
+        CU_ASSERT(vector_size(&test_vector) == i + 1);
     }
 }
 
@@ -43,7 +43,7 @@ void test_vector_get(void) {
     }
 
     // We try to fetch a too high an index; this should return NULL
-    CU_ASSERT_PTR_NULL(vector_get(&test_vector, TEST_VAL_COUNT+1));
+    CU_ASSERT_PTR_NULL(vector_get(&test_vector, TEST_VAL_COUNT + 1));
 }
 
 void test_vector_iterator(void) {
@@ -53,7 +53,7 @@ void test_vector_iterator(void) {
 
     // Read values from the vector
     while((val = iter_next(&it)) != NULL) {
-        CU_ASSERT(test_values[*val] == TEST_VAL_COUNT-*val);
+        CU_ASSERT(test_values[*val] == TEST_VAL_COUNT - *val);
         test_values[*val] = 0;
     }
 
@@ -81,11 +81,25 @@ void test_vector_delete(void) {
 
 void vector_test_suite(CU_pSuite suite) {
     // Add tests
-    if(CU_add_test(suite, "Test for vector create", test_vector_create) == NULL) { return; }
-    if(CU_add_test(suite, "Test for vector append", test_vector_append) == NULL) { return; }
-    if(CU_add_test(suite, "Test for vector prepend", test_vector_prepend) == NULL) { return; }
-    if(CU_add_test(suite, "Test for vector get", test_vector_get) == NULL) { return; }
-    if(CU_add_test(suite, "Test for vector iterator", test_vector_iterator) == NULL) { return; }
-    if(CU_add_test(suite, "Test for vector delete", test_vector_delete) == NULL) { return; }
-    if(CU_add_test(suite, "Test for vector free operation", test_vector_free) == NULL) { return; }
+    if(CU_add_test(suite, "Test for vector create", test_vector_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for vector append", test_vector_append) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for vector prepend", test_vector_prepend) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for vector get", test_vector_get) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for vector iterator", test_vector_iterator) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for vector delete", test_vector_delete) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for vector free operation", test_vector_free) == NULL) {
+        return;
+    }
 }

--- a/tools/shared/animation_misc.h
+++ b/tools/shared/animation_misc.h
@@ -6,7 +6,7 @@
 #include "formats/animation.h"
 #include "formats/bk.h"
 
-int sprite_key_get_id(const char* key);
+int sprite_key_get_id(const char *key);
 void sprite_set_key(sd_sprite *s, const char **key, int kcount, const char *value);
 void sprite_get_key(sd_sprite *s, const char **key, int kcount);
 void sprite_keylist();
@@ -16,7 +16,7 @@ void sprite_export_key(sd_sprite *s, const char **key, int kcount, const char *f
 void sprite_import_key(sd_sprite *s, const char **key, int kcount, const char *filename, int transparent_index);
 
 void anim_common_info(sd_animation *ani);
-int anim_key_get_id(const char* key);
+int anim_key_get_id(const char *key);
 void anim_get_key(sd_animation *ani, int kn, const char **key, int kcount, int pcount);
 void anim_set_key(sd_animation *ani, int kn, const char **key, int kcount, const char *value);
 void anim_keylist();

--- a/tools/shared/conversions.h
+++ b/tools/shared/conversions.h
@@ -3,12 +3,12 @@
 
 #include <stdint.h>
 
-uint8_t  conv_ubyte(const char* data);
-int8_t   conv_byte(const char* data);
-uint16_t conv_uword(const char* data);
-int16_t  conv_word(const char* data);
-uint32_t conv_udword(const char* data);
-int32_t  conv_dword(const char* data);
-float    conv_float(const char* data);
+uint8_t conv_ubyte(const char *data);
+int8_t conv_byte(const char *data);
+uint16_t conv_uword(const char *data);
+int16_t conv_word(const char *data);
+uint32_t conv_udword(const char *data);
+int32_t conv_dword(const char *data);
+float conv_float(const char *data);
 
 #endif // CONVERSIONS_H


### PR DESCRIPTION
CMake integration was not handling some things correctly, so I swapped the integration to just pure GLOB search of C and H files and then running clang-format against them. This way it does not care about what targets are enabled.