### PR TITLE
Improve clang-tidy options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,8 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-diagnostic-unused-command-line-argument'
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-diagnostic-unused-command-line-argument,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
-FormatStyle:     none
+FormatStyle: llvm
 CheckOptions:
   - key:             llvm-else-after-return.WarnOnConditionVariables
     value:           'false'

--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -334,7 +334,7 @@ int get_enemy_range(const controller *ctrl) {
     har *h = object_get_userdata(o);
     object *o_enemy = game_state_get_player(o->gs, h->player_id == 1 ? 0 : 1)->har;
 
-    int range_units = abs(o_enemy->pos.x - o->pos.x) / 30;
+    int range_units = fabsf(o_enemy->pos.x - o->pos.x) / 30;
     switch(range_units) {
         case 0:
         case 1:


### PR DESCRIPTION
This is on top of clang-format stuff.

I dropped the secure function (_s) checks, as they seem to be rather pointless, and are marked optional in the spec. Let's not bother.

Otherwise, work-in-progress. This should be expanded to also add fixes for all tidy warnings, and then set WarningsAsErrors: '*' in .clang-tidy to make sure problems crash the build. Also, set -DUSE_TIDY=1 in tests builds.