### PR TITLE
Rank loss in tournament

### DIFF
--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -11,6 +11,7 @@
 #include "controller/net_controller.h"
 #include "formats/error.h"
 #include "formats/rec.h"
+#include "formats/chr.h"
 #include "game/game_player.h"
 #include "game/game_state.h"
 #include "game/gui/filler.h"
@@ -546,7 +547,10 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
                 player_winner->pilot->money += player_loser->pilot->winnings;
                 scene_youwin_anim_start(scene->gs);
             } else {
-                scene_youlose_anim_start(scene->gs);
+               if (player_loser->pilot->rank = player_loser->pilot->enemies_ex_unranked) {
+                    player_loser->pilot->rank++;
+                   }
+               scene_youlose_anim_start(scene->gs);
             }
         }
     }

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -11,7 +11,6 @@
 #include "controller/net_controller.h"
 #include "formats/error.h"
 #include "formats/rec.h"
-#include "formats/chr.h"
 #include "game/game_player.h"
 #include "game/game_state.h"
 #include "game/gui/filler.h"
@@ -547,9 +546,8 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
                 player_winner->pilot->money += player_loser->pilot->winnings;
                 scene_youwin_anim_start(scene->gs);
             } else {
-               if (player_loser->pilot->rank = player_loser->pilot->enemies_ex_unranked) {
+               if (player_loser->pilot->rank == player_loser->pilot->enemies_ex_unranked)
                     player_loser->pilot->rank++;
-                   }
                scene_youlose_anim_start(scene->gs);
             }
         }

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -546,7 +546,7 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
                 player_winner->pilot->money += player_loser->pilot->winnings;
                 scene_youwin_anim_start(scene->gs);
             } else {
-               if (player_loser->pilot->rank == player_loser->pilot->enemies_ex_unranked)
+               if (player_loser->pilot->rank <= player_loser->pilot->enemies_ex_unranked)
                     player_loser->pilot->rank++;
                scene_youlose_anim_start(scene->gs);
             }

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -546,9 +546,9 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
                 player_winner->pilot->money += player_loser->pilot->winnings;
                 scene_youwin_anim_start(scene->gs);
             } else {
-               if (player_loser->pilot->rank <= player_loser->pilot->enemies_ex_unranked)
+                if(player_loser->pilot->rank <= player_loser->pilot->enemies_ex_unranked)
                     player_loser->pilot->rank++;
-               scene_youlose_anim_start(scene->gs);
+                scene_youlose_anim_start(scene->gs);
             }
         }
     }


### PR DESCRIPTION
This makes the player to lose a rank position in the tournament when a match is lost.
A check is added to avoid going out of the array list of ranked participants if the player loses the match while being already at the bottom of the ladder.  