### PR TITLE
resources: Free sd_tournament_file nodes in trnmanager list

### DIFF
--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -31,7 +31,7 @@ int sd_chr_from_trn(sd_chr_file *chr, sd_tournament_file *trn, sd_pilot *pilot) 
     for(int i = 0; i < trn->enemy_count; i++) {
         chr->enemies[i] = omf_calloc(1, sizeof(sd_chr_enemy));
         sd_pilot_create(&chr->enemies[i]->pilot);
-        memcpy(&chr->enemies[i]->pilot, trn->enemies[i], sizeof(sd_pilot));
+        sd_pilot_clone(&chr->enemies[i]->pilot, trn->enemies[i]);
         if(!trn->enemies[i]->secret) {
             ranked++;
             chr->enemies[i]->pilot.rank = ranked;

--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -15,6 +15,15 @@ int sd_pilot_create(sd_pilot *pilot) {
     return SD_SUCCESS;
 }
 
+void sd_pilot_clone(sd_pilot *dest, const sd_pilot *src) {
+    memcpy(dest, src, sizeof(sd_pilot));
+    for(int m = 0; m < 10; m++) {
+        if(src->quotes[m] != NULL) {
+            dest->quotes[m] = strdup(src->quotes[m]);
+        }
+    }
+}
+
 void sd_pilot_free(sd_pilot **pilot) {
     if(*pilot == NULL)
         return;

--- a/src/formats/pilot.h
+++ b/src/formats/pilot.h
@@ -133,6 +133,8 @@ typedef enum
  */
 int sd_pilot_create(sd_pilot *pilot);
 
+void sd_pilot_clone(sd_pilot *dest, const sd_pilot *src);
+
 /*! \brief Free pilot structure
  *
  * Frees up all memory reserved by the pilot structure.

--- a/src/resources/trnmanager.c
+++ b/src/resources/trnmanager.c
@@ -9,6 +9,11 @@
 #include <stdio.h>
 #include <string.h>
 
+static void trnlist_node_free_callback(void *data) {
+    sd_tournament_file *trn = data;
+    sd_tournament_free(trn);
+}
+
 list *trnlist_init(void) {
     int ret;
     list dirlist;
@@ -31,6 +36,7 @@ list *trnlist_init(void) {
 
     list *trnlist = omf_calloc(1, sizeof(list));
     list_create(trnlist);
+    list_set_node_free_cb(trnlist, trnlist_node_free_callback);
 
     iterator it;
     list_iter_begin(&dirlist, &it);


### PR DESCRIPTION
This reverts commit 9465d97a9f01f1fd706b03e094c8f67e972723ff.