### PR TITLE
Reduce RAM by deduping sprites

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1101,7 +1101,7 @@ void har_collide_with_har(object *obj_a, object *obj_b, int loop) {
 
 void har_collide_with_projectile(object *o_har, object *o_pjt) {
     har *h = object_get_userdata(o_har);
-    af *prog_owner_af_data = projectile_get_af_data(o_pjt);
+    const af *prog_owner_af_data = projectile_get_af_data(o_pjt);
     har *other = object_get_userdata(
         game_state_find_object(o_har->gs, game_state_get_player(o_har->gs, abs(h->player_id - 1))->har_obj_id));
 

--- a/src/game/objects/har.h
+++ b/src/game/objects/har.h
@@ -129,7 +129,7 @@ typedef struct har_t {
     uint8_t flinching;
     uint8_t close;
     uint8_t enqueued;
-    af *af_data;
+    const af *af_data;
     uint8_t damage_done;     // Damage was done this animation
     uint8_t damage_received; // Damage was received this animation
     uint8_t air_attacked;

--- a/src/game/objects/projectile.c
+++ b/src/game/objects/projectile.c
@@ -10,7 +10,7 @@
 
 typedef struct projectile_local_t {
     uint8_t player_id;
-    af *af_data;
+    const af *af_data;
     int wall_bounce;
     int ground_freeze;
     int invincible;
@@ -117,7 +117,7 @@ int projectile_create(object *obj, har *har) {
     return 0;
 }
 
-af *projectile_get_af_data(object *obj) {
+const af *projectile_get_af_data(object *obj) {
     return ((projectile_local *)object_get_userdata(obj))->af_data;
 }
 

--- a/src/game/objects/projectile.h
+++ b/src/game/objects/projectile.h
@@ -7,7 +7,7 @@
 typedef struct har_t har;
 
 int projectile_create(object *obj, har *har);
-af *projectile_get_af_data(object *obj);
+const af *projectile_get_af_data(object *obj);
 uint8_t projectile_get_owner(object *obj);
 void projectile_set_wall_bounce(object *obj, int bounce);
 void projectile_set_invincible(object *obj);

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -230,7 +230,7 @@ void object_render(object *obj) {
     if(obj->cur_sprite_id < 0)
         return;
 
-    sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
+    const sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
     if(cur_sprite == NULL)
         return;
 
@@ -321,7 +321,7 @@ void object_render_shadow(object *obj) {
         return;
     }
 
-    sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
+    const sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
     if(cur_sprite == NULL) {
         return;
     }
@@ -456,7 +456,7 @@ int object_clone_free(object *obj) {
  * \param obj Object handle
  * \param ptr Pointer to the STL (30 byte char array)
  */
-void object_set_stl(object *obj, char *ptr) {
+void object_set_stl(object *obj, const char *ptr) {
     obj->sound_translation_table = ptr;
 }
 
@@ -464,7 +464,7 @@ void object_set_stl(object *obj, char *ptr) {
  * \param obj Object handle
  * \return Pointer to the sound translation table
  */
-char *object_get_stl(const object *obj) {
+const char *object_get_stl(const object *obj) {
     return obj->sound_translation_table;
 }
 

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -94,7 +94,7 @@ struct object_t {
 
     animation *cur_animation;
     int cur_sprite_id;
-    char *sound_translation_table;
+    const char *sound_translation_table;
     uint8_t sprite_override; //< Tells whether cur_sprite should be kept constant regardless of anim string.
 
     // 0 if this object is not attached to any other objects
@@ -159,8 +159,8 @@ void object_set_stride(object *obj, int stride);
 void object_set_delay(object *obj, int delay);
 void object_set_playback_direction(object *obj, int dir);
 
-void object_set_stl(object *obj, char *ptr);
-char *object_get_stl(const object *obj);
+void object_set_stl(object *obj, const char *ptr);
+const char *object_get_stl(const object *obj);
 
 void object_set_animation_owner(object *obj, int owner);
 void object_set_animation(object *obj, animation *ani);

--- a/src/game/protos/scene.c
+++ b/src/game/protos/scene.c
@@ -54,24 +54,6 @@ int scene_create(scene *scene, game_state *gs, int scene_id) {
     return 0;
 }
 
-void har_fix_sprite_coords(animation *ani, int fix_x, int fix_y) {
-    iterator it;
-    sprite *s;
-    // Fix sprite positions
-    vector_iter_begin(&ani->sprites, &it);
-    while((s = iter_next(&it)) != NULL) {
-        s->pos.x += fix_x;
-        s->pos.y += fix_y;
-    }
-    // Fix collisions coordinates
-    collision_coord *c;
-    vector_iter_begin(&ani->collision_coords, &it);
-    while((c = iter_next(&it)) != NULL) {
-        c->pos.x += fix_x;
-        c->pos.y += fix_y;
-    }
-}
-
 int scene_load_har(scene *scene, int player_id) {
     game_player *player = game_state_get_player(scene->gs, player_id);
     if(scene->af_data[player_id]) {
@@ -85,9 +67,6 @@ int scene_load_har(scene *scene, int player_id) {
         PERROR("Unable to load HAR %s (%s)!", har_get_name(player->pilot->har_id), get_resource_name(resource_id));
         return 1;
     }
-
-    // Fix some coordinates on jump sprites
-    har_fix_sprite_coords(&af_get_move(scene->af_data[player_id], ANIM_JUMPING)->ani, 0, -50);
 
     DEBUG("Loaded HAR %s (%s).", har_get_name(player->pilot->har_id), get_resource_name(resource_id));
     return 0;

--- a/src/resources/af.c
+++ b/src/resources/af.c
@@ -44,17 +44,11 @@ af_move *af_get_move(const af *a, int id) {
 void af_free(af *a) {
     iterator it;
     af_move *move = NULL;
-    sprite *sprite = NULL;
     array_iter_begin(&a->moves, &it);
     while((move = array_iter_next(&it))) {
         af_move_free(move);
         omf_free(move);
     }
     array_free(&a->moves);
-    array_iter_begin(&a->sprites, &it);
-    while((sprite = array_iter_next(&it))) {
-        sprite_free(sprite);
-        omf_free(sprite);
-    }
     array_free(&a->sprites);
 }

--- a/src/resources/af.c
+++ b/src/resources/af.c
@@ -37,7 +37,7 @@ void af_create(af *a, void *src) {
     }
 }
 
-af_move *af_get_move(af *a, int id) {
+af_move *af_get_move(const af *a, int id) {
     return array_get(&a->moves, id);
 }
 

--- a/src/resources/af.c
+++ b/src/resources/af.c
@@ -1,5 +1,6 @@
 #include "formats/af.h"
 #include "resources/af.h"
+#include "resources/sprite.h"
 #include <string.h>
 
 void af_create(af *a, void *src) {
@@ -23,27 +24,37 @@ void af_create(af *a, void *src) {
     a->sound_translation_table[26] = 0;
     a->sound_translation_table[27] = 0;
 
+    array_create(&a->moves);
+    array_create(&a->sprites);
+
     // Moves
     for(int i = 0; i < 70; i++) {
         if(sdaf->moves[i] != NULL) {
-            af_move_create(&a->moves[i], (void *)sdaf->moves[i], i);
-        } else {
-            a->moves[i].id = -1;
+            af_move *move = omf_calloc(1, sizeof(af_move));
+            af_move_create(move, &a->sprites, (void *)sdaf->moves[i], i);
+            array_set(&a->moves, i, move);
         }
     }
 }
 
 af_move *af_get_move(af *a, int id) {
-    if(a->moves[id].id == -1) {
-        return NULL;
-    }
-    return &a->moves[id];
+    return array_get(&a->moves, id);
 }
 
 void af_free(af *a) {
-    for(int i = 0; i < 70; i++) {
-        if(a->moves[i].id != -1) {
-            af_move_free(&a->moves[i]);
-        }
+    iterator it;
+    af_move *move = NULL;
+    sprite *sprite = NULL;
+    array_iter_begin(&a->moves, &it);
+    while((move = array_iter_next(&it))) {
+        af_move_free(move);
+        omf_free(move);
     }
+    array_free(&a->moves);
+    array_iter_begin(&a->sprites, &it);
+    while((sprite = array_iter_next(&it))) {
+        sprite_free(sprite);
+        omf_free(sprite);
+    }
+    array_free(&a->sprites);
 }

--- a/src/resources/af.h
+++ b/src/resources/af.h
@@ -19,7 +19,7 @@ typedef struct af_t {
 } af;
 
 void af_create(af *a, void *src);
-af_move *af_get_move(af *a, int id);
+af_move *af_get_move(const af *a, int id);
 void af_free(af *a);
 
 #endif // AF_H

--- a/src/resources/af.h
+++ b/src/resources/af.h
@@ -2,6 +2,8 @@
 #define AF_H
 
 #include "resources/af_move.h"
+#include "utils/array.h"
+#include "utils/allocator.h"
 
 typedef struct af_t {
     unsigned int id;
@@ -11,7 +13,8 @@ typedef struct af_t {
     float reverse_speed;
     float jump_speed;
     float fall_speed;
-    af_move moves[70];
+    array sprites;
+    array moves;
     char sound_translation_table[30];
 } af;
 

--- a/src/resources/af.h
+++ b/src/resources/af.h
@@ -2,8 +2,8 @@
 #define AF_H
 
 #include "resources/af_move.h"
-#include "utils/array.h"
 #include "utils/allocator.h"
+#include "utils/array.h"
 
 typedef struct af_t {
     unsigned int id;

--- a/src/resources/af_move.c
+++ b/src/resources/af_move.c
@@ -18,6 +18,10 @@ void af_move_create(af_move *move, array *sprites, void *src, int id) {
     move->collision_opts = sdmv->collision_opts;
     move->extra_string_selector = sdmv->extra_string_selector;
     animation_create(&move->ani, sprites, sdmv->animation, id);
+    if(id == ANIM_JUMPING) {
+        // fixup the jump coordinates
+        animation_fixup_coordinates(&move->ani, 0, -50);
+    }
 }
 
 void af_move_free(af_move *move) {

--- a/src/resources/af_move.c
+++ b/src/resources/af_move.c
@@ -1,7 +1,7 @@
 #include "resources/af_move.h"
 #include "formats/move.h"
 
-void af_move_create(af_move *move, void *src, int id) {
+void af_move_create(af_move *move, array *sprites, void *src, int id) {
     sd_move *sdmv = (sd_move *)src;
     str_from_c(&move->move_string, sdmv->move_string);
     str_from_c(&move->footer_string, sdmv->footer_string);
@@ -17,7 +17,7 @@ void af_move_create(af_move *move, void *src, int id) {
     move->pos_constraints = sdmv->pos_constraint;
     move->collision_opts = sdmv->collision_opts;
     move->extra_string_selector = sdmv->extra_string_selector;
-    animation_create(&move->ani, sdmv->animation, id);
+    animation_create(&move->ani, sprites, sdmv->animation, id);
 }
 
 void af_move_free(af_move *move) {

--- a/src/resources/af_move.h
+++ b/src/resources/af_move.h
@@ -2,8 +2,8 @@
 #define AF_MOVE_H
 
 #include "resources/animation.h"
-#include "utils/str.h"
 #include "utils/array.h"
+#include "utils/str.h"
 
 typedef struct af_move_t {
     int id;

--- a/src/resources/af_move.h
+++ b/src/resources/af_move.h
@@ -3,6 +3,7 @@
 
 #include "resources/animation.h"
 #include "utils/str.h"
+#include "utils/array.h"
 
 typedef struct af_move_t {
     int id;
@@ -25,7 +26,7 @@ typedef struct af_move_t {
 #endif
 } af_move;
 
-void af_move_create(af_move *move, void *src, int id);
+void af_move_create(af_move *move, array *sprites, void *src, int id);
 void af_move_free(af_move *move);
 
 #endif // AF_MOVE_H

--- a/src/resources/animation.c
+++ b/src/resources/animation.c
@@ -3,6 +3,11 @@
 #include "utils/allocator.h"
 #include <stdlib.h>
 
+typedef struct sprite_reference_t {
+    sprite *sprite;
+    bool owned;
+} sprite_reference;
+
 void animation_create(animation *ani, array *sprites, void *src, int id) {
     sd_animation *sdani = (sd_animation *)src;
 
@@ -32,17 +37,29 @@ void animation_create(animation *ani, array *sprites, void *src, int id) {
     }
 
     // Handle sprites
-    vector_create_with_size(&ani->sprites, sizeof(sprite *), sdani->sprite_count);
+    vector_create_with_size(&ani->sprites, sizeof(sprite_reference), sdani->sprite_count);
     sprite *tmp_sprite;
     for(int i = 0; i < sdani->sprite_count; i++) {
         if(sdani->sprites[i]->missing) {
+            // read the right index from the sprite table
             tmp_sprite = array_get(sprites, sdani->sprites[i]->index);
-            vector_append(&ani->sprites, &tmp_sprite);
+            sprite_reference spr;
+            spr.sprite = tmp_sprite;
+            spr.owned = false;
+            vector_append(&ani->sprites, &spr);
         } else {
             tmp_sprite = omf_calloc(1, sizeof(sprite));
             sprite_create(tmp_sprite, (void *)sdani->sprites[i], i);
-            array_set(sprites, sdani->sprites[i]->index, tmp_sprite);
-            vector_append(&ani->sprites, &tmp_sprite);
+            sprite_reference spr;
+            spr.sprite = tmp_sprite;
+            spr.owned = false;
+            if(sdani->sprites[i]->index) {
+                // insert into the global sprite table
+                array_set(sprites, sdani->sprites[i]->index, tmp_sprite);
+            } else {
+                spr.owned = true;
+            }
+            vector_append(&ani->sprites, &spr);
         }
     }
 }
@@ -54,8 +71,11 @@ animation *create_animation_from_single(sprite *sp, vec2i pos) {
     str_from_c(&a->animation_string, "A9999999999");
     vector_create_with_size(&a->collision_coords, sizeof(collision_coord), 0);
     vector_create_with_size(&a->extra_strings, sizeof(str), 0);
-    vector_create_with_size(&a->sprites, sizeof(sprite *), 1);
-    vector_append(&a->sprites, sp);
+    vector_create_with_size(&a->sprites, sizeof(sprite_reference), 1);
+    sprite_reference spr;
+    spr.sprite = sp;
+    spr.owned = false;
+    vector_append(&a->sprites, &spr);
     return a;
 }
 
@@ -78,22 +98,22 @@ int animation_clone(animation *src, animation *dst) {
         str_from(&new_str, tmp_str);
         vector_append(&dst->extra_strings, &new_str);
     }
-    vector_create_with_size(&dst->sprites, sizeof(sprite), vector_size(&src->sprites));
+    vector_create_with_size(&dst->sprites, sizeof(sprite_reference), vector_size(&src->sprites));
     vector_iter_begin(&src->sprites, &it);
-    sprite **tmp_sprite = NULL;
-    while((tmp_sprite = iter_next(&it)) != NULL) {
-        vector_append(&dst->sprites, *tmp_sprite);
+    sprite_reference *spr = NULL;
+    while((spr = iter_next(&it)) != NULL) {
+        vector_append(&dst->sprites, spr);
     }
 
     return 0;
 }
 
 sprite *animation_get_sprite(animation *ani, int sprite_id) {
-    sprite **s = (sprite **)vector_get(&ani->sprites, sprite_id);
+    sprite_reference *s = (sprite_reference *)vector_get(&ani->sprites, sprite_id);
     if(s == NULL) {
         return NULL;
     }
-    return *s;
+    return s->sprite;
 }
 
 int animation_get_sprite_count(animation *ani) {
@@ -116,6 +136,15 @@ void animation_free(animation *ani) {
         str_free(tmp_str);
     }
     vector_free(&ani->extra_strings);
+
+    vector_iter_begin(&ani->sprites, &it);
+    sprite_reference *spr;
+    while((spr = iter_next(&it)) != NULL) {
+        if(spr->owned) {
+            sprite_free(spr->sprite);
+            omf_free(spr->sprite);
+        }
+    }
 
     vector_free(&ani->sprites);
 }

--- a/src/resources/animation.c
+++ b/src/resources/animation.c
@@ -5,7 +5,6 @@
 
 typedef struct sprite_reference_t {
     sprite *sprite;
-    bool owned;
 } sprite_reference;
 
 void animation_create(animation *ani, array *sprites, void *src, int id) {
@@ -42,22 +41,20 @@ void animation_create(animation *ani, array *sprites, void *src, int id) {
     for(int i = 0; i < sdani->sprite_count; i++) {
         if(sdani->sprites[i]->missing) {
             // read the right index from the sprite table
-            tmp_sprite = array_get(sprites, sdani->sprites[i]->index);
+            tmp_sprite = omf_calloc(1, sizeof(sprite));
+            sprite_create_reference(tmp_sprite, (void *)sdani->sprites[i], i,
+                                    ((sprite *)array_get(sprites, sdani->sprites[i]->index))->data);
             sprite_reference spr;
             spr.sprite = tmp_sprite;
-            spr.owned = false;
             vector_append(&ani->sprites, &spr);
         } else {
             tmp_sprite = omf_calloc(1, sizeof(sprite));
             sprite_create(tmp_sprite, (void *)sdani->sprites[i], i);
             sprite_reference spr;
             spr.sprite = tmp_sprite;
-            spr.owned = false;
             if(sdani->sprites[i]->index) {
                 // insert into the global sprite table
                 array_set(sprites, sdani->sprites[i]->index, tmp_sprite);
-            } else {
-                spr.owned = true;
             }
             vector_append(&ani->sprites, &spr);
         }
@@ -74,7 +71,6 @@ animation *create_animation_from_single(sprite *sp, vec2i pos) {
     vector_create_with_size(&a->sprites, sizeof(sprite_reference), 1);
     sprite_reference spr;
     spr.sprite = sp;
-    spr.owned = false;
     vector_append(&a->sprites, &spr);
     return a;
 }
@@ -106,6 +102,24 @@ int animation_clone(animation *src, animation *dst) {
     }
 
     return 0;
+}
+
+void animation_fixup_coordinates(animation *ani, int fix_x, int fix_y) {
+    iterator it;
+    sprite_reference *spr;
+    // Fix sprite positions
+    vector_iter_begin(&ani->sprites, &it);
+    while((spr = iter_next(&it)) != NULL) {
+        spr->sprite->pos.x += fix_x;
+        spr->sprite->pos.y += fix_y;
+    }
+    // Fix collisions coordinates
+    collision_coord *c;
+    vector_iter_begin(&ani->collision_coords, &it);
+    while((c = iter_next(&it)) != NULL) {
+        c->pos.x += fix_x;
+        c->pos.y += fix_y;
+    }
 }
 
 sprite *animation_get_sprite(animation *ani, int sprite_id) {
@@ -140,10 +154,8 @@ void animation_free(animation *ani) {
     vector_iter_begin(&ani->sprites, &it);
     sprite_reference *spr;
     while((spr = iter_next(&it)) != NULL) {
-        if(spr->owned) {
-            sprite_free(spr->sprite);
-            omf_free(spr->sprite);
-        }
+        sprite_free(spr->sprite);
+        omf_free(spr->sprite);
     }
 
     vector_free(&ani->sprites);

--- a/src/resources/animation.c
+++ b/src/resources/animation.c
@@ -32,7 +32,7 @@ void animation_create(animation *ani, array *sprites, void *src, int id) {
     }
 
     // Handle sprites
-    vector_create_with_size(&ani->sprites, sizeof(sprite), sdani->sprite_count);
+    vector_create_with_size(&ani->sprites, sizeof(sprite *), sdani->sprite_count);
     sprite *tmp_sprite;
     for(int i = 0; i < sdani->sprite_count; i++) {
         if(sdani->sprites[i]->missing) {
@@ -54,7 +54,7 @@ animation *create_animation_from_single(sprite *sp, vec2i pos) {
     str_from_c(&a->animation_string, "A9999999999");
     vector_create_with_size(&a->collision_coords, sizeof(collision_coord), 0);
     vector_create_with_size(&a->extra_strings, sizeof(str), 0);
-    vector_create_with_size(&a->sprites, sizeof(sprite), 1);
+    vector_create_with_size(&a->sprites, sizeof(sprite *), 1);
     vector_append(&a->sprites, sp);
     return a;
 }
@@ -90,7 +90,7 @@ int animation_clone(animation *src, animation *dst) {
 
 sprite *animation_get_sprite(animation *ani, int sprite_id) {
     sprite **s = (sprite **)vector_get(&ani->sprites, sprite_id);
-    if (s == NULL) {
+    if(s == NULL) {
         return NULL;
     }
     return *s;

--- a/src/resources/animation.h
+++ b/src/resources/animation.h
@@ -53,6 +53,7 @@ void animation_free(animation *ani);
 int animation_get_sprite_count(animation *ani);
 
 animation *create_animation_from_single(sprite *sp, vec2i pos);
+void animation_fixup_coordinates(animation *ani, int fix_x, int fix_y);
 
 int animation_clone(animation *src, animation *dst);
 

--- a/src/resources/animation.h
+++ b/src/resources/animation.h
@@ -2,10 +2,10 @@
 #define ANIMATION_H
 
 #include "resources/sprite.h"
+#include "utils/array.h"
 #include "utils/str.h"
 #include "utils/vec.h"
 #include "utils/vector.h"
-#include "utils/array.h"
 
 // All HARs have these predefined animations
 enum

--- a/src/resources/animation.h
+++ b/src/resources/animation.h
@@ -5,6 +5,7 @@
 #include "utils/str.h"
 #include "utils/vec.h"
 #include "utils/vector.h"
+#include "utils/array.h"
 
 // All HARs have these predefined animations
 enum
@@ -45,7 +46,7 @@ typedef struct animation_t {
     vector sprites;
 } animation;
 
-void animation_create(animation *ani, void *src, int id);
+void animation_create(animation *ani, array *sprites, void *src, int id);
 sprite *animation_get_sprite(animation *ani, int sprite_id);
 void animation_free(animation *ani);
 

--- a/src/resources/bk.c
+++ b/src/resources/bk.c
@@ -1,7 +1,6 @@
 #include "formats/bk.h"
 #include "resources/bk.h"
 #include "utils/allocator.h"
-#include "utils/log.h"
 #include <string.h>
 
 void bk_create(bk *b, void *src) {
@@ -73,12 +72,5 @@ void bk_free(bk *b) {
     }
     hashmap_free(&b->infos);
 
-    sprite *sprite = NULL;
-    array_iter_begin(&b->sprites, &it);
-    while((sprite = array_iter_next(&it))) {
-        DEBUG("freeing sprite");
-        sprite_free(sprite);
-        omf_free(sprite);
-    }
     array_free(&b->sprites);
 }

--- a/src/resources/bk.c
+++ b/src/resources/bk.c
@@ -81,5 +81,4 @@ void bk_free(bk *b) {
         omf_free(sprite);
     }
     array_free(&b->sprites);
-
 }

--- a/src/resources/bk.h
+++ b/src/resources/bk.h
@@ -2,9 +2,9 @@
 #define BK_H
 
 #include "resources/bk_info.h"
+#include "utils/array.h"
 #include "utils/hashmap.h"
 #include "utils/vector.h"
-#include "utils/array.h"
 
 typedef struct bk_t {
     int file_id;

--- a/src/resources/bk.h
+++ b/src/resources/bk.h
@@ -4,12 +4,14 @@
 #include "resources/bk_info.h"
 #include "utils/hashmap.h"
 #include "utils/vector.h"
+#include "utils/array.h"
 
 typedef struct bk_t {
     int file_id;
     surface background;
     hashmap infos;
     vector palettes;
+    array sprites;
     char sound_translation_table[30];
 } bk;
 

--- a/src/resources/bk_info.c
+++ b/src/resources/bk_info.c
@@ -1,9 +1,9 @@
 #include "resources/bk_info.h"
 #include "formats/bkanim.h"
 
-void bk_info_create(bk_info *info, void *src, int id) {
+void bk_info_create(bk_info *info, array *sprites, void *src, int id) {
     sd_bk_anim *sdinfo = (sd_bk_anim *)src;
-    animation_create(&info->ani, sdinfo->animation, id);
+    animation_create(&info->ani, sprites, sdinfo->animation, id);
     info->chain_hit = sdinfo->chain_hit;
     info->chain_no_hit = sdinfo->chain_no_hit;
     info->load_on_start = sdinfo->load_on_start;

--- a/src/resources/bk_info.h
+++ b/src/resources/bk_info.h
@@ -13,7 +13,7 @@ typedef struct bk_info_t {
     animation ani;
 } bk_info;
 
-void bk_info_create(bk_info *info, void *src, int id);
+void bk_info_create(bk_info *info, array *sprites, void *src, int id);
 void bk_info_free(bk_info *info);
 
 #endif // BK_INFO_H

--- a/src/resources/sprite.c
+++ b/src/resources/sprite.c
@@ -15,6 +15,7 @@ void sprite_create(sprite *sp, void *src, int id) {
     sp->id = id;
     sp->pos = vec2i_create(sdsprite->pos_x, sdsprite->pos_y);
     sp->data = omf_calloc(1, sizeof(surface));
+    sp->owned = true;
 
     // Load data
     sd_vga_image raw;
@@ -22,6 +23,14 @@ void sprite_create(sprite *sp, void *src, int id) {
     surface_create_from_data(sp->data, raw.w, raw.h, (unsigned char *)raw.data);
     memcpy(sp->data->stencil, raw.stencil, raw.w * raw.h);
     sd_vga_image_free(&raw);
+}
+
+void sprite_create_reference(sprite *sp, void *src, int id, void *data) {
+    sd_sprite *sdsprite = (sd_sprite *)src;
+    sp->id = id;
+    sp->pos = vec2i_create(sdsprite->pos_x, sdsprite->pos_y);
+    sp->data = data;
+    sp->owned = false;
 }
 
 int sprite_clone(sprite *src, sprite *dst) {
@@ -32,8 +41,10 @@ int sprite_clone(sprite *src, sprite *dst) {
 }
 
 void sprite_free(sprite *sp) {
-    surface_free(sp->data);
-    omf_free(sp->data);
+    if(sp->owned) {
+        surface_free(sp->data);
+        omf_free(sp->data);
+    }
 }
 
 vec2i sprite_get_size(sprite *sp) {

--- a/src/resources/sprite.h
+++ b/src/resources/sprite.h
@@ -8,7 +8,7 @@ typedef struct sprite_t {
     int id;
     vec2i pos;
     surface *data;
-    bool owned;
+    bool owned; // if we own the surface data
 } sprite;
 
 void sprite_create(sprite *sp, void *src, int id);

--- a/src/resources/sprite.h
+++ b/src/resources/sprite.h
@@ -8,10 +8,12 @@ typedef struct sprite_t {
     int id;
     vec2i pos;
     surface *data;
+    bool owned;
 } sprite;
 
 void sprite_create(sprite *sp, void *src, int id);
 void sprite_create_custom(sprite *sp, vec2i pos, surface *sur);
+void sprite_create_reference(sprite *sp, void *src, int id, void *data);
 int sprite_clone(sprite *src, sprite *dst);
 void sprite_free(sprite *sp);
 

--- a/src/utils/array.c
+++ b/src/utils/array.c
@@ -39,7 +39,7 @@ void array_set(array *array, unsigned int key, const void *ptr) {
 }
 
 void *array_get(const array *array, unsigned int key) {
-    if(key > array->allocated_size) {
+    if(key >= array->allocated_size) {
         return NULL;
     }
     return array->data[key];

--- a/src/utils/array.h
+++ b/src/utils/array.h
@@ -15,6 +15,8 @@ void array_set(array *array, unsigned int key, const void *ptr);
 void *array_get(const array *array, unsigned int key);
 
 void array_iter_begin(const array *array, iterator *iterator);
+void *array_iter_next(iterator *iter);
+void *array_iter_prev(iterator *iter);
 void array_iter_end(const array *arrat, iterator *iterator);
 
 #endif // ARRAY_H


### PR DESCRIPTION
This attempts to preserve the deduping of sprites in the AF files when loading them into the game.

This branch appears to save about 1.2mb of sprites.

However, this branch seems to also cause some weird leaks, and some crashes when HARs jump, so it needs more work.