### PR TITLE
Fix MSVC Compilation

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -66,6 +66,42 @@ jobs:
         cd build-test
         make test ARGS="-V"
 
+  # Build msvc binary, to ensure it doesn't regress.
+  # -----------------------------------------------------------------------------------------------
+  check_msvc:
+    needs: [unittest, formatting-check]
+
+    name: Check Windows MSVC build
+    runs-on: windows-latest
+
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+    steps:
+    - name: Export Github Actions cache environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    - uses: actions/checkout@v4
+    - name: Check out VCPKG
+      # must be checked out *after* openomf.git
+      uses: actions/checkout@v4
+      with:
+        repository: 'microsoft/vcpkg'
+        path: 'vcpkg'
+    - uses: lukka/get-cmake@latest
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Install VCPKG Dependencies, Configure CMake
+      run: >
+        cmake -S . -B build-msvc
+        -G "Ninja Multi-Config"
+        --toolchain vcpkg/scripts/buildsystems/vcpkg.cmake
+        -DVCPKG_BUILD_TYPE="debug" # skip release deps
+    - name: Build openomf
+      run: cmake --build build-msvc --config Debug --target openomf
+
   # Build ubuntu package, release artifact and update "latest" release if necessary.
   # -----------------------------------------------------------------------------------------------
   build_ubuntu:
@@ -277,7 +313,7 @@ jobs:
   # Create a "latest" release
   # -----------------------------------------------------------------------------------------------
   make_release:
-    needs: [build_windows, build_macos-arm, build_ubuntu]
+    needs: [build_windows, build_macos-arm, build_ubuntu, check_msvc]
     if: github.ref == 'refs/heads/master'
 
     name: Make "latest" release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,9 +114,9 @@ if(MINGW)
     set(CORELIBS mingw32 ${CORELIBS})
 endif()
 
-# On windows, add winsock2 and winmm
+# On windows, add winsock2, winmm, and shlwapi
 if(WIN32)
-    set(CORELIBS ${CORELIBS} ws2_32 winmm)
+    set(CORELIBS ${CORELIBS} ws2_32 winmm shlwapi)
 endif()
 
 # On unix platforms, add libm (sometimes needed, it seems)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,19 +243,17 @@ else()
     message(STATUS "Development: Asan and Ubsan disabled")
 endif()
 
-if(MINGW)
-    # Don't show console on mingw in release builds (but enable if debug mode)
-    if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-        set_target_properties(openomf PROPERTIES LINK_FLAGS "-mwindows")
-    else()
-        set_target_properties(openomf PROPERTIES LINK_FLAGS "-mconsole")
-    endif()
+if(WIN32)
+    # Don't show console in windows release builds (but enable if debug mode)
+    set_target_properties(openomf PROPERTIES WIN32_EXECUTABLE "$<IF:$<CONFIG:Debug>,OFF,ON>")
 
     # Make sure console apps are always in terminal output mode.
     foreach(TARGET ${TOOL_TARGET_NAMES})
-        set_target_properties(${TARGET} PROPERTIES LINK_FLAGS "-mconsole")
+        set_target_properties(${TARGET} PROPERTIES WIN32_EXECUTABLE OFF)
     endforeach()
+endif()
 
+if(MINGW)
     # Use static libgcc when on mingw
     target_link_options(openomf PRIVATE -static-libgcc)
     foreach(TARGET ${TOOL_TARGET_NAMES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ OPTION(USE_FORMAT "Use clang-format for checks" OFF)
 
 # These flags are used for all builds
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat -pedantic -Wvla")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -DDEBUGMODE -Werror -fno-omit-frame-pointer")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g -O2 -fno-omit-frame-pointer -DNDEBUG")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -DNDEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,18 @@ OPTION(USE_FORMAT "Use clang-format for checks" OFF)
 
 # These flags are used for all builds
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat -pedantic -Wvla")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -DDEBUGMODE -Werror -fno-omit-frame-pointer")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g -O2 -fno-omit-frame-pointer -DNDEBUG")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -DNDEBUG")
-set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Os -DNDEBUG")
+if(MSVC)
+    # remove cmake's default /W3 to avoid warning D9025
+    string(REGEX REPLACE "/W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    # we would probably like to pass /Wall instead of /W4, but there's a lot
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat -pedantic -Wvla")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -DDEBUGMODE -Werror -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g -O2 -fno-omit-frame-pointer -DNDEBUG")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -DNDEBUG")
+    set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Os -DNDEBUG")
+endif()
 add_definitions(-DV_MAJOR=${VERSION_MAJOR} -DV_MINOR=${VERSION_MINOR} -DV_PATCH=${VERSION_PATCH})
 
 # See if we have Git, and use it to fetch current SHA1 hash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ endif()
 
 # Build the game binary
 add_executable(openomf src/main.c src/engine.c ${ICON_RESOURCE})
+set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT openomf)
 
 # This is used to copy shader files from source directory to the binary output directory during compile.
 add_custom_target(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(GIT_FOUND)
     add_definitions(-DSHA1_HASH="${SHA1_HASH}")
 endif()
 
+if(WIN32)
+    add_definitions(-DWIN32_LEAN_AND_MEAN)
+endif()
+
 # System packages (hard dependencies)
 find_package(SDL2 REQUIRED)
 find_package(SDL2_mixer REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 endif()
 
 # Find OpenOMF core sources
-file(GLOB_RECURSE OPENOMF_SRC RELATIVE ${CMAKE_SOURCE_DIR} "src/*/*.c")
+file(GLOB_RECURSE OPENOMF_SRC RELATIVE ${CMAKE_SOURCE_DIR} "src/*/*.c" "src/*/*.h")
 
 set(COREINCS
     src

--- a/cmake-scripts/FindSDL2.cmake
+++ b/cmake-scripts/FindSDL2.cmake
@@ -145,6 +145,27 @@ This needed to change because "proper" SDL convention is #include
 because not all systems place things in SDL/ (see FreeBSD).
 #]=======================================================================]
 
+if(VCPKG_TOOLCHAIN)
+  if(TARGET SDL2::Main)
+    return()
+  endif()
+  find_package(SDL2 CONFIG)
+  if(SDL2_FOUND)
+    if(TARGET SDL2::SDL2)
+      set(SDL2_LIBRARIES SDL2::SDL2)
+    else()
+      set(SDL2_LIBRARIES SDL2::SDL2-static)
+    endif()
+    get_target_property(SDL2_INCLUDE_DIR "${SDL2_LIBRARIES}" INTERFACE_INCLUDE_DIRECTORIES)
+    add_library(SDL2::Main INTERFACE IMPORTED)
+    target_link_libraries(SDL2::Main INTERFACE
+      SDL2::SDL2main
+      "${SDL2_LIBRARIES}"
+    )
+    return()
+  endif(SDL2_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 # Define options for searching SDL2 Library in a custom path
 
 set(SDL2_PATH "" CACHE STRING "Custom SDL2 Library path")

--- a/cmake-scripts/FindSDL2_mixer.cmake
+++ b/cmake-scripts/FindSDL2_mixer.cmake
@@ -123,6 +123,21 @@ if (NOT SDL2_FOUND)
     unset(SDL2_MIXER_SDL2_NOT_FOUND)
 endif ()
 
+if(VCPKG_TOOLCHAIN)
+    find_package(SDL2_mixer CONFIG)
+    if(SDL2_mixer_FOUND)
+        set(SDL2_MIXER_FOUND TRUE)
+        if(TARGET SDL2_mixer::SDL2_mixer)
+            add_library(SDL2::Mixer ALIAS SDL2_mixer::SDL2_mixer)
+            get_target_property(SDL2_MIXER_INCLUDE_DIRS SDL2_mixer::SDL2_mixer INTERFACE_INCLUDE_DIRECTORIES)
+        else()
+            add_library(SDL2::Mixer ALIAS SDL2_mixer::SDL2_mixer-static)
+            get_target_property(SDL2_MIXER_INCLUDE_DIRS SDL2_mixer::SDL2_mixer-static INTERFACE_INCLUDE_DIRECTORIES)
+        endif()
+        return()
+    endif(SDL2_mixer_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 
 # Define options for searching SDL2_mixer Library in a custom path
 

--- a/cmake-scripts/Findargtable2.cmake
+++ b/cmake-scripts/Findargtable2.cmake
@@ -1,3 +1,17 @@
+if(VCPKG_TOOLCHAIN)
+    find_package(Argtable2 CONFIG)
+    if(Argtable2_FOUND)
+        set(ARGTABLE2_FOUND ON)
+        set(ARGTABLE2_LIBRARY argtable2::argtable2)
+        set(ARGTABLE2_INCLUDE_DIR)
+        set(ARGTABLE2_INCLUDE_DIRS)
+        set(ARGTABLE2_LIBRARIES ${ARGTABLE2_LIBRARY})
+
+        mark_as_advanced(ARGTABLE2_INCLUDE_DIR ARGTABLE2_LIBRARY)
+        return()
+    endif(Argtable2_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 set(ARGTABLE2_SEARCH_PATHS
     /usr/local
     /usr

--- a/cmake-scripts/Findargtable3.cmake
+++ b/cmake-scripts/Findargtable3.cmake
@@ -1,3 +1,17 @@
+if(VCPKG_TOOLCHAIN)
+    find_package(Argtable3 CONFIG)
+    if(Argtable3_FOUND)
+        set(ARGTABLE3_FOUND ON)
+        set(ARGTABLE3_LIBRARY argtable3::argtable3)
+        set(ARGTABLE3_INCLUDE_DIR)
+        set(ARGTABLE3_INCLUDE_DIRS)
+        set(ARGTABLE3_LIBRARIES ${ARGTABLE3_LIBRARY})
+
+        mark_as_advanced(ARGTABLE3_INCLUDE_DIR ARGTABLE3_LIBRARY)
+        return()
+    endif(Argtable3_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 set(ARGTABLE3_SEARCH_PATHS
     /usr/local
     /usr

--- a/cmake-scripts/Findconfuse.cmake
+++ b/cmake-scripts/Findconfuse.cmake
@@ -1,4 +1,15 @@
 
+if(VCPKG_TOOLCHAIN)
+    find_package(unofficial-libconfuse CONFIG)
+    if(unofficial-libconfuse_FOUND)
+        get_target_property(CONFUSE_INCLUDE_DIR unofficial::libconfuse::libconfuse INTERFACE_INCLUDE_DIRECTORIES)
+        set(CONFUSE_LIBRARY unofficial::libconfuse::libconfuse)
+
+        mark_as_advanced(CONFUSE_INCLUDE_DIR CONFUSE_LIBRARY)
+        return()
+    endif(unofficial-libconfuse_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 SET(CONFUSE_SEARCH_PATHS
     /usr/local/
     /usr

--- a/cmake-scripts/Findxmp.cmake
+++ b/cmake-scripts/Findxmp.cmake
@@ -1,4 +1,20 @@
 
+if(VCPKG_TOOLCHAIN)
+    find_package(libxmp CONFIG)
+    if(libxmp_FOUND)
+        if(TARGET libxmp::xmp_shared)
+            set(XMP_LIBRARY libxmp::xmp_shared)
+        else()
+            set(XMP_LIBRARY libxmp::xmp_static)
+        endif()
+
+        get_target_property(XMP_INCLUDE_DIR "${XMP_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES)
+
+        mark_as_advanced(XMP_INCLUDE_DIR XMP_LIBRARY)
+        return()
+    endif()
+endif()
+
 SET(XMP_SEARCH_PATHS
     /usr/local/
     /usr

--- a/src/console/console.c
+++ b/src/console/console.c
@@ -69,7 +69,7 @@ void console_handle_line(game_state *gs) {
         memcpy(input_copy, con->input, sizeof(con->input));
         int argc = make_argv(con->input, NULL);
         if(argc > 0) {
-            char *argv[argc];
+            char **argv = omf_calloc(argc, sizeof(char *));
             void *val = 0;
             unsigned int len;
             make_argv(con->input, argv);
@@ -94,6 +94,7 @@ void console_handle_line(game_state *gs) {
                 console_output_add(argv[0]);
                 console_output_addline(" NOT RECOGNIZED");
             }
+            omf_free(argv);
         } else {
             console_output_addline(">");
         }

--- a/src/console/console_cmd.c
+++ b/src/console/console_cmd.c
@@ -27,13 +27,12 @@ int sort_command_by_name(const void *a, const void *b) {
 int console_cmd_history(game_state *gs, int argc, char **argv) {
     iterator it;
     char *input;
-    int input_len = sizeof(con->input);
-    char buf[input_len];
+    char buf[sizeof con->input];
     int i = 1;
 
     list_iter_begin(&con->history, &it);
     while((input = iter_next(&it)) != NULL) {
-        snprintf(buf, input_len, "%d. %s", i, input);
+        snprintf(buf, sizeof buf, "%d. %s", i, input);
         console_output_addline(buf);
         i++;
     }

--- a/src/formats/bk.c
+++ b/src/formats/bk.c
@@ -1,6 +1,6 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "formats/animation.h"
 #include "formats/bk.h"
@@ -253,7 +253,7 @@ int sd_bk_save(const sd_bk_file *bk, const char *filename) {
     return SD_SUCCESS;
 
 error:
-    unlink(filename);
+    remove(filename);
     sd_writer_close(w);
     return SD_FILE_WRITE_ERROR;
 }

--- a/src/formats/bk.c
+++ b/src/formats/bk.c
@@ -97,7 +97,7 @@ int sd_bk_load(sd_bk_file *bk, const char *filename) {
     int ret = SD_SUCCESS;
 
     size_t fn_len = strlen(filename);
-    if(fn_len >= 4 && strncasecmp(&filename[fn_len - 4], ".PCX", 4) == 0) {
+    if(fn_len >= 4 && strncmp(&filename[fn_len - 4], ".PCX", 4) == 0) {
         return sd_bk_load_from_pcx(bk, filename);
     }
 

--- a/src/formats/internal/reader.c
+++ b/src/formats/internal/reader.c
@@ -186,10 +186,12 @@ float sd_peek_float(sd_reader *reader) {
 }
 
 int sd_match(sd_reader *reader, const char *buf, unsigned int nbytes) {
-    char t[nbytes];
+    char *t = omf_malloc(nbytes);
     if(sd_peek_buf(reader, t, nbytes) == 0 && memcmp(t, buf, nbytes) == 0) {
+        omf_free(t);
         return 1;
     }
+    omf_free(t);
     return 0;
 }
 

--- a/src/formats/language.c
+++ b/src/formats/language.c
@@ -55,7 +55,7 @@ int sd_language_load(sd_language *language, const char *filename) {
 
     // Some variables etc.
     unsigned int offset = 0;
-    unsigned int offsets[string_count + 1];
+    unsigned int *offsets = omf_calloc(string_count + 1, sizeof(unsigned int));
     language->strings = omf_calloc(string_count, sizeof(sd_lang_string));
     language->count = string_count;
 
@@ -70,6 +70,7 @@ int sd_language_load(sd_language *language, const char *filename) {
 
     // Valid file with no content
     if(pos <= 0) {
+        omf_free(offsets);
         sd_reader_close(r);
         return SD_SUCCESS;
     }
@@ -92,6 +93,7 @@ int sd_language_load(sd_language *language, const char *filename) {
     }
 
     // All done.
+    omf_free(offsets);
     sd_reader_close(r);
     return SD_SUCCESS;
 }

--- a/src/formats/pic.c
+++ b/src/formats/pic.c
@@ -1,6 +1,6 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "formats/error.h"
 #include "formats/internal/reader.h"
@@ -163,7 +163,7 @@ int sd_pic_save(const sd_pic_file *pic, const char *filename) {
     return SD_SUCCESS;
 
 error:
-    unlink(filename);
+    remove(filename);
     sd_writer_close(w);
     return SD_FILE_WRITE_ERROR;
 }

--- a/src/formats/setup.h
+++ b/src/formats/setup.h
@@ -10,6 +10,7 @@
 #ifndef SD_SETUP_H
 #define SD_SETUP_H
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -26,7 +27,8 @@ typedef struct {
     uint16_t unk3 : 2;
     uint16_t power_2 : 3;
     uint16_t unk4 : 3;
-} __attribute__((packed)) gflags0;
+} gflags0;
+static_assert(2 == sizeof(gflags0), "gflags0 should pack into 2 bytes");
 
 typedef struct {
     uint8_t knockdown : 2;
@@ -35,20 +37,23 @@ typedef struct {
     uint8_t hyper_mode : 1;
     uint8_t screen_shakes : 1;
     uint8_t animations : 1;
-} __attribute__((packed)) gflags1;
+} gflags1;
+static_assert(1 == sizeof(gflags1), "gflags1 should pack into 1 byte");
 
 typedef struct {
     uint8_t palette_animation : 1;
     uint8_t unk2 : 2;
     uint8_t snow_checking : 1;
     uint8_t unk3 : 4;
-} __attribute__((packed)) gflags2;
+} gflags2;
+static_assert(1 == sizeof(gflags2), "gflags2 should pack into 1 byte");
 
 typedef struct {
     uint32_t stereo_reversed : 1;
     uint32_t match_count : 2;
     uint32_t unk : 29;
-} __attribute__((packed)) gflags3;
+} gflags3;
+static_assert(4 == sizeof(gflags3), "gflags3 should pack into 4 bytes");
 
 typedef struct {
     uint8_t game_speed;
@@ -71,7 +76,8 @@ typedef struct {
     uint8_t sound_volume;
     uint8_t music_volume;
     char unknown_r[38];
-} __attribute__((packed)) sd_setup_file;
+} sd_setup_file;
+static_assert(296 == sizeof(sd_setup_file), "sd_setup_file should pack into 296 bytes");
 
 int sd_setup_create(sd_setup_file *setup);
 void sd_setup_free(sd_setup_file *setup);

--- a/src/formats/tournament.c
+++ b/src/formats/tournament.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h> // Required on linux
 
 #include "formats/error.h"
 #include "formats/internal/reader.h"
@@ -319,7 +318,7 @@ int sd_tournament_save(const sd_tournament_file *trn, const char *filename) {
     return SD_SUCCESS;
 
 error:
-    unlink(filename);
+    remove(filename);
     sd_writer_close(w);
     return SD_FILE_WRITE_ERROR;
 }

--- a/src/formats/vga_image.c
+++ b/src/formats/vga_image.c
@@ -176,7 +176,7 @@ int sd_vga_image_to_png(const sd_vga_image *img, const palette *pal, const char 
     png_infop info_ptr;
     png_colorp palette;
     int ret = SD_SUCCESS;
-    char *rows[img->h];
+    char **rows = omf_calloc(img->h, sizeof(char *));
 
     FILE *handle = fopen(filename, "wb");
     if(handle == NULL) {
@@ -237,5 +237,6 @@ error_2:
 error_1:
     fclose(handle);
 error_0:
+    omf_free(rows);
     return ret;
 }

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -276,7 +276,7 @@ void har_set_ani(object *obj, int animation_id, int repeat) {
     uint8_t has_corner_hack = obj->animation_state.shadow_corner_hack;
     object_set_animation(obj, &move->ani);
     obj->animation_state.shadow_corner_hack = has_corner_hack;
-    if(s != NULL && strcasecmp(s, "!") && strcasecmp(s, "0") && h->delay > 0) {
+    if(s != NULL && strcmp(s, "!") != 0 && strcmp(s, "0") != 0 && h->delay > 0) {
         DEBUG("delaying move %d %s by %d ticks", move->id, s, h->delay);
         object_set_delay(obj, h->delay);
     }

--- a/src/game/protos/intersect.c
+++ b/src/game/protos/intersect.c
@@ -1,3 +1,5 @@
+#include <assert.h>
+
 #include "game/protos/intersect.h"
 
 /**
@@ -96,7 +98,8 @@ int intersect_sprite_hitpoint(object *obj, object *target, int level, vec2i *poi
     }
 
     // Iterate through hitpoints
-    vec2i hcoords[level];
+    assert(level == 1 || level == 2);
+    vec2i hcoords[2];
     int found = 0;
     iterator it;
     collision_coord *cc;

--- a/src/main.c
+++ b/src/main.c
@@ -19,9 +19,7 @@
 #include <enet/enet.h>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <time.h>
-#include <unistd.h>
 
 #ifndef SHA1_HASH
 static const char *git_sha1_hash = "";

--- a/src/resources/pathmanager.c
+++ b/src/resources/pathmanager.c
@@ -81,7 +81,7 @@ int pm_init(void) {
     local_path_build(LOG_PATH, local_base_dir, logfile_name);
     local_path_build(CONFIG_PATH, local_base_dir, configfile_name);
     local_path_build(SCORE_PATH, local_base_dir, scorefile_name);
-    if(!strcasecmp(SDL_GetPlatform(), "Windows")) {
+    if(strcmp(SDL_GetPlatform(), "Windows") == 0) {
         local_path_build(SAVE_PATH, local_base_dir, "save\\");
     } else {
         local_path_build(SAVE_PATH, local_base_dir, "save/");
@@ -93,19 +93,19 @@ int pm_init(void) {
         // where is the openomf binary, if this call fails we will look for resources in ./resources
         bin_base_dir = SDL_GetBasePath();
         if(bin_base_dir != NULL) {
-            if(!strcasecmp(SDL_GetPlatform(), "Windows")) {
+            if(strcmp(SDL_GetPlatform(), "Windows") == 0) {
                 // on windows, the resources will be in ./resources, relative to the binary
                 local_path_build(RESOURCE_PATH, bin_base_dir, "resources\\");
                 local_path_build(SHADER_PATH, bin_base_dir, "shaders\\");
                 m_ok = 1;
-            } else if(!strcasecmp(SDL_GetPlatform(), "Linux")) {
+            } else if(strcmp(SDL_GetPlatform(), "Linux") == 0) {
                 // on linux, the resources will be in ../share/games/openomf, relative to the binary
                 // so if openomf is installed to /usr/local/bin,
                 // the resources will be in /usr/local/share/games/openomf
                 local_path_build(RESOURCE_PATH, bin_base_dir, "../share/games/openomf/");
                 local_path_build(SHADER_PATH, bin_base_dir, "../share/games/openomf/shaders/");
                 m_ok = 1;
-            } else if(!strcasecmp(SDL_GetPlatform(), "Mac OS X")) {
+            } else if(strcmp(SDL_GetPlatform(), "Mac OS X") == 0) {
                 // on OSX, GetBasePath returns the 'Resources' directory
                 // if run from an app bundle, so we can use this as-is
                 local_path_build(RESOURCE_PATH, bin_base_dir, "");
@@ -119,7 +119,7 @@ int pm_init(void) {
 
     // Set default resource paths
     if(!m_ok) {
-        if(!strcasecmp(SDL_GetPlatform(), "Windows")) {
+        if(strcmp(SDL_GetPlatform(), "Windows") == 0) {
             local_path_build(RESOURCE_PATH, "resources\\", "");
             local_path_build(SHADER_PATH, "shaders\\", "");
         } else {
@@ -129,7 +129,7 @@ int pm_init(void) {
     }
 
     char *platform_sep = "/";
-    if(!strcasecmp(SDL_GetPlatform(), "Windows")) {
+    if(strcmp(SDL_GetPlatform(), "Windows") == 0) {
         platform_sep = "\\";
     }
 

--- a/src/resources/sgmanager.c
+++ b/src/resources/sgmanager.c
@@ -8,7 +8,6 @@
 #include "utils/scandir.h"
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 int sg_init(void) {
     int ret;
@@ -156,8 +155,8 @@ int sg_delete(const char *pilotname) {
 
     const char *dirname = pm_get_local_path(SAVE_PATH);
     snprintf(pathname, sizeof(pathname), "%s%s.CHR", dirname, pilotname);
-    int ret = unlink(pathname);
-    if(ret < 0) {
+    int ret = remove(pathname);
+    if(ret != 0) {
         PERROR("Failed to delete %s: %m", pathname);
         return SD_FILE_UNLINK_ERROR;
     }

--- a/src/utils/scandir.c
+++ b/src/utils/scandir.c
@@ -1,8 +1,28 @@
 #include "utils/scandir.h"
-#include <dirent.h>
 #include <string.h>
 
+#if defined(_WIN32) || defined(WIN32)
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
+
 int scan_directory(list *dir_list, const char *dir) {
+#if defined(_WIN32) || defined(WIN32)
+
+    WIN32_FIND_DATAA entry;
+    HANDLE hFind;
+    if((hFind = FindFirstFileA(dir, &entry)) == INVALID_HANDLE_VALUE) {
+        return 1;
+    }
+    while(FindNextFileA(hFind, &entry) != FALSE) {
+        list_append(dir_list, entry.cFileName, strlen(entry.cFileName) + 1);
+    }
+    FindClose(hFind);
+    return 0;
+
+#else
+
     DIR *dp;
     struct dirent *entry;
     if((dp = opendir(dir)) == NULL) {
@@ -13,38 +33,82 @@ int scan_directory(list *dir_list, const char *dir) {
     }
     closedir(dp);
     return 0;
+
+#endif
 }
 
 int scan_directory_prefix(list *dir_list, const char *dir, const char *prefix) {
+#if defined(_WIN32) || defined(WIN32)
+
+    WIN32_FIND_DATAA entry;
+    HANDLE hFind;
+    if((hFind = FindFirstFileA(dir, &entry)) == INVALID_HANDLE_VALUE) {
+        return 1;
+    }
+    size_t prefix_len = strlen(prefix);
+    while(FindNextFileA(hFind, &entry) != FALSE) {
+        size_t filename_len = strlen(entry.cFileName);
+        if(filename_len >= prefix_len && memcmp(entry.cFileName, prefix, prefix_len) == 0) {
+            list_append(dir_list, entry.cFileName, filename_len + 1);
+        }
+    }
+    FindClose(hFind);
+    return 0;
+
+#else
+
     DIR *dp;
     struct dirent *entry;
     if((dp = opendir(dir)) == NULL) {
         return 1;
     }
+    size_t prefix_len = strlen(prefix);
     while((entry = readdir(dp)) != NULL) {
-        if(strlen(entry->d_name) >= strlen(prefix)) {
-            if(strncmp(entry->d_name, prefix, strlen(prefix)) == 0) {
-                list_append(dir_list, entry->d_name, strlen(entry->d_name) + 1);
-            }
+        size_t filename_len = strlen(entry->d_name);
+        if(filename_len >= prefix_len && memcmp(entry->d_name, prefix, prefix_len) == 0) {
+            list_append(dir_list, entry->d_name, filename_len + 1);
         }
     }
     closedir(dp);
     return 0;
+
+#endif
 }
 
 int scan_directory_suffix(list *dir_list, const char *dir, const char *suffix) {
+#if defined(_WIN32) || defined(WIN32)
+
+    WIN32_FIND_DATAA entry;
+    HANDLE hFind;
+    if((hFind = FindFirstFileA(dir, &entry)) == INVALID_HANDLE_VALUE) {
+        return 1;
+    }
+    size_t suffix_len = strlen(suffix);
+    while(FindNextFileA(hFind, &entry) != FALSE) {
+        size_t filename_len = strlen(entry.cFileName);
+        if(filename_len >= suffix_len && memcmp(entry.cFileName + filename_len - suffix_len, suffix, suffix_len) == 0) {
+            list_append(dir_list, entry.cFileName, filename_len + 1);
+        }
+    }
+    FindClose(hFind);
+    return 0;
+
+#else
+
     DIR *dp;
     struct dirent *entry;
     if((dp = opendir(dir)) == NULL) {
         return 1;
     }
+    size_t suffix_len = strlen(suffix);
     while((entry = readdir(dp)) != NULL) {
-        if(strlen(entry->d_name) >= strlen(suffix)) {
-            if(strncmp(entry->d_name + strlen(entry->d_name) - strlen(suffix), suffix, strlen(suffix)) == 0) {
-                list_append(dir_list, entry->d_name, strlen(entry->d_name) + 1);
-            }
+        size_t filename_len = strlen(entry->d_name);
+        if(filename_len >= suffix_len && memcmp(entry->d_name + filename_len - suffix_len, suffix, suffix_len) == 0) {
+            list_append(dir_list, entry->d_name, filename_len + 1);
         }
     }
     closedir(dp);
     return 0;
+
+#endif
 }

--- a/src/video/opengl/object_array.c
+++ b/src/video/opengl/object_array.c
@@ -1,4 +1,6 @@
+#include <assert.h>
 #include <epoxy/gl.h>
+#include <stdalign.h>
 #include <stdlib.h>
 
 #include "utils/allocator.h"
@@ -24,7 +26,8 @@ typedef struct {
     GLint palette_offset;
     GLint palette_limit;
     GLuint options;
-} __attribute__((aligned(4))) object_data;
+} object_data;
+static_assert(4 == alignof(object_data), "object_data alignment is expected to be 4");
 
 typedef struct object_array {
     GLuint vbo_ids[BUFFER_COUNT];

--- a/src/video/opengl/shaders.c
+++ b/src/video/opengl/shaders.c
@@ -87,7 +87,7 @@ static bool load_shader(GLuint program_id, GLenum shader_type, const char *shade
 void delete_program(GLuint program_id) {
     GLsizei attached_count = 0;
     glGetProgramiv(program_id, GL_ATTACHED_SHADERS, &attached_count);
-    GLuint shaders[attached_count];
+    GLuint *shaders = omf_calloc(attached_count, sizeof(GLuint));
     glUseProgram(0);
     glGetAttachedShaders(program_id, attached_count, NULL, shaders);
     for(int i = 0; i < attached_count; i++) {
@@ -96,6 +96,7 @@ void delete_program(GLuint program_id) {
     }
     glDeleteProgram(program_id);
     DEBUG("Program %d deleted", program_id);
+    omf_free(shaders);
 }
 
 bool create_program(GLuint *program_id, const char *vertex_shader, const char *fragment_shader) {

--- a/src/video/opengl/shared.c
+++ b/src/video/opengl/shared.c
@@ -1,3 +1,4 @@
+#include <stdalign.h>
 #include <stdlib.h>
 
 #include "utils/allocator.h"
@@ -5,8 +6,8 @@
 #include "video/opengl/ubo.h"
 
 typedef struct data_buffer {
-    GLfloat palette[1024]; // 256 * sizeof(vec4f)
-} __attribute__((aligned(16))) data_buffer;
+    alignas(16) GLfloat palette[1024]; // 256 * sizeof(vec4f)
+} data_buffer;
 
 typedef struct shared {
     GLuint ubo_id;

--- a/src/video/opengl/texture_atlas.c
+++ b/src/video/opengl/texture_atlas.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdlib.h>
 
 #include "utils/allocator.h"
@@ -14,7 +15,8 @@ typedef struct {
     uint16_t y;
     uint16_t w;
     uint16_t h;
-} __attribute__((packed)) zone;
+} zone;
+static_assert(8 == sizeof(zone), "zone should pack into 8 bytes");
 
 typedef struct texture_atlas {
     hashmap items;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "name": "sdl2",
+      "default-features": false
+    },
+    {
+      "name": "sdl2",
+      "default-features": false,
+      "platform": "linux",
+      "features": [
+        "x11",
+        "wayland"
+      ]
+    },
+    {
+      "name": "sdl2-mixer",
+      "default-features": false,
+      "features": [
+        "wavpack"
+      ]
+    },
+    "libxmp",
+    "libepoxy",
+    "enet",
+    "libconfuse",
+    "argtable3",
+    "libpng"
+  ]
+}


### PR DESCRIPTION
Fixes compilation with MSVC.

With `/Wall`, MSVC currently generates ~13,000 warnings when compiling openomf & core; mostly repeated warnings about padding in SDL headers.

VCPKG is introduced & used to install dependencies.
A Github Action check_msvc is added to ensure MSVC does not regress, but it does not emit a release artifact (as we already ship a mingw release, and I'd rather not port the zip packaging steps to powershell at this moment).