### PR TITLE
`str` String fixes

### DIFF
--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -16,7 +16,7 @@
 
 static void str_resize_buffer(str *dst, size_t size) {
     size_t size_with_zero = size + 1;
-    if(size_with_zero >= STR_STACK_SIZE) {
+    if(size_with_zero > STR_STACK_SIZE) {
         dst->data = omf_realloc(dst->data, size_with_zero);
         dst->small[0] = 0;
     } else {
@@ -30,7 +30,7 @@ static void str_resize_buffer(str *dst, size_t size) {
 
 static void str_resize_and_copy_buffer(str *dst, size_t size) {
     size_t size_with_zero = size + 1;
-    if(size_with_zero >= STR_STACK_SIZE) {
+    if(size_with_zero > STR_STACK_SIZE) {
         // New size is larger than the stack buffer; do malloc.
         if(dst->data == NULL) {
             // Old string is in stack, move to heap

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -265,7 +265,7 @@ void str_replace(str *dst, const char *seek, const char *replacement, int limit)
     size_t replacement_len = strlen(replacement);
     assert(seek_len > 0);
     int found = 0;
-    size_t diff = replacement_len - seek_len;
+    ptrdiff_t diff = replacement_len - (ptrdiff_t)seek_len;
     size_t current_pos = 0;
     while(str_find_next(dst, seek[0], &current_pos) && (found < limit || limit < 0)) {
         if(strncmp(str_ptr(dst) + current_pos, seek, seek_len) == 0) {

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -282,8 +282,10 @@ void str_replace(str *dst, const char *seek, const char *replacement, int limit)
             str_zero(dst);
 
             found++;
+            current_pos += replacement_len;
+        } else {
+            current_pos++;
         }
-        current_pos++;
     }
 }
 

--- a/testing/test_str.c
+++ b/testing/test_str.c
@@ -351,6 +351,21 @@ void test_str_replace_sm(void) {
     str_free(&d);
 }
 
+void test_str_replace_sm_regression(void) {
+    str d;
+    char long_str[STR_STACK_SIZE + 1];
+    memset(long_str, 'A', sizeof long_str);
+    long_str[sizeof long_str - 2] = 'B';
+    long_str[sizeof long_str - 1] = '\0';
+    str_from_c(&d, long_str);
+    CU_ASSERT_PTR_NOT_NULL(d.data);
+
+    str_replace(&d, "AA", "C", 1);
+    CU_ASSERT(str_c(&d)[d.len] == '\0');
+    CU_ASSERT(str_c(&d)[d.len - 1] == 'B');
+    str_free(&d);
+}
+
 void test_str_replace_multi(void) {
     str d;
     str_from_c(&d, "test $1 string $1");
@@ -445,6 +460,10 @@ void str_test_suite(CU_pSuite suite) {
         return;
     }
     if(CU_add_test(suite, "Test for str_replace (shorter replacement)", test_str_replace_sm) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (shorter replacement regression test)",
+                   test_str_replace_sm_regression) == NULL) {
         return;
     }
     if(CU_add_test(suite, "Test for str_replace (multiple hits)", test_str_replace_multi) == NULL) {

--- a/testing/test_str.c
+++ b/testing/test_str.c
@@ -375,6 +375,24 @@ void test_str_replace_multi(void) {
     str_free(&d);
 }
 
+void test_str_replace_multi_regression(void) {
+    str d;
+    str_from_c(&d, "test $1 string");
+    str_replace(&d, "$1", "$2 $1", 2);
+    CU_ASSERT(str_c(&d)[d.len] == 0);
+    CU_ASSERT_STRING_EQUAL(str_c(&d), "test $2 $1 string");
+    str_free(&d);
+}
+
+void test_str_replace_multi_consecutive(void) {
+    str d;
+    str_from_c(&d, "test $1$1 string");
+    str_replace(&d, "$1", "", -1);
+    CU_ASSERT(str_c(&d)[d.len] == 0);
+    CU_ASSERT_STRING_EQUAL(str_c(&d), "test  string");
+    str_free(&d);
+}
+
 void test_str_replace_multi_limit(void) {
     str d;
     str_from_c(&d, "test $1 string $1");
@@ -467,6 +485,14 @@ void str_test_suite(CU_pSuite suite) {
         return;
     }
     if(CU_add_test(suite, "Test for str_replace (multiple hits)", test_str_replace_multi) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (multiple hits, replacement contains seek)",
+                   test_str_replace_multi_regression) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_replace (multiple consecutive hits w/empty)",
+                   test_str_replace_multi_consecutive) == NULL) {
         return;
     }
     if(CU_add_test(suite, "Test for str_replace (multiple hits w/limit)", test_str_replace_multi_limit) == NULL) {

--- a/testing/test_str.c
+++ b/testing/test_str.c
@@ -26,6 +26,26 @@ void test_str_from(void) {
     str_free(&src);
 }
 
+void test_str_from_threshold_short(void) {
+    str d;
+    char short_str[STR_STACK_SIZE];
+    memset(short_str, 'A', sizeof short_str);
+    short_str[sizeof short_str - 1] = '\0';
+    str_from_c(&d, short_str);
+    CU_ASSERT_PTR_NULL(d.data);
+    str_free(&d);
+}
+
+void test_str_from_threshold_long(void) {
+    str d;
+    char long_str[STR_STACK_SIZE + 1];
+    memset(long_str, 'A', sizeof long_str);
+    long_str[sizeof long_str - 1] = '\0';
+    str_from_c(&d, long_str);
+    CU_ASSERT_PTR_NOT_NULL(d.data);
+    str_free(&d);
+}
+
 void test_str_from_long(void) {
     str src;
     str_from_c(&src, "testdatatestdatatestdatatestdata1"); // 33
@@ -327,7 +347,7 @@ void test_str_replace_sm(void) {
     str_replace(&d, "$1", "1", -1);
     str_replace(&d, "$2", "2", -1);
     CU_ASSERT(str_c(&d)[d.len] == 0);
-    CU_ASSERT_STRING_EQUAL(d.data, "test 1 string 2");
+    CU_ASSERT_STRING_EQUAL(str_c(&d), "test 1 string 2");
     str_free(&d);
 }
 
@@ -345,7 +365,7 @@ void test_str_replace_multi_limit(void) {
     str_from_c(&d, "test $1 string $1");
     str_replace(&d, "$1", "one", 1);
     CU_ASSERT(str_c(&d)[d.len] == 0);
-    CU_ASSERT_STRING_EQUAL(d.data, "test one string $1");
+    CU_ASSERT_STRING_EQUAL(str_c(&d), "test one string $1");
     str_free(&d);
 }
 
@@ -357,6 +377,12 @@ void str_test_suite(CU_pSuite suite) {
         return;
     }
     if(CU_add_test(suite, "Test for str_from", test_str_from) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from small string threshold, short", test_str_from_threshold_short) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_from small string threshold, long", test_str_from_threshold_long) == NULL) {
         return;
     }
     if(CU_add_test(suite, "Test for long str_from", test_str_from_long) == NULL) {


### PR DESCRIPTION
- Strings of length 15 were being missed by the small string optimization,
- str_replace would always resize the string before replacing (potentially truncating the contents), and
- str_replace no longer falls into an infinite loop when replacement contains seek, and can find consecutive hits even with an empty replacement.

~~Also .gitignore'd the test artifacts, clangd compile_commands.json & .cache, and any untracked files added to /resources (typically the OMF 2097 assets).~~