### PR TITLE
Gitignore clangd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ mingw_build/
 .vscode
 cmake-build-debug/
 cmake-build-release/
+.cache
+compile_commands.json


### PR DESCRIPTION
.cache and compile_commands.json are for use with clangd
https://clangd.llvm.org/design/compile-commands
https://stackoverflow.com/questions/51402740/visual-studio-code-clangd-extension-configuration#51692215

the build instructions BUILD.md states:
> On Linux in debug mode, the OMF resource files should be put in resources/ subdirectory.

To prevent these from being checked in accidentally (and generally ruining my git status), each file from omf2097-assets.zip is now gitignored.