### PR TITLE
Support vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 endif()
 
 # Find OpenOMF core sources
-file(GLOB_RECURSE OPENOMF_SRC RELATIVE ${CMAKE_SOURCE_DIR} "src/*/*.c")
+file(GLOB_RECURSE OPENOMF_SRC RELATIVE ${CMAKE_SOURCE_DIR} "src/*/*.c" "src/*/*.h")
 
 set(COREINCS
     src

--- a/cmake-scripts/FindSDL2.cmake
+++ b/cmake-scripts/FindSDL2.cmake
@@ -145,6 +145,27 @@ This needed to change because "proper" SDL convention is #include
 because not all systems place things in SDL/ (see FreeBSD).
 #]=======================================================================]
 
+if(VCPKG_TOOLCHAIN)
+  if(TARGET SDL2::Main)
+    return()
+  endif()
+  find_package(SDL2 CONFIG)
+  if(SDL2_FOUND)
+    if(TARGET SDL2::SDL2)
+      set(SDL2_LIBRARIES SDL2::SDL2)
+    else()
+      set(SDL2_LIBRARIES SDL2::SDL2-static)
+    endif()
+    get_target_property(SDL2_INCLUDE_DIR "${SDL2_LIBRARIES}" INTERFACE_INCLUDE_DIRECTORIES)
+    add_library(SDL2::Main INTERFACE IMPORTED)
+    target_link_libraries(SDL2::Main INTERFACE
+      SDL2::SDL2main
+      "${SDL2_LIBRARIES}"
+    )
+    return()
+  endif(SDL2_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 # Define options for searching SDL2 Library in a custom path
 
 set(SDL2_PATH "" CACHE STRING "Custom SDL2 Library path")

--- a/cmake-scripts/FindSDL2_mixer.cmake
+++ b/cmake-scripts/FindSDL2_mixer.cmake
@@ -123,6 +123,21 @@ if (NOT SDL2_FOUND)
     unset(SDL2_MIXER_SDL2_NOT_FOUND)
 endif ()
 
+if(VCPKG_TOOLCHAIN)
+    find_package(SDL2_mixer CONFIG)
+    if(SDL2_mixer_FOUND)
+        set(SDL2_MIXER_FOUND TRUE)
+        if(TARGET SDL2_mixer::SDL2_mixer)
+            add_library(SDL2::Mixer ALIAS SDL2_mixer::SDL2_mixer)
+            get_target_property(SDL2_MIXER_INCLUDE_DIRS SDL2_mixer::SDL2_mixer INTERFACE_INCLUDE_DIRECTORIES)
+        else()
+            add_library(SDL2::Mixer ALIAS SDL2_mixer::SDL2_mixer-static)
+            get_target_property(SDL2_MIXER_INCLUDE_DIRS SDL2_mixer::SDL2_mixer-static INTERFACE_INCLUDE_DIRECTORIES)
+        endif()
+        return()
+    endif(SDL2_mixer_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 
 # Define options for searching SDL2_mixer Library in a custom path
 

--- a/cmake-scripts/Findargtable2.cmake
+++ b/cmake-scripts/Findargtable2.cmake
@@ -1,3 +1,17 @@
+if(VCPKG_TOOLCHAIN)
+    find_package(Argtable2 CONFIG)
+    if(Argtable2_FOUND)
+        set(ARGTABLE2_FOUND ON)
+        set(ARGTABLE2_LIBRARY argtable2::argtable2)
+        set(ARGTABLE2_INCLUDE_DIR)
+        set(ARGTABLE2_INCLUDE_DIRS)
+        set(ARGTABLE2_LIBRARIES ${ARGTABLE2_LIBRARY})
+
+        mark_as_advanced(ARGTABLE2_INCLUDE_DIR ARGTABLE2_LIBRARY)
+        return()
+    endif(Argtable2_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 set(ARGTABLE2_SEARCH_PATHS
     /usr/local
     /usr

--- a/cmake-scripts/Findargtable3.cmake
+++ b/cmake-scripts/Findargtable3.cmake
@@ -1,3 +1,17 @@
+if(VCPKG_TOOLCHAIN)
+    find_package(Argtable3 CONFIG)
+    if(Argtable3_FOUND)
+        set(ARGTABLE3_FOUND ON)
+        set(ARGTABLE3_LIBRARY argtable3::argtable3)
+        set(ARGTABLE3_INCLUDE_DIR)
+        set(ARGTABLE3_INCLUDE_DIRS)
+        set(ARGTABLE3_LIBRARIES ${ARGTABLE3_LIBRARY})
+
+        mark_as_advanced(ARGTABLE3_INCLUDE_DIR ARGTABLE3_LIBRARY)
+        return()
+    endif(Argtable3_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 set(ARGTABLE3_SEARCH_PATHS
     /usr/local
     /usr

--- a/cmake-scripts/Findconfuse.cmake
+++ b/cmake-scripts/Findconfuse.cmake
@@ -1,4 +1,15 @@
 
+if(VCPKG_TOOLCHAIN)
+    find_package(unofficial-libconfuse CONFIG)
+    if(unofficial-libconfuse_FOUND)
+        get_target_property(CONFUSE_INCLUDE_DIR unofficial::libconfuse::libconfuse INTERFACE_INCLUDE_DIRECTORIES)
+        set(CONFUSE_LIBRARY unofficial::libconfuse::libconfuse)
+
+        mark_as_advanced(CONFUSE_INCLUDE_DIR CONFUSE_LIBRARY)
+        return()
+    endif(unofficial-libconfuse_FOUND)
+endif(VCPKG_TOOLCHAIN)
+
 SET(CONFUSE_SEARCH_PATHS
     /usr/local/
     /usr

--- a/cmake-scripts/Findxmp.cmake
+++ b/cmake-scripts/Findxmp.cmake
@@ -1,4 +1,20 @@
 
+if(VCPKG_TOOLCHAIN)
+    find_package(libxmp CONFIG)
+    if(libxmp_FOUND)
+        if(TARGET libxmp::xmp_shared)
+            set(XMP_LIBRARY libxmp::xmp_shared)
+        else()
+            set(XMP_LIBRARY libxmp::xmp_static)
+        endif()
+
+        get_target_property(XMP_INCLUDE_DIR "${XMP_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES)
+
+        mark_as_advanced(XMP_INCLUDE_DIR XMP_LIBRARY)
+        return()
+    endif()
+endif()
+
 SET(XMP_SEARCH_PATHS
     /usr/local/
     /usr

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "name": "sdl2",
+      "default-features": false
+    },
+    {
+      "name": "sdl2",
+      "default-features": false,
+      "platform": "linux",
+      "features": [
+        "x11",
+        "wayland"
+      ]
+    },
+    {
+      "name": "sdl2-mixer",
+      "default-features": false,
+      "features": [
+        "wavpack"
+      ]
+    },
+    "libxmp",
+    "libepoxy",
+    "enet",
+    "libconfuse",
+    "argtable3",
+    "libpng"
+  ]
+}


### PR DESCRIPTION
to build with vcpkg, set the toolchain to vcpkg when configuring:
```
cmake -S. -Bbuild --toolchain=PATH_TO/vcpkg/scripts/buildsystems/vcpkg.cmake
```

FindXYZ cmake scripts are modified to use find_package(CONFIG) when vcpkg is detected, which will use each installed `XYZConfig.cmake` file.

I turned sdl2's default features off to make my life easier when developing on Void Linux, as sdl2's dbus feature then in turn default-depends on libsystemd, which pans out poorly on Void.