### PR TITLE
Bugfixes

### DIFF
--- a/src/game/gui/text_render.c
+++ b/src/game/gui/text_render.c
@@ -14,6 +14,7 @@ void text_defaults(text_settings *settings) {
     settings->cdisabled = 0xC0;
     settings->cshadow = 0xC0;
     settings->cspacing = 0;
+    settings->max_lines = UINT8_MAX;
     settings->strip_leading_whitespace = false;
 }
 
@@ -162,7 +163,7 @@ int text_char_width(const text_settings *settings) {
 int text_find_line_count(const text_settings *settings, int cols, int rows, int len, const char *text) {
     int ptr = 0;
     int lines = 0;
-    while(ptr < len) {
+    while(lines < settings->max_lines && ptr < len) {
         // Find out how many characters for this row/col
         int line_len;
         if(settings->direction == TEXT_HORIZONTAL)
@@ -233,7 +234,9 @@ void text_render(const text_settings *settings, text_mode mode, int x, int y, in
         int line_ph;
 
         // Find out how many characters for this row/col
-        if(settings->direction == TEXT_HORIZONTAL)
+        if(line + 1 == fit_lines)
+            line_len = strlen(text + ptr);
+        else if(settings->direction == TEXT_HORIZONTAL)
             line_len = text_find_max_strlen(settings, cols, text + ptr);
         else
             line_len = text_find_max_strlen(settings, rows, text + ptr);

--- a/src/game/gui/text_render.h
+++ b/src/game/gui/text_render.h
@@ -73,7 +73,7 @@ typedef struct {
     uint8_t cspacing;
     uint8_t lspacing;
     bool strip_leading_whitespace;
-    bool wrap;
+    uint8_t max_lines;
 } text_settings;
 
 // New text rendering functions

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -590,7 +590,7 @@ void player_run(object *obj) {
         }
 
         // If UA is set, force other HAR to damage animation
-        if(sd_script_isset(frame, "ua") && enemy->cur_animation->id != 9 && enemy) {
+        if(sd_script_isset(frame, "ua") && enemy && enemy->cur_animation->id != 9) {
 
             DEBUG("my position %f, %f, their position %f %f", obj->pos.x, obj->pos.y, enemy->pos.x, enemy->pos.y);
             har_set_ani(enemy, 9, 0);

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -512,6 +512,8 @@ static void render_pilot_select(melee_local *local, bool player2_is_selectable) 
     component_render(local->bar_agility[0]);
     component_render(local->bar_endurance[0]);
 
+    object_render(&local->player2_placeholder);
+
     if(player2_is_selectable) {
         // player 2 name
         text_render(&tconf_black, TEXT_DEFAULT, 320 - 66, 52, 66, 8, lang_get(20 + current_b));
@@ -534,8 +536,6 @@ static void render_pilot_select(melee_local *local, bool player2_is_selectable) 
         // 'choose your pilot'
         text_render(&tconf_green, TEXT_DEFAULT, 160, 97, 160, 8, lang_get(187));
     }
-
-    object_render(&local->player2_placeholder);
 
     // player 1 name
     text_render(&tconf_black, TEXT_DEFAULT, 0, 52, 66, 8, lang_get(20 + current_a));

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -68,9 +68,9 @@ void newsroom_fixup_str(newsroom_local *local) {
 
        1= Player1 - Crystal
        2= Player2 - Steffan
-       3= HAR1 - jaguar
-       4= HAR2 - shadow
-       5= Arena - Stadium. (DOS OMF always refers to the arena as Stadium)
+       3= HAR1 - Jaguar
+       4= HAR2 - Shadow
+       5= Arena - Stadium
        6= P1 Possessive pronoun - Her
        7= P1 Objective pronoun  - Her
        8= P1 Subjective pronoun - She
@@ -103,8 +103,7 @@ void newsroom_fixup_str(newsroom_local *local) {
     str_replace(&tmp, "~1", str_c(&local->pilot1), -1);
 
     str_free(&local->news_str);
-    str_from(&local->news_str, &tmp);
-    str_free(&tmp);
+    local->news_str = tmp;
 }
 
 void newsroom_set_names(newsroom_local *local, const char *pilot1, const char *pilot2, int har1, int har2, int sex1,
@@ -154,15 +153,16 @@ void newsroom_overlay_render(scene *scene) {
 
     // Render text
     if(str_size(&local->news_str) > 0) {
-        video_draw(&local->news_bg, 20, 140);
+        video_draw(&local->news_bg, 20, 131);
         text_settings tconf_yellow;
         text_defaults(&tconf_yellow);
-        tconf_yellow.font = FONT_SMALL;
+        tconf_yellow.font = FONT_BIG;
         tconf_yellow.cforeground = COLOR_YELLOW;
-        tconf_yellow.shadow = TEXT_SHADOW_RIGHT | TEXT_SHADOW_BOTTOM;
+        tconf_yellow.shadow = TEXT_SHADOW_NONE;
         tconf_yellow.cshadow = 202;
         tconf_yellow.halign = TEXT_CENTER;
-        text_render(&tconf_yellow, TEXT_DEFAULT, 30, 150, 250, 6, str_c(&local->news_str));
+        tconf_yellow.lspacing = 1;
+        text_render(&tconf_yellow, TEXT_DEFAULT, 30, 140, 250, 6, str_c(&local->news_str));
     }
 
     // Dialog
@@ -296,7 +296,7 @@ int newsroom_create(scene *scene) {
     local->news_id = rand_int(24) * 2;
     local->screen = 0;
     local->champion = false;
-    menu_background_create(&local->news_bg, 280, 50);
+    menu_background_create(&local->news_bg, 280, 55);
 
     game_player *p1 = game_state_get_player(scene->gs, 0);
     game_player *p2 = game_state_get_player(scene->gs, 1);

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -18,8 +18,9 @@
 // newsroom text starts at 87
 // there are 24*2 texts in total
 #define NEWSROOM_TEXT 87
-// there are 3*2 pronouns in total
+
 #define NEWSROOM_PRONOUN 81
+#define NEWSROOM_HAR 31
 
 typedef struct newsroom_local_t {
     int news_id;
@@ -27,7 +28,7 @@ typedef struct newsroom_local_t {
     surface news_bg;
     str news_str;
     str pilot1, pilot2;
-    str har1, har2;
+    int har1, har2;
     int sex1, sex2;
     int won;
     bool champion;
@@ -51,7 +52,7 @@ const char *subject_pronoun(int sex) {
 
 char const *pronoun_strip(char const *pronoun, char *buf, size_t buf_size) {
     size_t pronoun_len = strlen(pronoun);
-    while(pronoun_len && pronoun[pronoun_len - 1] == '\n'){
+    while(pronoun_len && pronoun[pronoun_len - 1] == '\n') {
         pronoun_len--;
     }
     if(pronoun_len > buf_size)
@@ -96,8 +97,8 @@ void newsroom_fixup_str(newsroom_local *local) {
     str_replace(&tmp, "~7", pronoun_strip(object_pronoun(local->sex1), scratch, sizeof scratch), -1);
     str_replace(&tmp, "~6", pronoun_strip(possessive_pronoun(local->sex1), scratch, sizeof scratch), -1);
     str_replace(&tmp, "~5", "Stadium", -1);
-    str_replace(&tmp, "~4", str_c(&local->har2), -1);
-    str_replace(&tmp, "~3", str_c(&local->har1), -1);
+    str_replace(&tmp, "~4", pronoun_strip(lang_get(local->har2 + NEWSROOM_HAR), scratch, sizeof scratch), -1);
+    str_replace(&tmp, "~3", pronoun_strip(lang_get(local->har1 + NEWSROOM_HAR), scratch, sizeof scratch), -1);
     str_replace(&tmp, "~2", str_c(&local->pilot2), -1);
     str_replace(&tmp, "~1", str_c(&local->pilot1), -1);
 
@@ -106,13 +107,13 @@ void newsroom_fixup_str(newsroom_local *local) {
     str_free(&tmp);
 }
 
-void newsroom_set_names(newsroom_local *local, const char *pilot1, const char *pilot2, const char *har1,
-                        const char *har2, int sex1, int sex2) {
+void newsroom_set_names(newsroom_local *local, const char *pilot1, const char *pilot2, int har1, int har2, int sex1,
+                        int sex2) {
 
     str_from_c(&local->pilot1, pilot1);
     str_from_c(&local->pilot2, pilot2);
-    str_from_c(&local->har1, har1);
-    str_from_c(&local->har2, har2);
+    local->har1 = har1;
+    local->har2 = har2;
     local->sex1 = sex1;
     local->sex2 = sex2;
 
@@ -128,8 +129,6 @@ void newsroom_free(scene *scene) {
     str_free(&local->news_str);
     str_free(&local->pilot1);
     str_free(&local->pilot2);
-    str_free(&local->har1);
-    str_free(&local->har2);
     dialog_free(&local->continue_dialog);
     omf_free(local);
     scene_set_userdata(scene, local);
@@ -353,13 +352,12 @@ int newsroom_create(scene *scene) {
     // XXX TODO set winner/loser names properly
     if(p1->chr) {
         // TODO pilot genders
-        newsroom_set_names(local, p1->pilot->name, p2->pilot->name, har_get_name(p1->pilot->har_id),
-                           har_get_name(p2->pilot->har_id), pilot_sex(p1->pilot->pilot_id),
-                           pilot_sex(p2->pilot->pilot_id));
+        newsroom_set_names(local, p1->pilot->name, p2->pilot->name, p1->pilot->har_id, p2->pilot->har_id,
+                           pilot_sex(p1->pilot->pilot_id), pilot_sex(p2->pilot->pilot_id));
     } else {
         newsroom_set_names(local, lang_get(20 + p1->pilot->pilot_id), lang_get(20 + p2->pilot->pilot_id),
-                           har_get_name(p1->pilot->har_id), har_get_name(p2->pilot->har_id),
-                           pilot_sex(p1->pilot->pilot_id), pilot_sex(p2->pilot->pilot_id));
+                           p1->pilot->har_id, p2->pilot->har_id, pilot_sex(p1->pilot->pilot_id),
+                           pilot_sex(p2->pilot->pilot_id));
     }
     newsroom_fixup_str(local);
 

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -162,6 +162,7 @@ void newsroom_overlay_render(scene *scene) {
         tconf_yellow.cshadow = 202;
         tconf_yellow.halign = TEXT_CENTER;
         tconf_yellow.lspacing = 1;
+        tconf_yellow.max_lines = 4;
         text_render(&tconf_yellow, TEXT_DEFAULT, 30, 140, 250, 6, str_c(&local->news_str));
     }
 


### PR DESCRIPTION
Misc bugs that have been fixed:
- Player 2's Pilot name was hidden, rendering behind its background
- Newsroom was using the wrong font 
- Newsroom was using hardcoded pronouns and pilot names, which had incorrect case
- Newsroom wrapping didn't match original game. Unsure if this is entirely correct, but I think this is better.
 This PR wraps newsroom text at 31 characters (250px), and never wraps the fourth line:
```
Whoa, this challenger meant
business tonight. Shirro
could show the old pros a
thing or two about that Jaguar.
```