### PR TITLE
Make many network settings configurable:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,9 @@ if(MINIUPNPC_FOUND)
     add_compile_definitions(MINIUPNPC_FOUND)
 endif()
 
-if(NATPMP_FOUND)
-    set(CORELIBS ${CORELIBS} ${NATPMP_LIBRARY})
-    set(COREINCS ${COREINCS} ${NATPMP_INCLUDE_DIR})
+if(LIBNATPMP_FOUND)
+    set(CORELIBS ${CORELIBS} ${LIBNATPMP_LIBRARY})
+    set(COREINCS ${COREINCS} ${LIBNATPMP_INCLUDE_DIR})
     add_compile_definitions(NATPMP_FOUND)
 endif()
 

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -1,10 +1,12 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
+#include "game/utils/settings.h"
 #include "nat.h"
 #include "utils/log.h"
 
-void nat_try_upnp(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
+bool nat_create_upnp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
 #ifdef MINIUPNPC_FOUND
     char int_portstr[6];
     snprintf(int_portstr, sizeof(int_portstr), "%d", int_port);
@@ -12,18 +14,8 @@ void nat_try_upnp(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
     char ext_portstr[6];
     snprintf(ext_portstr, sizeof(ext_portstr), "%d", ext_port);
 
-    int error = 0;
-    struct UPNPDev *upnp_dev =
-        upnpDiscover(2000,    // time to wait (milliseconds)
-                     NULL,    // multicast interface (or null defaults to 239.255.255.250)
-                     NULL,    // path to minissdpd socket (or null defaults to /var/run/minissdpd.sock)
-                     0,       // source port to use (or zero defaults to port 1900)
-                     0,       // 0==IPv4, 1==IPv6
-                     2,       // TTL
-                     &error); // error condition
     char lan_address[64];
-    int status = UPNP_GetValidIGD(upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address));
-    // look up possible "status" values, the number "1" indicates a valid IGD was found
+    int status = UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address));
 
     if(status == 1) {
         // get the external (WAN) IP address
@@ -31,7 +23,7 @@ void nat_try_upnp(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
         UPNP_GetExternalIPAddress(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype, wan_address);
 
         // add a new UDP port mapping from WAN port 12345 to local host port 24680
-        error = UPNP_AddPortMapping(
+        int error = UPNP_AddPortMapping(
             ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype,
             ext_portstr, // external (WAN) port requested
             int_portstr, // internal (LAN) port to which packets will be redirected
@@ -41,31 +33,25 @@ void nat_try_upnp(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
             NULL,        // remote (peer) host address or nullptr for no restriction
             "86400");    // port map lease duration (in seconds) or zero for "as long as possible"
         if(error == 0) {
-            DEBUG("NAT-uPNP Port map successfully created!");
+            DEBUG("NAT-uPNP Port map successfully created from %d to %d!", int_port, ext_port);
 
-            ctx->type = NAT_TYPE_UPNP;
             ctx->int_port = int_port;
             ctx->ext_port = ext_port;
+            return true;
         } else {
             DEBUG("NAT-uPNP port mapping failed with %d", error);
             // TODO there are some errors we can work around here
-            // like the external port being in use, etc
+            // like overly short lifetimes
+            return false;
         }
     }
-#else
-    DEBUG("NAT-uPNP support not available");
 #endif
+    return false;
 }
 
-void nat_try_pmp(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
-#ifdef HAVE_NATPMP
-    // try nat-pmp
-    int r;
-    natpmp_t natpmp;
-    natpmpresp_t response;
-    in_addr_t forcedgw = {0};
-    initnatpmp(&natpmp, 0, forcedgw);
-    sendnewportmappingrequest(&natpmp, NATPMP_PROTOCOL_UDP, int_port, ext_port, 3600);
+bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
+#ifdef NATPMP_FOUND
+    sendnewportmappingrequest(&ctx->natpmp, NATPMP_PROTOCOL_UDP, int_port, ext_port, 3600);
     do {
         fd_set fds;
         struct timeval timeout;
@@ -79,14 +65,67 @@ void nat_try_pmp(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
     if(r == 0) {
         DEBUG("mapped public port %hu to localport %hu liftime %u\n", response.pnu.newportmapping.mappedpublicport,
               response.pnu.newportmapping.privateport, response.pnu.newportmapping.lifetime);
-        ctx->type = NAT_TYPE_PMP;
         ctx->int_port = response.pnu.newportmapping.privateport;
         ctx->ext_port = response.pnu.newportmapping.mappedpublicport;
+        return true;
     } else {
         DEBUG("NAT-PMP failed with error %d", r);
         // TODO handle some errors here
+        return false;
     }
-    closenatpmp(&natpmp);
+#endif
+    return false;
+}
+
+bool nat_create_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
+    switch(ctx->type) {
+        case NAT_TYPE_UPNP:
+            return nat_create_upnp_mapping(ctx, int_port, ext_port);
+            break;
+        case NAT_TYPE_PMP:
+            return nat_create_pmp_mapping(ctx, int_port, ext_port);
+            break;
+        default:
+            return false;
+    }
+}
+
+void nat_try_upnp(nat_ctx *ctx) {
+#ifdef MINIUPNPC_FOUND
+    int error = 0;
+    ctx->upnp_dev = upnpDiscover(2000,    // time to wait (milliseconds)
+                                 NULL,    // multicast interface (or null defaults to 239.255.255.250)
+                                 NULL,    // path to minissdpd socket (or null defaults to /var/run/minissdpd.sock)
+                                 0,       // source port to use (or zero defaults to port 1900)
+                                 0,       // 0==IPv4, 1==IPv6
+                                 2,       // TTL
+                                 &error); // error condition
+    // TODO check error here?
+    // try to look up our lan address, to test it
+    char lan_address[64];
+    int status = UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address));
+    // look up possible "status" values, the number "1" indicates a valid IGD was found
+
+    if(status == 1) {
+        DEBUG("discovered uPNP server");
+        ctx->type = NAT_TYPE_UPNP;
+    }
+#else
+    DEBUG("NAT-uPNP support not available");
+#endif
+}
+
+void nat_try_pmp(nat_ctx *ctx) {
+#ifdef HAVE_NATPMP
+    // try nat-pmp
+    int r;
+    natpmp_t natpmp;
+    natpmpresp_t response;
+    in_addr_t forcedgw = {0};
+    if(initnatpmp(&natpmp, 0, forcedgw) == 0) {
+        DEBUG("discovered NAT-PMP server");
+        ctx->type = NAT_TYPE_PMP;
+    }
 #else
     DEBUG("NAT-PMP support not available");
 #endif
@@ -110,10 +149,7 @@ void nat_release_upnp(nat_ctx *ctx) {
 
 void nat_release_pmp(nat_ctx *ctx) {
 #ifdef NATPMP_FOUND
-    natpmp_t natpmp;
     natpmpresp_t response;
-    in_addr_t forcedgw = {0};
-    initnatpmp(&natpmp, 0, forcedgw);
     sendnewportmappingrequest(&natpmp, NATPMP_PROTOCOL_UDP, ctx->int_port, ctx->ext_port, 0);
     do {
         fd_set fds;
@@ -130,20 +166,27 @@ void nat_release_pmp(nat_ctx *ctx) {
     } else {
         DEBUG("NAT-PMP release failed with error %d", r);
     }
+    closenatpmp(&natpmp);
 #endif
 }
 
-void nat_create(nat_ctx *ctx, uint16_t port) {
+void nat_create(nat_ctx *ctx) {
 
     ctx->type = NAT_TYPE_NONE;
+    ctx->int_port = 0;
+    ctx->ext_port = 0;
 
-    nat_try_upnp(ctx, port, port);
+    if(settings_get()->net.net_use_upnp) {
+        nat_try_upnp(ctx);
+    }
 
     if(ctx->type != NAT_TYPE_NONE) {
         return;
     }
 
-    nat_try_pmp(ctx, port, port);
+    if(settings_get()->net.net_use_pmp) {
+        nat_try_pmp(ctx);
+    }
 }
 
 void nat_free(nat_ctx *ctx) {

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -15,7 +15,12 @@ bool nat_create_upnp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port)
     snprintf(ext_portstr, sizeof(ext_portstr), "%d", ext_port);
 
     char lan_address[64];
+#if(MINIUPNPC_API_VERSION >= 18)
+    int status =
+        UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address), NULL, 0);
+#else
     int status = UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address));
+#endif
 
     if(status == 1) {
         // get the external (WAN) IP address
@@ -103,7 +108,12 @@ void nat_try_upnp(nat_ctx *ctx) {
     // TODO check error here?
     // try to look up our lan address, to test it
     char lan_address[64];
+#if(MINIUPNPC_API_VERSION >= 18)
+    int status =
+        UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address), NULL, 0);
+#else
     int status = UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, lan_address, sizeof(lan_address));
+#endif
     // look up possible "status" values, the number "1" indicates a valid IGD was found
 
     if(status == 1) {

--- a/src/game/utils/nat.h
+++ b/src/game/utils/nat.h
@@ -8,19 +8,6 @@
 #include <miniupnpc/upnpcommands.h>
 #endif
 
-// socklen_t nonsense
-#if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#include <windows.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
-
 typedef enum
 {
     NAT_TYPE_NONE,

--- a/src/game/utils/nat.h
+++ b/src/game/utils/nat.h
@@ -35,9 +35,15 @@ typedef struct nat_ctx_t {
 #ifdef MINIUPNPC_FOUND
     struct UPNPUrls upnp_urls;
     struct IGDdatas upnp_data;
+    struct UPNPDev *upnp_dev;
+#endif
+#ifdef NATPMP_FOUND
+    natpmp_t natpmp;
 #endif
 } nat_ctx;
 
-void nat_create(nat_ctx *ctx, uint16_t port);
+void nat_create(nat_ctx *ctx);
+
+bool nat_create_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port);
 
 void nat_free(nat_ctx *ctx);

--- a/src/game/utils/settings.c
+++ b/src/game/utils/settings.c
@@ -105,8 +105,15 @@ const field f_keyboard[] = {
     F_STRING(settings_keyboard, key2_punch, "Left Ctrl"), F_STRING(settings_keyboard, key2_escape, "Escape")};
 
 const field f_net[] = {F_STRING(settings_network, net_connect_ip, "localhost"),
-                       F_STRING(settings_network, trace_file, NULL), F_INT(settings_network, net_connect_port, 2097),
-                       F_INT(settings_network, net_listen_port, 2097)};
+                       F_STRING(settings_network, net_username, ""),
+                       F_STRING(settings_network, trace_file, NULL),
+                       F_INT(settings_network, net_connect_port, 2097),
+                       F_INT(settings_network, net_listen_port_start, 0),
+                       F_INT(settings_network, net_listen_port_end, 0),
+                       F_INT(settings_network, net_ext_port_start, 0),
+                       F_INT(settings_network, net_ext_port_end, 0),
+                       F_BOOL(settings_network, net_use_pmp, 1),
+                       F_BOOL(settings_network, net_use_upnp, 1)};
 
 // Map struct to field
 const struct_to_field struct_to_fields[] = {S_2_F(&_settings.video, f_video),

--- a/src/game/utils/settings.h
+++ b/src/game/utils/settings.h
@@ -106,8 +106,14 @@ typedef struct {
 typedef struct {
     char *net_connect_ip;
     char *trace_file;
+    char *net_username;
     int net_connect_port;
-    int net_listen_port;
+    int net_listen_port_start;
+    int net_listen_port_end;
+    int net_ext_port_start;
+    int net_ext_port_end;
+    int net_use_upnp;
+    int net_use_pmp;
 } settings_network;
 
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -124,23 +124,22 @@ int main(int argc, char *argv[]) {
         if(port->count > 0) {
             connect_port = port->ival[0] & 0xFFFF;
         }
-        if(trace->count > 0) {
-            trace_file = strdup(trace->sval[0]);
-        }
     } else if(listen->count > 0) {
         init_flags.net_mode = NET_MODE_SERVER;
         listen_port = 2097;
-        if(port->count > 0) {
-            listen_port = port->ival[0] & 0xFFFF;
-        }
-        if(trace->count > 0) {
-            trace_file = strdup(trace->sval[0]);
-        }
     } else if(play->count > 0) {
         strncpy(init_flags.rec_file, play->filename[0], 254);
     } else if(rec->count > 0) {
         init_flags.record = 1;
         strncpy(init_flags.rec_file, rec->filename[0], 254);
+    }
+
+    if(port->count > 0) {
+        listen_port = port->ival[0] & 0xFFFF;
+    }
+
+    if(trace->count > 0) {
+        trace_file = strdup(trace->sval[0]);
     }
 
     // Init log
@@ -201,7 +200,8 @@ int main(int argc, char *argv[]) {
     }
     if(listen_port > 0 && listen_port < 0xFFFF) {
         DEBUG("Listen Port overridden to %u", listen_port & 0xFFFF);
-        settings_get()->net.net_listen_port = listen_port;
+        settings_get()->net.net_listen_port_start = listen_port;
+        settings_get()->net.net_listen_port_end = listen_port;
     }
 
     // Init SDL2


### PR DESCRIPTION
Makes the following fields configurable from settings:

* Internal port range to bind to
* External port range to map to, using upnp or PMP
* Whether to use upnp or PMP, or neither
* Username for lobby

Port 0 will mean "random port", ranges are inclusive, so 2097-2097 contains a single port, port 0 as an external port will first try to use the internal port, then fall back to using random.