### PR TITLE
Fix libnatpmp vcpkg port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(argtable2)
 find_package(Argtable3 CONFIG)
 find_package(PNG)
 find_package(ZLIB)
-find_package(miniupnpc)
+include(cmake-scripts/Findminiupnpc.cmake)
 find_package(natpmp)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,18 +139,6 @@ elseif(ARGTABLE3_FOUND)
   set(CORELIBS ${CORELIBS} ${ARGTABLE3_LIBRARY})
 endif()
 
-if(MINIUPNPC_FOUND)
-    set(CORELIBS ${CORELIBS} ${MINIUPNPC_LIBRARY})
-    set(COREINCS ${COREINCS} ${MINIUPNPC_INCLUDE_DIR})
-    add_compile_definitions(MINIUPNPC_FOUND)
-endif()
-
-if(LIBNATPMP_FOUND)
-    set(CORELIBS ${CORELIBS} ${LIBNATPMP_LIBRARY})
-    set(COREINCS ${COREINCS} ${LIBNATPMP_INCLUDE_DIR})
-    add_compile_definitions(NATPMP_FOUND)
-endif()
-
 # MingW build should add mingw32 lib
 if(MINGW)
     set(CORELIBS mingw32 ${CORELIBS})
@@ -172,13 +160,28 @@ include_directories(${COREINCS})
 # Build core sources first as an object library
 # this can then be reused in tests and main executable to speed things up
 add_library(openomf_core OBJECT ${OPENOMF_SRC})
-target_link_libraries(openomf_core PRIVATE ${XMP_LIBRARY})
 set(CORELIBS openomf_core ${CORELIBS})
 
 # Set icon for windows executable
 if(WIN32)
     SET(ICON_RESOURCE "resources/icons/openomf.rc")
 endif()
+
+# Link openomf_core to libraries directly, so their defines are present
+target_link_libraries(openomf_core PUBLIC ${XMP_LIBRARY})
+if(MINIUPNPC_FOUND)
+    target_link_libraries(openomf_core PUBLIC ${MINIUPNPC_LIBRARY})
+    target_include_directories(openomf_core PUBLIC ${MINIUPNPC_INCLUDE_DIR})
+    target_compile_definitions(openomf_core PUBLIC MINIUPNPC_FOUND)
+endif()
+
+if(LIBNATPMP_FOUND)
+    target_link_libraries(openomf_core PUBLIC ${LIBNATPMP_LIBRARY})
+    target_include_directories(openomf_core PUBLIC ${LIBNATPMP_INCLUDE_DIR})
+    target_compile_definitions(openomf_core PUBLIC NATPMP_FOUND)
+endif()
+
+
 
 # Build the game binary
 add_executable(openomf src/main.c src/engine.c ${ICON_RESOURCE})

--- a/cmake-scripts/Findminiupnpc.cmake
+++ b/cmake-scripts/Findminiupnpc.cmake
@@ -1,3 +1,16 @@
+if(VCPKG_TOOLCHAIN)
+  if(TARGET miniupnpc::miniupnpc)
+    return()
+  endif()
+  find_package(miniupnpc CONFIG)
+  if(TARGET miniupnpc::miniupnpc)
+    MESSAGE(STATUS "Found miniupnp in vcpkg")
+    set(MINIUPNPC_LIBRARY miniupnpc::miniupnpc)
+    SET(MINIUPNPC_FOUND TRUE)
+    set(MINIUPNPC_INCLUDE_DIR)
+    return()
+  endif()
+endif(VCPKG_TOOLCHAIN)
 
 SET(MINIUPNPC_SEARCH_PATHS
     /usr/local/

--- a/cmake-scripts/Findnatpmp.cmake
+++ b/cmake-scripts/Findnatpmp.cmake
@@ -1,3 +1,16 @@
+if(VCPKG_TOOLCHAIN)
+  if(TARGET libnatpmp::natpmp)
+    return()
+  endif()
+  find_package(libnatpmp CONFIG)
+  if(TARGET libnatpmp::natpmp)
+    MESSAGE(STATUS "Found libnatpmp in vcpkg")
+    set(LIBNATPMP_LIBRARY libnatpmp::natpmp)
+    SET(LIBNATPMP_FOUND TRUE)
+    set(LIBNATPMP_INCLUDE_DIR)
+    return()
+  endif()
+endif(VCPKG_TOOLCHAIN)
 
 SET(LIBNATPMP_SEARCH_PATHS
     /usr/local/

--- a/vcpkg-ports/libnatpmp/install-targets.patch
+++ b/vcpkg-ports/libnatpmp/install-targets.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5df1be2..bfc7492 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,8 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+ 
+ # Library itself
+ add_library(natpmp ${NATPMP_SOURCES})
+-target_include_directories(natpmp PUBLIC ${CMAKE_CURRENT_LIST_DIR})
++target_include_directories(natpmp PRIVATE ${CMAKE_CURRENT_LIST_DIR})
++target_include_directories(natpmp INTERFACE $<INSTALL_INTERFACE:include>)
+ target_compile_definitions(natpmp PRIVATE -DENABLE_STRNATPMPERR)
+ 
+ if (WIN32)
+@@ -52,7 +53,14 @@ include(GNUInstallDirs)
+ configure_file(natpmp.pc.in natpmp.pc @ONLY)
+ 
+ # install
+-install(TARGETS natpmp natpmpc
++install(TARGETS natpmp
++        EXPORT libnatpmp-targets
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++
++# undone: natpmpc export target
++install(TARGETS natpmpc
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+@@ -63,3 +71,19 @@ install(FILES natpmp.h
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/natpmp.pc
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
++include(CMakePackageConfigHelpers)
++configure_package_config_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/libnatpmp-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/libnatpmp-config.cmake"
++  INSTALL_DESTINATION "share/libnatpmp"
++)
++install(
++  FILES "${CMAKE_CURRENT_BINARY_DIR}/libnatpmp-config.cmake"
++  DESTINATION "share/libnatpmp"
++)
++
++install(
++    EXPORT libnatpmp-targets
++    DESTINATION share/libnatpmp
++    NAMESPACE libnatpmp::
++)

--- a/vcpkg-ports/libnatpmp/libnatpmp-config.cmake.in
+++ b/vcpkg-ports/libnatpmp/libnatpmp-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libnatpmp-targets.cmake")
+
+check_required_components(libnatpmp)

--- a/vcpkg-ports/libnatpmp/portfile.cmake
+++ b/vcpkg-ports/libnatpmp/portfile.cmake
@@ -9,9 +9,8 @@ vcpkg_from_github(
 
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
 )
 
 vcpkg_install_cmake()
@@ -24,5 +23,4 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/libnatpmp/portfile.cmake
+++ b/vcpkg-ports/libnatpmp/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         "install-declspec-header.patch"
-
+        "install-targets.patch"
 )
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libnatpmp-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -15,12 +17,14 @@ vcpkg_cmake_configure(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
+
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/libnatpmp/vcpkg.json
+++ b/vcpkg-ports/libnatpmp/vcpkg.json
@@ -4,7 +4,16 @@
   "description": "NAT-PMP client library",
   "homepage": "https://github.com/miniupnp/libnatpmp",
   "license": "BSD-3-Clause",
-  "dependencies": [],
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "tool": {
       "description": "Build natpmpc tool"


### PR DESCRIPTION
The link issue was because the MINIUPNP_STATICLIB and NATPMP_STATICLIB defines weren't being propogated from the dependency into openomf_core, which caused the headers to misbehave (and think they were part of a DLL build)

By linking to an imported cmake target we can be certain that any PUBLIC target_add_definitions in the libraries get to the openomf target we are linking them to, here openomf_core.

Unfortunately, [ubuntu's libminiupnpc-dev](https://packages.ubuntu.com/focal/amd64/libminiupnpc-dev/filelist) does not ship an exported cmake target (they are probably using the Makefile to build their package); if they did ship an exported cmake target, we would be able to rid ourselves of the Findminiupnpc.cmake script entirely and rely on find_package(CONFIG).