### PR TITLE
Don't statically link dependencies, yet

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -106,7 +106,7 @@ jobs:
         --toolchain vcpkg/scripts/buildsystems/vcpkg.cmake
         -DCMAKE_BUILD_TYPE="Release"
         -DVCPKG_BUILD_TYPE="release"
-        -DVCPKG_TARGET_TRIPLET="x64-windows-static"
+        -DVCPKG_TARGET_TRIPLET="x64-windows"
     - name: Build openomf
       run: cmake --build build-msvc --target openomf
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 project(OpenOMF C)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-scripts)
 
@@ -369,7 +369,23 @@ file(COPY resources/openomf.bk resources/gamecontrollerdb.txt DESTINATION resour
 if(WIN32)
     # On windows, generate a flat directory structure under openomf/ subdir.
     # This way we have an "openomf/" root directory inside the zip file.
-    install(TARGETS openomf RUNTIME DESTINATION openomf/ COMPONENT Binaries)
+    if(CMAKE_CROSSCOMPILING)
+        # RUNTIME_DEPENDENCIES is not supported when cross compiling
+        install(TARGETS openomf
+                RUNTIME
+                    DESTINATION openomf/
+                    COMPONENT Binaries
+        )
+    else()
+        install(TARGETS openomf
+            RUNTIME_DEPENDENCIES
+              PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+              POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+            RUNTIME
+                DESTINATION openomf/
+                COMPONENT Binaries
+        )
+    endif()
     install(FILES resources/openomf.bk resources/gamecontrollerdb.txt DESTINATION openomf/resources/ COMPONENT Data)
     install(DIRECTORY shaders/ DESTINATION openomf/shaders COMPONENT Data)
     install(FILES README.md BUILD.md LICENSE DESTINATION openomf/ COMPONENT Data)


### PR DESCRIPTION
Until we replace dependencies that are LGPL licensed (libxmp, getopt-win32)
we shouldn't statically link our dependencies.

libopenmpt looks like a good alternative to libxmp, and getopt-win32 is a transitive dependency via argtable.