### PR TITLE
Fixes for text dialog, kreissack dialog

### DIFF
--- a/src/game/gui/dialog.c
+++ b/src/game/gui/dialog.c
@@ -6,7 +6,7 @@
 #include "video/video.h"
 #include <string.h>
 
-#define MAX_WIDTH 160
+#define SCREEN_WIDTH 320
 
 void dialog_cancel(component *c, void *userdata) {
     dialog *dlg = userdata;
@@ -37,9 +37,11 @@ void dialog_create_with_tconf(dialog *dlg, dialog_style style, text_settings *tc
     dlg->userdata = NULL;
     dlg->clicked = NULL;
 
+    int w = SCREEN_WIDTH - 2 * x;
+
     component *menu = menu_create(11);
 
-    menu_attach(menu, label_create_with_width(tconf_desc, text, MAX_WIDTH));
+    menu_attach(menu, label_create_with_width(tconf_desc, text, w));
 
     component *menu2 = menu_create(11);
 
@@ -67,7 +69,7 @@ void dialog_create_with_tconf(dialog *dlg, dialog_style style, text_settings *tc
         menu_attach(menu2, ok);
     }
 
-    dlg->frame = guiframe_create(x, y, MAX_WIDTH, 80);
+    dlg->frame = guiframe_create(x, y, w, 80);
     guiframe_set_root(dlg->frame, menu);
     guiframe_layout(dlg->frame);
 }

--- a/src/game/gui/label.c
+++ b/src/game/gui/label.c
@@ -44,11 +44,10 @@ component *label_create_with_width(const text_settings *tconf, const char *text,
     local->text = strdup(text);
 
     int tsize = text_char_width(tconf);
-    int w, h;
-    w = text_find_max_strlen(tconf, max_width / tsize, text);
-    h = text_find_line_count(tconf, w, 0, strlen(text), text) * 8; // fonts are all 8 high?
+    int h = text_find_line_count(tconf, max_width / tsize, 0, strlen(text), text);
 
-    component_set_size_hints(c, w * tsize, h);
+    // fonts are all 8 high?
+    component_set_size_hints(c, max_width, h * 8);
 
     // local->tconf.cforeground = color_create(0, 255, 0, 255);
 

--- a/src/game/gui/text_render.c
+++ b/src/game/gui/text_render.c
@@ -16,7 +16,7 @@ void text_defaults(text_settings *settings) {
     settings->cspacing = 0;
     settings->max_lines = UINT8_MAX;
     settings->strip_leading_whitespace = false;
-    settings->strip_trailing_whitespace = false;
+    settings->strip_trailing_whitespace = true;
 }
 
 int text_render_char(const text_settings *settings, text_mode state, int x, int y, char ch) {

--- a/src/game/gui/textinput.c
+++ b/src/game/gui/textinput.c
@@ -235,6 +235,7 @@ component *textinput_create(const text_settings *tconf, const char *text, const 
     textinput *tb = omf_calloc(1, sizeof(textinput));
     tb->text = strdup(text);
     memcpy(&tb->tconf, tconf, sizeof(text_settings));
+    tb->tconf.max_lines = 1;
     tb->bg_enabled = 1;
     tb->max_chars = 15;
     tb->pos = 0;

--- a/src/game/scenes/vs.c
+++ b/src/game/scenes/vs.c
@@ -643,9 +643,15 @@ int vs_create(scene *scene) {
     local->quit_dialog.clicked = vs_quit_dialog_clicked;
 
     // Too Pathetic Dialog
-    char insult[512];
-    snprintf(insult, 512, lang_get(748), "Veteran", "Major Kreissack");
-    dialog_create(&local->too_pathetic_dialog, DIALOG_STYLE_OK, insult, 72, 40);
+
+    str insult;
+    str_from_c(&insult, lang_get(748));
+    str_replace(&insult, "%s", lang_get(345), 1);
+    str_replace(&insult, "%s", lang_get(30), 1);
+    // XXX HACK: Remove newline after kreissack's name until we clean up our string tables
+    str_replace(&insult, "\n.", ".", -1);
+    dialog_create(&local->too_pathetic_dialog, DIALOG_STYLE_OK, str_c(&insult), 40, 40);
+    str_free(&insult);
     local->too_pathetic_dialog.userdata = scene;
     local->too_pathetic_dialog.clicked = vs_too_pathetic_dialog_clicked;
 

--- a/src/game/scenes/vs.c
+++ b/src/game/scenes/vs.c
@@ -405,7 +405,7 @@ void vs_quit_dialog_clicked(dialog *dlg, dialog_result result) {
 
 void vs_too_pathetic_dialog_clicked(dialog *dlg, dialog_result result) {
     scene *sc = dlg->userdata;
-    game_state_set_next(sc->gs, SCENE_MENU);
+    game_state_set_next(sc->gs, SCENE_SCOREBOARD);
 }
 
 int vs_create(scene *scene) {


### PR DESCRIPTION
label_create_with_width was abusing `text_find_max_strlen` thinking it produces the length of the longest line in the text after wrapping, when it in fact only produces the next line's length.

Kreissack's difficulty dialog is now wider than other dialogs, which is good
compare OMF 2097:
![image](https://github.com/user-attachments/assets/999256ff-c77c-463e-8eaa-5b406ddea9d5)

and OpenOMF (with these changes)
![image](https://github.com/user-attachments/assets/01963103-b220-4e98-86b9-eaef8029933d)