### PR TITLE
Platform specific allocators

### DIFF
--- a/src/game/scenes/mainmenu/menu_language.c
+++ b/src/game/scenes/mainmenu/menu_language.c
@@ -68,6 +68,7 @@ component *menu_language_create(scene *s) {
     const char *dirname = pm_get_local_path(RESOURCE_PATH);
     if(dirname == NULL) {
         PERROR("Could not find resources path for menu_language!");
+        omf_free(local);
         return NULL;
     }
 

--- a/src/utils/allocator.c
+++ b/src/utils/allocator.c
@@ -1,27 +1,5 @@
 #include "utils/allocator.h"
-#include <stdio.h>
-#include <stdlib.h>
 
-void *omf_malloc_real(size_t size, const char *file, int line) {
-    void *ret = malloc(size);
-    if(ret != NULL)
-        return ret;
-    fprintf(stderr, "malloc(%zu) failed on %s:%d\n", size, file, line);
-    abort();
-}
-
-void *omf_calloc_real(size_t nmemb, size_t size, const char *file, int line) {
-    void *ret = calloc(nmemb, size);
-    if(ret != NULL)
-        return ret;
-    fprintf(stderr, "calloc(%zu, %zu) failed on %s:%d\n", nmemb, size, file, line);
-    abort();
-}
-
-void *omf_realloc_real(void *ptr, size_t size, const char *file, int line) {
-    void *ret = realloc(ptr, size);
-    if(ret != NULL)
-        return ret;
-    fprintf(stderr, "realloc(%p, %zu) failed on %s:%d\n", ptr, size, file, line);
-    abort();
-}
+const char *_text_malloc_error = "malloc(%zu) failed on %s:%d\n";
+const char *_text_calloc_error = "calloc(%zu, %zu) failed on %s:%d\n";
+const char *_text_realloc_error = "realloc(%p, %zu) failed on %s:%d\n";

--- a/src/utils/allocator.h
+++ b/src/utils/allocator.h
@@ -1,21 +1,15 @@
 #ifndef ALLOCATOR_H
 #define ALLOCATOR_H
 
-#include <stddef.h>
+extern const char *_text_malloc_error;
+extern const char *_text_calloc_error;
+extern const char *_text_realloc_error;
+
+// Add ifdefs here to include platform-specific allocators.
+#include "utils/allocator_default.h"
 
 #define omf_malloc(size) omf_malloc_real((size), __FILE__, __LINE__)
-void *omf_malloc_real(size_t size, const char *file, int line);
-
 #define omf_calloc(nmemb, size) omf_calloc_real((nmemb), (size), __FILE__, __LINE__)
-void *omf_calloc_real(size_t nmemb, size_t size, const char *file, int line);
-
 #define omf_realloc(ptr, size) omf_realloc_real((ptr), (size), __FILE__, __LINE__)
-void *omf_realloc_real(void *ptr, size_t size, const char *file, int line);
-
-#define omf_free(ptr)                                                                                                  \
-    do {                                                                                                               \
-        free(ptr);                                                                                                     \
-        (ptr) = NULL;                                                                                                  \
-    } while(0)
 
 #endif // ALLOCATOR_H

--- a/src/utils/allocator_default.h
+++ b/src/utils/allocator_default.h
@@ -1,0 +1,36 @@
+#ifndef ALLOCATOR_DEFAULT_H
+#define ALLOCATOR_DEFAULT_H
+
+#include <stddef.h>
+
+#define omf_free(ptr)                                                                                                  \
+    do {                                                                                                               \
+        free(ptr);                                                                                                     \
+        (ptr) = NULL;                                                                                                  \
+    } while(0)
+
+static inline void *omf_malloc_real(size_t size, const char *file, int line) {
+    void *ret = malloc(size);
+    if(ret != NULL)
+        return ret;
+    fprintf(stderr, _text_malloc_error, size, file, line);
+    abort();
+}
+
+static inline void *omf_calloc_real(size_t nmemb, size_t size, const char *file, int line) {
+    void *ret = calloc(nmemb, size);
+    if(ret != NULL)
+        return ret;
+    fprintf(stderr, _text_calloc_error, nmemb, size, file, line);
+    abort();
+}
+
+static inline void *omf_realloc_real(void *ptr, size_t size, const char *file, int line) {
+    void *ret = realloc(ptr, size);
+    if(ret != NULL)
+        return ret;
+    fprintf(stderr, _text_realloc_error, ptr, size, file, line);
+    abort();
+}
+
+#endif // ALLOCATOR_DEFAULT_H

--- a/src/utils/allocator_default.h
+++ b/src/utils/allocator_default.h
@@ -2,6 +2,7 @@
 #define ALLOCATOR_DEFAULT_H
 
 #include <stddef.h>
+#include <stdio.h>
 
 #define omf_free(ptr)                                                                                                  \
     do {                                                                                                               \


### PR DESCRIPTION
- Move allocators to a header and mark them "static inline". This should make the compiler inline the functions wherever needed.
- Add a way to make the allocator functions different per platform.