### PR TITLE
Fix mising include in allocator_default.h

### DIFF
--- a/src/utils/allocator_default.h
+++ b/src/utils/allocator_default.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define omf_free(ptr)                                                                                                  \
     do {                                                                                                               \


### PR DESCRIPTION
```
/home/andrew/openomf/src/utils/allocator_default.h:14:17: error: call to undeclared library function 'malloc' with type 'void *(unsigned long)'; ISO C99 and later do not support implicit function declarations [clang-diagnostic-implicit-function-declaration]
   14 |     void *ret = malloc(size);
      |                 ^
/home/andrew/openomf/src/utils/allocator_default.h:14:17: note: include the header <stdlib.h> or explicitly provide a declaration for 'malloc'
```