### PR TITLE
Fix palette crash again

### DIFF
--- a/src/game/gui/dialog.c
+++ b/src/game/gui/dialog.c
@@ -6,8 +6,6 @@
 #include "video/video.h"
 #include <string.h>
 
-#define SCREEN_WIDTH 320
-
 void dialog_cancel(component *c, void *userdata) {
     dialog *dlg = userdata;
     if(dlg->clicked) {
@@ -37,7 +35,7 @@ void dialog_create_with_tconf(dialog *dlg, dialog_style style, text_settings *tc
     dlg->userdata = NULL;
     dlg->clicked = NULL;
 
-    int w = SCREEN_WIDTH - 2 * x;
+    int w = NATIVE_W - 2 * x;
 
     component *menu = menu_create(11);
 

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -473,7 +473,8 @@ void object_free(object *obj) {
     if(obj == NULL) {
         return;
     }
-    vga_state_disable_palette_transform(object_scenewide_palette_transform, obj);
+    vga_state_disable_palette_transform(object_palette_copy_transform, obj);
+    vga_state_disable_palette_transform(object_scenewide_palette_transform, &obj->sprite_state);
     if(obj->free != NULL) {
         obj->free(obj);
     }


### PR DESCRIPTION
When adding (or otherwise changing) `vga_state_enable_palette_transform` calls, please ensure there are corresponding `vga_state_disable_palette_transform` calls to prevent use-after-frees.

Also a really minor cleanup in dialog.c