### PR TITLE
bb, bl, bm, and bj should not set blend_finish

### DIFF
--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -457,21 +457,13 @@ void player_run(object *obj) {
 
         // Blend mode stuff
         if(sd_script_isset(frame, "bb")) {
-            rstate->blend_finish = sd_script_get(frame, "bb");
             rstate->screen_shake_vertical = sd_script_get(frame, "bb");
         }
         if(sd_script_isset(frame, "bf")) {
             rstate->blend_finish = sd_script_get(frame, "bf");
         }
         if(sd_script_isset(frame, "bl")) {
-            rstate->blend_finish = sd_script_get(frame, "bl");
             rstate->screen_shake_horizontal = sd_script_get(frame, "bl");
-        }
-        if(sd_script_isset(frame, "bm")) {
-            rstate->blend_finish = sd_script_get(frame, "bm");
-        }
-        if(sd_script_isset(frame, "bj")) {
-            rstate->blend_finish = sd_script_get(frame, "bj");
         }
         if(sd_script_isset(frame, "bs")) {
             rstate->blend_start = sd_script_get(frame, "bs");


### PR DESCRIPTION
Fixes unwanted fades during animations that shake the screen (bb, bl), and animations that play other animations (bm, bj)

Note that bm and bj have handling lower down in player.c (away from the blend modes), that'll hopefully get fixed sometime.

the bug in question:
![image](https://github.com/user-attachments/assets/ae36e551-4909-4527-9ccd-66e01d5d27e7)
