### PR TITLE
Prevent palette transformers from staying stuck on

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -282,6 +282,7 @@ void engine_run(engine_init_flags *init_flags) {
             // with the actual gameplay stuff.
             has_dynamic = dynamic_wait > game_state_ms_per_dyntick(gs);
             if(has_dynamic) {
+                vga_state_dynamic_tick();
                 game_state_dynamic_tick(gs, false);
                 dynamic_wait -= game_state_ms_per_dyntick(gs);
             }

--- a/src/video/damage_tracker.c
+++ b/src/video/damage_tracker.c
@@ -12,6 +12,15 @@ void damage_copy(damage_tracker *dst, const damage_tracker *src) {
     memcpy(dst, src, sizeof(damage_tracker));
 }
 
+void damage_combine(damage_tracker *dst, const damage_tracker *src) {
+    if(!src->dirty) {
+        return;
+    }
+    dst->dirty = true;
+    dst->dirty_range_start = min2(dst->dirty_range_start, src->dirty_range_start);
+    dst->dirty_range_end = max2(dst->dirty_range_end, src->dirty_range_end);
+}
+
 void damage_set_range(damage_tracker *tracker, vga_index start, vga_index end) {
     tracker->dirty = true;
     tracker->dirty_range_start = min2(tracker->dirty_range_start, start);

--- a/src/video/damage_tracker.h
+++ b/src/video/damage_tracker.h
@@ -12,6 +12,7 @@ typedef struct damage_tracker {
 
 void damage_reset(damage_tracker *tracker);
 void damage_copy(damage_tracker *dst, const damage_tracker *src);
+void damage_combine(damage_tracker *dst, const damage_tracker *src);
 void damage_set_range(damage_tracker *tracker, vga_index start, vga_index end);
 
 #endif // DAMAGE_TRACKER_H

--- a/src/video/vga_state.c
+++ b/src/video/vga_state.c
@@ -56,10 +56,17 @@ void vga_state_render(void) {
         damage_reset(&state.dmg_base);
 
         // Run transformers on top. These may modify the current palette and change dirtiness state.
+        damage_tracker damage_transformers;
+        damage_reset(&damage_transformers);
         for(unsigned int i = 0; i < state.transformer_count; i++) {
-            state.transformers[i].callback(&state.dmg_current, &state.current, state.transformers[i].userdata);
+            state.transformers[i].callback(&damage_transformers, &state.current, state.transformers[i].userdata);
         }
         state.transformer_count = 0;
+
+        damage_combine(&state.dmg_current, &damage_transformers);
+        // mark next frame's base as damaged in these transformers' absence
+        damage_combine(&state.dmg_base, &damage_transformers);
+
         damage_copy(&state.dmg_previous, &state.dmg_current);
     }
 }

--- a/src/video/vga_state.h
+++ b/src/video/vga_state.h
@@ -11,6 +11,7 @@ typedef void (*vga_palette_transform)(damage_tracker *damage, vga_palette *palet
 void vga_state_init(void);
 void vga_state_close(void);
 void vga_state_render(void);
+void vga_state_dynamic_tick(void);
 
 void vga_state_mark_palette_flushed(void);
 void vga_state_mark_remaps_flushed(void);


### PR DESCRIPTION
Palette transformers now damage both the current frame's dmg_current and the next frame's dmg_base

This ensures that the first frame a palette transformer is removed, the base colors will be written to the current palette & uploaded.