### PR TITLE
Slightly better Newsroom Captures

### DIFF
--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -84,6 +84,8 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
     // Disable warp (debug) speed by default. This can be set in console.
     gs->warp_speed = 0;
 
+    gs->hide_ui = false;
+
     // Set up players
     gs->sc = omf_calloc(1, sizeof(scene));
     for(int i = 0; i < 2; i++) {

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -55,6 +55,9 @@ typedef struct game_state_t {
     int next_wait_ticks;
     int this_wait_ticks;
 
+    // Newsroom HAR screencaps
+    bool hide_ui;
+
     // For debugging, sets fastest possible mode :)
     int warp_speed;
 

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -614,7 +614,7 @@ void har_take_damage(object *obj, const str *string, float damage, float stun) {
     if(h->health == 0) {
         game_player *other_player = game_state_get_player(obj->gs, !h->player_id);
         object *other_har = game_state_find_object(obj->gs, other_player->har_obj_id);
-        har_screencaps_capture(&other_player->screencaps, other_har, SCREENCAP_BLOW);
+        har_screencaps_capture(&other_player->screencaps, other_har, obj, SCREENCAP_BLOW);
     }
 
     // If damage is high enough, slow down the game for a bit

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -237,10 +237,10 @@ void arena_screengrab_winner(scene *sc) {
     object *o1 = game_state_find_object(gs, game_state_get_player(gs, 0)->har_obj_id);
     har *h1 = object_get_userdata(o1);
     if(h1->state == STATE_VICTORY || h1->state == STATE_DONE) {
-        har_screencaps_capture(&game_state_get_player(gs, 0)->screencaps, o1, SCREENCAP_POSE);
+        har_screencaps_capture(&game_state_get_player(gs, 0)->screencaps, o1, NULL, SCREENCAP_POSE);
     } else {
         object *o2 = game_state_find_object(gs, game_state_get_player(gs, 0)->har_obj_id);
-        har_screencaps_capture(&game_state_get_player(gs, 1)->screencaps, o2, SCREENCAP_POSE);
+        har_screencaps_capture(&game_state_get_player(gs, 1)->screencaps, o2, NULL, SCREENCAP_POSE);
     }
 }
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1093,6 +1093,10 @@ int arena_event(scene *scene, SDL_Event *e) {
 }
 
 void arena_render_overlay(scene *scene) {
+    if(scene->gs->hide_ui) {
+        return;
+    }
+
     arena_local *local = scene_get_userdata(scene);
 
     // Render bars

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -681,7 +681,7 @@ static void load_har_portraits(scene *scene, melee_local *local) {
 
         // Copy the enabled image, and compress the colors to grayscale
         surface_create_from(&target->disabled, &target->enabled);
-        surface_convert_to_grayscale(&target->disabled, &pal, 0xD0, 0xDF);
+        surface_convert_to_grayscale(&target->disabled, &pal, 0xD0, 0xDF, 0);
     }
 }
 

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -387,6 +387,13 @@ int newsroom_create(scene *scene) {
     local->continue_dialog.userdata = scene;
     local->continue_dialog.clicked = newsroom_continue_dialog_clicked;
 
+    for(int i = 0; i < 2; i++) {
+        game_player *player = game_state_get_player(scene->gs, i);
+
+        // load the player's colors into the palette
+        palette_load_player_colors(&player->pilot->palette, i);
+    }
+
     // Set callbacks
     scene_set_userdata(scene, local);
     scene_set_input_poll_cb(scene, newsroom_input_tick);

--- a/src/game/utils/har_screencap.c
+++ b/src/game/utils/har_screencap.c
@@ -51,6 +51,8 @@ void har_screencaps_capture(har_screencaps *caps, object *obj, object *obj2, int
         caps->ok[id] = false;
     }
 
+    game_state *gs = obj->gs;
+
     // Position
     vec2i pos = camera_position_for(obj);
     vec2i size = {SCREENCAP_W, SCREENCAP_H};
@@ -62,6 +64,12 @@ void har_screencaps_capture(har_screencaps *caps, object *obj, object *obj2, int
         pos.x = min2(pos.x, pos2.x);
         pos.y -= (size.y - SCREENCAP_H) / 2;
     }
+
+    video_render_prepare();
+    gs->hide_ui = true;
+    game_state_render(gs);
+    gs->hide_ui = false;
+    video_render_finish_offscreen();
 
     // Capture
     video_area_capture(&caps->cap[id], pos.x, pos.y, size.x, size.y);

--- a/src/game/utils/har_screencap.c
+++ b/src/game/utils/har_screencap.c
@@ -48,10 +48,11 @@ void har_screencaps_capture(har_screencaps *caps, object *obj, int id) {
     int y = clamp(y_center + y_margin, 0, NATIVE_H);
 
     // Capture
-    video_area_capture(&caps->cap[id], x, y, SCREENCAP_W, SCREENCAP_H);
+    surface *cap = &caps->cap[id];
+    video_area_capture(cap, x, y, SCREENCAP_W, SCREENCAP_H);
     caps->ok[id] = true;
 }
 
 void har_screencaps_compress(har_screencaps *caps, const vga_palette *pal, int id) {
-    surface_convert_to_grayscale(&caps->cap[id], pal, 0xD0, 0xDF);
+    surface_convert_to_grayscale(&caps->cap[id], pal, 0xD0, 0xDF, 0x60);
 }

--- a/src/game/utils/har_screencap.h
+++ b/src/game/utils/har_screencap.h
@@ -20,7 +20,7 @@ void har_screencaps_create(har_screencaps *caps);
 void har_screencaps_free(har_screencaps *caps);
 void har_screencaps_reset(har_screencaps *caps);
 int har_screencaps_clone(har_screencaps *src, har_screencaps *dst);
-void har_screencaps_capture(har_screencaps *caps, object *obj, int id);
+void har_screencaps_capture(har_screencaps *caps, object *obj, object *obj2, int id);
 void har_screencaps_compress(har_screencaps *caps, const vga_palette *pal, int id);
 
 #endif // HAR_SCREENCAP_H

--- a/src/video/surface.c
+++ b/src/video/surface.c
@@ -126,13 +126,18 @@ void surface_flatten_to_mask(surface *sur, uint8_t value) {
     sur->guid = guid++;
 }
 
-void surface_convert_to_grayscale(surface *sur, const vga_palette *pal, int range_start, int range_end) {
+void surface_convert_to_grayscale(surface *sur, const vga_palette *pal, int range_start, int range_end,
+                                  int ignore_below) {
     float r, g, b;
     uint8_t idx;
     unsigned char mapping[256];
 
     // Make a mapping for fast search.
     for(int i = 0; i < 256; i++) {
+        if(i < ignore_below) {
+            mapping[i] = i;
+            continue;
+        }
         r = pal->colors[i].r * 0.3;
         g = pal->colors[i].g * 0.59;
         b = pal->colors[i].b * 0.11;

--- a/src/video/surface.h
+++ b/src/video/surface.h
@@ -75,8 +75,10 @@ void surface_compress_remap(surface *sur, int range_start, int range_end, int re
  * @param pal Palette to use.
  * @param range_start First grey palette color
  * @param range_end Last gray palette color
+ * @param ignore_below Leave indexes below this range alone
  */
-void surface_convert_to_grayscale(surface *sur, const vga_palette *pal, int range_start, int range_end);
+void surface_convert_to_grayscale(surface *sur, const vga_palette *pal, int range_start, int range_end,
+                                  int ignore_below);
 
 /**
  * Write surface to a PNG file.

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -171,6 +171,7 @@ static void video_set_blend_mode(object_array_blend_mode request_mode) {
 void video_area_capture(surface *sur, int x, int y, int w, int h) {
     render_target_activate(g_video_state.target);
     unsigned char *buffer = omf_calloc(1, w * h);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
     glReadPixels(x, y, w, h, GL_RED, GL_UNSIGNED_BYTE, buffer);
     surface_create_from_data_flip(sur, w, h, buffer);
     surface_set_transparency(sur, -1);

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -91,6 +91,7 @@ void video_draw_full(const surface *src_surface, int x, int y, int w, int h, int
 void video_reset_atlas(void);
 
 void video_render_prepare(void);
+void video_render_finish_offscreen(void);
 void video_render_finish(void);
 void video_close(void);
 void video_area_capture(surface *sur, int x, int y, int w, int h);


### PR DESCRIPTION
New:
1. Newsroom shows robots in color
2. Newsroom "final blow" capture will zoom out to show both robots as needed
3. Arena overlay UI is now hidden in captures (the round token objects are unfortunately still present)

1 and 2 are for parity with the original game, 3 is extra.

future work:
- the original game's seamless transition from arena to newsroom
- improve camera positioning + sizing logic
- hide objects in captures, chiefly the round token objects.
- shadow's shadows currently all show up in color, haven't checked what the original does

![image](https://github.com/user-attachments/assets/ad230eb1-446e-4f34-917b-7883c58bbe48)

![screenshot_20241106_122744](https://github.com/user-attachments/assets/140352f4-d8a2-49fd-88f8-2dcf2cff8a45)
