### PR TITLE
Treat object palette transformers like other cb's

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -289,6 +289,8 @@ void engine_run(engine_init_flags *init_flags) {
 
         // Do the actual video rendering jobs
         if(enable_screen_updates) {
+            vga_state_clear_palette_transform();
+            game_state_palette_transform(gs);
 
             vga_state_render();
             video_render_prepare();

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -650,18 +650,6 @@ void game_state_static_tick(game_state *gs, bool replay) {
         gs->next_wait_ticks--;
     }
 
-    // Tick controllers
-    game_state_tick_controllers(gs);
-
-    // Call static ticks for scene
-    scene_static_tick(gs->sc, game_state_is_paused(gs));
-
-    // Call static tick functions
-    game_state_call_tick(gs, TICK_STATIC);
-}
-
-// This function is called when the game speed requires it
-void game_state_dynamic_tick(game_state *gs, bool replay) {
     // We want to load another scene
     if(gs->this_id != gs->next_id && (gs->next_wait_ticks <= 1 || !settings_get()->video.crossfade_on)) {
         // If this is the end, set run to 0 so that engine knows to close here
@@ -685,6 +673,18 @@ void game_state_dynamic_tick(game_state *gs, bool replay) {
         }
     }
 
+    // Tick controllers
+    game_state_tick_controllers(gs);
+
+    // Call static ticks for scene
+    scene_static_tick(gs->sc, game_state_is_paused(gs));
+
+    // Call static tick functions
+    game_state_call_tick(gs, TICK_STATIC);
+}
+
+// This function is called when the game speed requires it
+void game_state_dynamic_tick(game_state *gs, bool replay) {
     // Change the screen shake value downwards
     if(gs->screen_shake_horizontal > 0 && !gs->paused) {
         gs->screen_shake_horizontal--;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -406,6 +406,21 @@ void game_state_render(game_state *gs) {
     scene_render_overlay(gs->sc);
 }
 
+void game_state_palette_transform(game_state *gs) {
+    // object transforms
+    render_obj *robj;
+    iterator it;
+    vector_iter_begin(&gs->objects, &it);
+    while((robj = iter_next(&it)) != NULL) {
+        object_palette_transform(robj->obj);
+    }
+
+    // Cross-fade effect
+    if(gs->next_wait_ticks > 0 || gs->this_wait_ticks > 0) {
+        vga_state_enable_palette_transform(cross_fade_transform, gs);
+    }
+}
+
 void game_state_debug(game_state *gs) {
     // If we are in debug mode, handle HAR debug layers
 #ifdef DEBUGMODE
@@ -668,11 +683,6 @@ void game_state_dynamic_tick(game_state *gs, bool replay) {
             gs->this_wait_ticks = 0;
             gs->next_wait_ticks = 0;
         }
-    }
-
-    // Cross-fade effect
-    if(gs->next_wait_ticks > 0 || gs->this_wait_ticks > 0) {
-        vga_state_enable_palette_transform(cross_fade_transform, gs);
     }
 
     // Change the screen shake value downwards

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -16,6 +16,7 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags);
 void game_state_free(game_state **gs);
 int game_state_handle_event(game_state *gs, SDL_Event *event);
 void game_state_render(game_state *gs);
+void game_state_palette_transform(game_state *gs);
 void game_state_debug(game_state *gs);
 void game_state_static_tick(game_state *gs, bool replay);
 void game_state_dynamic_tick(game_state *gs, bool replay);

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -34,7 +34,6 @@ void har_spawn_scrap(object *obj, vec2i pos, int amount);
 void har_palette_transform(damage_tracker *damage, vga_palette *pal, void *obj);
 
 void har_free(object *obj) {
-    vga_state_disable_palette_transform(har_palette_transform, obj);
     har *h = object_get_userdata(obj);
     list_free(&h->har_hooks);
 #ifdef DEBUGMODE
@@ -1329,8 +1328,10 @@ void har_tick(object *obj) {
     controller *ctrl = game_player_get_ctrl(game_state_get_player(obj->gs, h->player_id));
 
     if(h->p_ticks_left > 0) {
-        vga_state_enable_palette_transform(har_palette_transform, obj);
+        object_set_palette_transform_cb(obj, har_palette_transform);
         h->p_ticks_left--;
+    } else {
+        object_set_palette_transform_cb(obj, NULL);
     }
 
     if(h->in_stasis_ticks > 0) {

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -9,6 +9,7 @@
 #include "utils/random.h"
 #include "utils/vec.h"
 #include "video/surface.h"
+#include "video/vga_state.h"
 
 #define OBJECT_DEFAULT_LAYER 0x01
 #define OBJECT_NO_GROUP -1
@@ -132,6 +133,7 @@ struct object_t {
     object_collide_cb collide;
     object_finish_cb finish;
     object_move_cb move;
+    vga_palette_transform palette_transform;
     object_debug_cb debug;
     object_clone_cb clone;
     object_clone_free_cb clone_free;
@@ -141,6 +143,7 @@ void object_create(object *obj, game_state *gs, vec2i pos, vec2f vel);
 void object_create_static(object *obj, game_state *gs);
 void object_render(object *obj);
 void object_render_shadow(object *obj);
+void object_palette_transform(object *obj);
 void object_debug(object *obj);
 void object_static_tick(object *obj);
 void object_dynamic_tick(object *obj);
@@ -196,6 +199,7 @@ void object_set_static_tick_cb(object *obj, object_tick_cb cbfunc);
 void object_set_collide_cb(object *obj, object_collide_cb cbfunc);
 void object_set_finish_cb(object *obj, object_finish_cb cbfunc);
 void object_set_move_cb(object *obj, object_move_cb cbfunc);
+void object_set_palette_transform_cb(object *obj, vga_palette_transform palette_transform_cb);
 void object_set_debug_cb(object *obj, object_debug_cb cbfunc);
 
 void object_set_repeat(object *obj, int repeat);

--- a/src/video/damage_tracker.c
+++ b/src/video/damage_tracker.c
@@ -12,6 +12,14 @@ void damage_copy(damage_tracker *dst, const damage_tracker *src) {
     memcpy(dst, src, sizeof(damage_tracker));
 }
 
+void damage_combine(damage_tracker *dst, const damage_tracker *src) {
+    if(!src->dirty) {
+        return;
+    }
+    dst->dirty = true;
+    dst->dirty_range_start = min2(dst->dirty_range_start, src->dirty_range_start);
+    dst->dirty_range_end = max2(dst->dirty_range_end, src->dirty_range_end);
+}
 void damage_set_range(damage_tracker *tracker, vga_index start, vga_index end) {
     tracker->dirty = true;
     tracker->dirty_range_start = min2(tracker->dirty_range_start, start);

--- a/src/video/damage_tracker.h
+++ b/src/video/damage_tracker.h
@@ -12,6 +12,7 @@ typedef struct damage_tracker {
 
 void damage_reset(damage_tracker *tracker);
 void damage_copy(damage_tracker *dst, const damage_tracker *src);
+void damage_combine(damage_tracker *dst, const damage_tracker *src);
 void damage_set_range(damage_tracker *tracker, vga_index start, vga_index end);
 
 #endif // DAMAGE_TRACKER_H

--- a/src/video/vga_state.h
+++ b/src/video/vga_state.h
@@ -11,6 +11,7 @@ typedef void (*vga_palette_transform)(damage_tracker *damage, vga_palette *palet
 void vga_state_init(void);
 void vga_state_close(void);
 void vga_state_render(void);
+void vga_state_clear_palette_transform(void);
 
 void vga_state_mark_palette_flushed(void);
 void vga_state_mark_remaps_flushed(void);
@@ -38,7 +39,6 @@ void vga_state_set_base_palette_range(vga_index start, vga_index count, vga_colo
 void vga_state_copy_base_palette_range(vga_index dst, vga_index src, vga_index count);
 
 void vga_state_enable_palette_transform(vga_palette_transform transform_callback, void *userdata);
-bool vga_state_disable_palette_transform(vga_palette_transform transform_callback, void *userdata);
 
 // Take debug snapshot of the current palette state.
 void vga_state_debug_screenshot(const char *filename);


### PR DESCRIPTION
Objects now have a `palette_transform` field to store their palette transformer callback.

`vga_render` now calls into game_state and object to gather all the palette transformers for the render.

Much like PR 756, `vga_state_render` will now calculate the palette data on the first frame all transformers are off, to ensure the current palette is updated to match the base palette. This solves the bug where palette transformer's effects persist after removal.

Obsoletes PR #756

EDIT: removed vga_state_tick layer of laziness/change detection-- transformers are now gathered every render frame