### PR TITLE
Add incremental BK loading

### DIFF
--- a/src/formats/bk.c
+++ b/src/formats/bk.c
@@ -117,7 +117,7 @@ int sd_bk_load_incremental(sd_bk_file *bk, sd_reader *r) {
                 return SD_AGAIN;
             }
             if(!sd_reader_ok(r)) {
-                // is this an error?
+                // TODO is this an error?
                 return SD_INVALID_INPUT;
             }
 
@@ -184,7 +184,6 @@ int sd_bk_load(sd_bk_file *bk, const char *filename) {
     while((ret = sd_bk_load_incremental(bk, r)) == SD_AGAIN) {
     }
 
-exit_0:
     sd_reader_close(r);
     return ret;
 }

--- a/src/formats/bk.h
+++ b/src/formats/bk.h
@@ -193,6 +193,8 @@ int sd_bk_pop_palette(sd_bk_file *bk);
  */
 vga_palette *sd_bk_get_palette(const sd_bk_file *bk, int index);
 
+int sd_bk_load_incremental(sd_bk_file *bk, sd_reader *r);
+
 /*! \brief Load .BK file
  *
  * Loads the given BK file to memory. The structure must be initialized with sd_bk_create()

--- a/src/formats/bk.h
+++ b/src/formats/bk.h
@@ -18,7 +18,8 @@
 #define MAX_BK_ANIMS 50   ///< Amount of animations in the BK file. This is fixed!
 #define MAX_BK_PALETTES 8 ///< Maximum amount of palettes allowed in BK file.
 
-typedef enum {
+typedef enum
+{
     BK_LOAD_INIT = 0,
     BK_LOAD_ANIMS,
     BK_LOAD_BACKGROUND,

--- a/src/formats/bk.h
+++ b/src/formats/bk.h
@@ -18,11 +18,21 @@
 #define MAX_BK_ANIMS 50   ///< Amount of animations in the BK file. This is fixed!
 #define MAX_BK_PALETTES 8 ///< Maximum amount of palettes allowed in BK file.
 
+typedef enum {
+    BK_LOAD_INIT = 0,
+    BK_LOAD_ANIMS,
+    BK_LOAD_BACKGROUND,
+    BK_LOAD_PALETTES,
+    BK_LOAD_POSTPROCESS,
+    BK_LOAD_DONE,
+} bk_load_state;
+
 /*! \brief BK file information
  *
  * Contains information about an OMF:2097 scene. Eg. arenas, menus, intro, etc.
  */
 typedef struct {
+    bk_load_state load_state;
     uint32_t file_id;      ///< File ID
     uint8_t unknown_a;     ///< Unknown value
     uint8_t palette_count; ///< Number of palettes in the BK file

--- a/src/formats/error.c
+++ b/src/formats/error.c
@@ -27,6 +27,8 @@ const char *sd_get_error(enum SD_ERRORCODE error_code) {
             return "File could not be read";
         case SD_FILE_UNLINK_ERROR:
             return "File could not be unlinked";
+        case SD_AGAIN:
+            return "Function not finished, call it again";
     }
     abort();
 }

--- a/src/formats/error.h
+++ b/src/formats/error.h
@@ -27,6 +27,7 @@ enum SD_ERRORCODE
     SD_FILE_WRITE_ERROR,     ///< File could not be written
     SD_FILE_READ_ERROR,      ///< File could not be read
     SD_FILE_UNLINK_ERROR,    ///< File could not be unlinked
+    SD_AGAIN,                ///< Function isn't done, needs to be called again
 };
 
 /*! \brief Get text error for error ID

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -457,11 +457,6 @@ int game_load_new(game_state *gs, int scene_id) {
     // Free texture items, we are going to create new ones.
     video_reset_atlas();
 
-    if(scene_create(gs->sc, gs, scene_id)) {
-        PERROR("Error while loading scene %d.", scene_id);
-        goto error_0;
-    }
-
     // Remove old objects
     render_obj *robj;
     iterator it;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -437,12 +437,12 @@ void game_state_debug(game_state *gs) {
 
 int game_load_new(game_state *gs, int scene_id) {
     // Free old scene
-    //scene_free(gs->sc);
-    //omf_free(gs->sc);
+    // scene_free(gs->sc);
+    // omf_free(gs->sc);
 
     // Initialize new scene with BK data etc.
-    //gs->sc = omf_calloc(1, sizeof(scene));
-    int ret =scene_create_incremental(gs->sc, gs, scene_id);
+    // gs->sc = omf_calloc(1, sizeof(scene));
+    int ret = scene_create_incremental(gs->sc, gs, scene_id);
 
     if(ret == SD_AGAIN) {
         DEBUG("scene still loading");
@@ -473,8 +473,6 @@ int game_load_new(game_state *gs, int scene_id) {
             vector_delete(&gs->objects, &it);
         }
     }
-
-
 
     // Load scene specifics
     switch(scene_id) {
@@ -681,7 +679,7 @@ void game_state_static_tick(game_state *gs, bool replay) {
             PERROR("Error while loading new scene! bailing.");
             gs->run = 0;
             return;
-        } 
+        }
         if(settings_get()->video.crossfade_on) {
             gs->this_wait_ticks = FRAME_WAIT_TICKS;
         } else {

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -445,7 +445,6 @@ int game_load_new(game_state *gs, int scene_id) {
     int ret = scene_create_incremental(gs->sc, gs, scene_id);
 
     if(ret == SD_AGAIN) {
-        DEBUG("scene still loading");
         return SD_AGAIN;
     }
 

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -1,6 +1,8 @@
 #ifndef GAME_STATE_TYPE_H
 #define GAME_STATE_TYPE_H
 
+#include <stdbool.h>
+
 #include "engine.h"
 #include "game/protos/fight_stats.h"
 #include "utils/random.h"

--- a/src/game/protos/scene.c
+++ b/src/game/protos/scene.c
@@ -81,9 +81,10 @@ int scene_create_incremental(scene *scene, game_state *gs, int scene_id) {
         // not done loading yet
         return SD_AGAIN;
     }
-    bk_free(scene->bk_data);
     scene_free(scene);
     scene->bk_data = scene->next_bk_data->bk;
+
+    DEBUG("setting bk_data %p", scene->bk_data);
     omf_free(scene->next_bk_data);
     scene->id = scene_id;
     scene->gs = gs;
@@ -266,6 +267,7 @@ void scene_free(scene *scene) {
     if(scene->free != NULL) {
         scene->free(scene);
     }
+    DEBUG("freeing %p", scene->bk_data);
     bk_free(scene->bk_data);
     omf_free(scene->bk_data);
     if(scene->af_data[0]) {

--- a/src/game/protos/scene.c
+++ b/src/game/protos/scene.c
@@ -77,7 +77,7 @@ int scene_create_incremental(scene *scene, game_state *gs, int scene_id) {
     if(ret != SD_SUCCESS && ret != SD_AGAIN) {
         PERROR("Unable to load scene %s (%s)!", scene_get_name(scene_id), get_resource_name(resource_id));
         return ret;
-    } else if (ret == SD_AGAIN) {
+    } else if(ret == SD_AGAIN) {
         // not done loading yet
         return SD_AGAIN;
     }
@@ -118,7 +118,6 @@ int scene_create_incremental(scene *scene, game_state *gs, int scene_id) {
     DEBUG("Loaded scene %s (%s).", scene_get_name(scene_id), get_resource_name(resource_id));
     return 0;
 }
-
 
 int scene_load_har(scene *scene, int player_id) {
     game_player *player = game_state_get_player(scene->gs, player_id);

--- a/src/game/protos/scene.h
+++ b/src/game/protos/scene.h
@@ -9,8 +9,8 @@
 #include "game/utils/serial.h"
 #include "game/utils/ticktimer.h"
 #include "resources/bk.h"
-#include "video/surface.h"
 #include "resources/bk_loader.h"
+#include "video/surface.h"
 #include <SDL.h>
 
 typedef struct scene_t scene;

--- a/src/game/protos/scene.h
+++ b/src/game/protos/scene.h
@@ -10,6 +10,7 @@
 #include "game/utils/ticktimer.h"
 #include "resources/bk.h"
 #include "video/surface.h"
+#include "resources/bk_loader.h"
 #include <SDL.h>
 
 typedef struct scene_t scene;
@@ -30,6 +31,7 @@ typedef void (*scene_clone_free_cb)(scene *scene);
 struct scene_t {
     game_state *gs;
     int id;
+    bk_inc *next_bk_data;
     bk *bk_data;
     af *af_data[2];
     void *userdata;
@@ -50,6 +52,7 @@ struct scene_t {
 };
 
 int scene_create(scene *scene, game_state *gs, int scene_id);
+int scene_create_incremental(scene *scene, game_state *gs, int scene_id);
 int scene_load_har(scene *scene, int player_id);
 void scene_init(scene *scene);
 void scene_free(scene *scene);

--- a/src/resources/bk.h
+++ b/src/resources/bk.h
@@ -16,7 +16,9 @@ typedef struct bk_t {
     char sound_translation_table[30];
 } bk;
 
+void bk_create_inc(bk *b, void *src);
 void bk_create(bk *b, void *src);
+int bk_convert_inc(bk *b, void *src);
 bk_info *bk_get_info(bk *b, int id);
 vga_palette *bk_get_palette(bk *b, int id);
 vga_remap_tables *bk_get_remaps(bk *b, int id);

--- a/src/resources/bk_loader.c
+++ b/src/resources/bk_loader.c
@@ -1,7 +1,7 @@
 #include "resources/bk_loader.h"
 #include "formats/bk.h"
-#include "formats/error.h"
 #include "resources/pathmanager.h"
+#include "utils/allocator.h"
 
 int load_bk_file(bk *b, int id) {
     // Get directory + filename
@@ -21,4 +21,48 @@ int load_bk_file(bk *b, int id) {
     bk_create(b, &tmp);
     sd_bk_free(&tmp);
     return 0;
+}
+
+int bk_inc_create(bk_inc *b, int id) {
+    // Get directory + filename
+    const char *filename = pm_get_resource_path(id);
+
+    // Initialize reader
+    if(!(b->r = sd_reader_open(filename))) {
+        return SD_FILE_OPEN_ERROR;
+    }
+
+    if(sd_bk_create(&b->sd_bk) != SD_SUCCESS) {
+        sd_bk_free(&b->sd_bk);
+        sd_reader_close(b->r);
+        return 1;
+    }
+
+    b->state = 1;
+    return SD_AGAIN;
+}
+
+int load_bk_file_incremental(bk_inc *b, int id) {
+    int ret = SD_SUCCESS;
+    switch(b->state) {
+        case 0:
+            return bk_inc_create(b, id);
+        case 1:
+            ret = sd_bk_load_incremental(&b->sd_bk, b->r);
+            if (ret == SD_SUCCESS) {
+                b->state = 2;
+                return SD_AGAIN;
+            }
+            if(ret != SD_AGAIN) {
+                sd_reader_close(b->r);
+            }
+            return ret;
+        case 2:
+            b->bk = omf_calloc(1, sizeof(bk));
+            // this should be fast, so do it in one pass
+            bk_create(b->bk, &b->sd_bk);
+            b->state = 3;
+            return SD_SUCCESS;
+    }
+    return ret;
 }

--- a/src/resources/bk_loader.c
+++ b/src/resources/bk_loader.c
@@ -2,6 +2,7 @@
 #include "formats/bk.h"
 #include "resources/pathmanager.h"
 #include "utils/allocator.h"
+#include "utils/log.h"
 
 int load_bk_file(bk *b, int id) {
     // Get directory + filename
@@ -59,8 +60,11 @@ int load_bk_file_incremental(bk_inc *b, int id) {
             return ret;
         case 2:
             b->bk = omf_calloc(1, sizeof(bk));
+            DEBUG("creating BK %p", b->bk);
             // this should be fast, so do it in one pass
             bk_create(b->bk, &b->sd_bk);
+            sd_bk_free(&b->sd_bk);
+            sd_reader_close(b->r);
             b->state = 3;
             return SD_SUCCESS;
     }

--- a/src/resources/bk_loader.c
+++ b/src/resources/bk_loader.c
@@ -61,12 +61,17 @@ int load_bk_file_incremental(bk_inc *b, int id) {
         case 2:
             b->bk = omf_calloc(1, sizeof(bk));
             DEBUG("creating BK %p", b->bk);
-            // this should be fast, so do it in one pass
-            bk_create(b->bk, &b->sd_bk);
-            sd_bk_free(&b->sd_bk);
-            sd_reader_close(b->r);
+            bk_create_inc(b->bk, &b->sd_bk);
             b->state = 3;
-            return SD_SUCCESS;
+            return SD_AGAIN;
+        case 3:
+            ret = bk_convert_inc(b->bk, &b->sd_bk);
+            if(ret != SD_AGAIN) {
+                sd_bk_free(&b->sd_bk);
+                sd_reader_close(b->r);
+                b->state = 4;
+            }
+            return ret;
     }
     return ret;
 }

--- a/src/resources/bk_loader.c
+++ b/src/resources/bk_loader.c
@@ -49,7 +49,7 @@ int load_bk_file_incremental(bk_inc *b, int id) {
             return bk_inc_create(b, id);
         case 1:
             ret = sd_bk_load_incremental(&b->sd_bk, b->r);
-            if (ret == SD_SUCCESS) {
+            if(ret == SD_SUCCESS) {
                 b->state = 2;
                 return SD_AGAIN;
             }

--- a/src/resources/bk_loader.h
+++ b/src/resources/bk_loader.h
@@ -1,9 +1,9 @@
 #ifndef BK_LOADER_H
 #define BK_LOADER_H
 
-#include "resources/bk.h"
 #include "formats/bk.h"
 #include "formats/error.h"
+#include "resources/bk.h"
 
 /*typedef enum {
     BK_LOADER_INIT,

--- a/src/resources/bk_loader.h
+++ b/src/resources/bk_loader.h
@@ -2,7 +2,22 @@
 #define BK_LOADER_H
 
 #include "resources/bk.h"
+#include "formats/bk.h"
+#include "formats/error.h"
+
+/*typedef enum {
+    BK_LOADER_INIT,
+    BK_LOADER_LOAD_BK,*/
+
+typedef struct {
+    int id;
+    sd_reader *r;
+    int state;
+    sd_bk_file sd_bk;
+    bk *bk;
+} bk_inc;
 
 int load_bk_file(bk *b, int id);
+int load_bk_file_incremental(bk_inc *b, int id);
 
 #endif // BK_LOADER_H


### PR DESCRIPTION
On slow hardware, the blocking bk loading can cause the audio to stutter because it blocks the engine loop. This PR makes loading BK files incremental, so the game loop can keep ticking and loading the BK file incrementally during scene transitions.