### PR TITLE
Show Newsroom and VS in DEMO mode and Score fixes

### DIFF
--- a/src/console/console.c
+++ b/src/console/console.c
@@ -232,7 +232,7 @@ bool console_init(void) {
     list_create(&con->history);
     hashmap_create(&con->cmds);
     menu_transparent_bg_create(&con->background1, 322, 101);
-    menu_background_create(&con->background2, 322, 101);
+    menu_background_create(&con->background2, 322, 101, MenuBackground);
 
     // Read from stdin needs to be nonblocking
 #if !defined(WIN32) && !defined(_WIN32)

--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -2578,6 +2578,12 @@ bool handle_queued_tactic(controller *ctrl, ctrl_event **ev) {
 int ai_controller_poll(controller *ctrl, ctrl_event **ev) {
     ai *a = ctrl->data;
     object *o = game_state_find_object(ctrl->gs, ctrl->har_obj_id);
+    scene *scene = game_state_get_scene(ctrl->gs);
+    if(scene->id == SCENE_VS || scene->id == SCENE_NEWSROOM) {
+        if(ctrl->gs->warp_speed || (scene->static_ticks_since_start + 1) % 256 == 0) {
+            controller_cmd(ctrl, ACT_PUNCH, ev);
+        }
+    }
     if(!o) {
         return 1;
     }

--- a/src/game/common_defines.h
+++ b/src/game/common_defines.h
@@ -91,6 +91,8 @@ enum
     PILOT_RAVEN,
     PILOT_KREISSACK,
     NUMBER_OF_PILOT_TYPES,
+    // Major Kreissack is not a playable character
+    NUMBER_OF_PLAYABLE_PILOT_TYPES = NUMBER_OF_PILOT_TYPES - 1,
 };
 
 enum

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -1022,3 +1022,25 @@ int game_state_clone(game_state *src, game_state *dst) {
 
     return 0;
 }
+
+bool is_netplay(game_state *gs) {
+    return game_state_get_player(gs, 0)->ctrl->type == CTRL_TYPE_NETWORK ||
+           game_state_get_player(gs, 1)->ctrl->type == CTRL_TYPE_NETWORK;
+}
+
+bool is_singleplayer(game_state *gs) {
+    return game_state_get_player(gs, 1)->ctrl->type == CTRL_TYPE_AI;
+}
+
+bool is_tournament(game_state *gs) {
+    return game_state_get_player(gs, 0)->chr;
+}
+
+bool is_demoplay(game_state *gs) {
+    return game_state_get_player(gs, 0)->ctrl->type == CTRL_TYPE_AI &&
+           game_state_get_player(gs, 1)->ctrl->type == CTRL_TYPE_AI;
+}
+
+bool is_twoplayer(game_state *gs) {
+    return !is_demoplay(gs) && !is_netplay(gs) && !is_singleplayer(gs);
+}

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -320,6 +320,11 @@ void game_state_set_paused(game_state *gs, unsigned int paused) {
 
 // Return 0 if event was handled here
 int game_state_handle_event(game_state *gs, SDL_Event *event) {
+    // ESC during demo mode jumps you back to the main menu
+    if(event->type == SDL_KEYDOWN && is_demoplay(gs) && event->key.keysym.sym == SDLK_ESCAPE) {
+        game_state_set_next(gs, SCENE_MENU);
+        return 0;
+    }
     if(scene_event(gs->sc, event) == 0) {
         return 0;
     }
@@ -882,11 +887,11 @@ void game_state_init_demo(game_state *gs) {
         sd_pilot *pl = game_player_get_pilot(player);
         ai_controller_create(ctrl, 4, pl, player->pilot->pilot_id);
         game_player_set_ctrl(player, ctrl);
-        game_player_set_selectable(player, 1);
+        game_player_set_selectable(player, 0);
 
         // select random pilot and har
-        player->pilot->pilot_id = rand_int(10);
-        player->pilot->har_id = rand_int(11);
+        player->pilot->pilot_id = rand_int(NUMBER_OF_PLAYABLE_PILOT_TYPES);
+        player->pilot->har_id = rand_int(NUMBER_OF_HAR_TYPES);
         chr_score_reset(&player->score, 1);
 
         // set proper color

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -320,10 +320,19 @@ void game_state_set_paused(game_state *gs, unsigned int paused) {
 
 // Return 0 if event was handled here
 int game_state_handle_event(game_state *gs, SDL_Event *event) {
-    // ESC during demo mode jumps you back to the main menu
     if(event->type == SDL_KEYDOWN && is_demoplay(gs) && event->key.keysym.sym == SDLK_ESCAPE) {
+        // ESC during demo mode jumps you back to the main menu
         game_state_set_next(gs, SCENE_MENU);
         return 0;
+    } else if(event->type == SDL_KEYDOWN && is_demoplay(gs) && event->key.keysym.sym == SDLK_RETURN) {
+        // ENTER during demo mode skips menus
+        if(gs->sc->id < SCENE_ARENA0 || gs->sc->id > SCENE_ARENA4) {
+            if(gs->sc->id != SCENE_VS) {
+                game_state_init_demo(gs);
+            }
+            game_state_set_next(gs, rand_arena());
+            return 0;
+        }
     }
     if(scene_event(gs->sc, event) == 0) {
         return 0;

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -57,4 +57,10 @@ void game_state_del_animation(game_state *gs, int anim_id);
 void game_state_get_projectiles(game_state *gs, vector *obj_proj);
 void game_state_clear_hazards_projectiles(game_state *gs);
 
+bool is_netplay(game_state *gs);
+bool is_singleplayer(game_state *gs);
+bool is_tournament(game_state *gs);
+bool is_demoplay(game_state *gs);
+bool is_twoplayer(game_state *gs);
+
 #endif // GAME_STATE_H

--- a/src/game/gui/menu.c
+++ b/src/game/gui/menu.c
@@ -304,7 +304,7 @@ static void menu_layout(component *c, int x, int y, int w, int h) {
     }
     if(m->bg2 == NULL && m->background) {
         m->bg2 = omf_malloc(sizeof(surface));
-        menu_background_create(m->bg2, w, height + m->margin_top * 2);
+        menu_background_create(m->bg2, w, height + m->margin_top * 2, MenuBackground);
     }
     if(m->help_bg1 == NULL && m->background) {
         m->help_bg1 = omf_calloc(1, sizeof(surface));
@@ -312,7 +312,7 @@ static void menu_layout(component *c, int x, int y, int w, int h) {
     }
     if(m->help_bg2 == NULL && m->background) {
         m->help_bg2 = omf_calloc(1, sizeof(surface));
-        menu_background_create(m->help_bg2, m->help_w + 16, m->help_w / 8);
+        menu_background_create(m->help_bg2, m->help_w + 16, m->help_w / 8, MenuBackground);
     }
 
     component_set_size_hints(c, w, height);

--- a/src/game/gui/menu_background.c
+++ b/src/game/gui/menu_background.c
@@ -13,35 +13,37 @@ void menu_transparent_bg_create(surface *s, int w, int h) {
     surface_set_transparency(s, -1);
 }
 
-void menu_background_create(surface *s, int w, int h) {
+void menu_background_create(surface *s, int w, int h, menu_background_style style) {
     image img;
     image_create(&img, w, h);
     image_clear(&img, COLOR_MENU_BG);
-    for(int x = 5; x < w; x += 8) {
-        image_line(&img, x, 0, x, h - 1, COLOR_MENU_LINE);
+    switch(style) {
+        case MenuBackground: {
+            for(int x = 5; x < w; x += 8) {
+                image_line(&img, x, 0, x, h - 1, COLOR_MENU_LINE);
+            }
+            for(int y = 5; y < h; y += 8) {
+                image_line(&img, 0, y, w - 1, y, COLOR_MENU_LINE);
+            }
+            image_rect(&img, 0, 0, w - 1, h - 1, COLOR_MENU_BORDER);
+            break;
+        }
+        case MenuBackgroundMeleeVs: {
+            for(int x = 5; x < w; x += 5) {
+                image_line(&img, x, 0, x, h - 1, COLOR_MENU_LINE2);
+            }
+            for(int y = 4; y < h; y += 5) {
+                image_line(&img, 0, y, w - 1, y, COLOR_MENU_LINE2);
+            }
+            image_rect(&img, 1, 1, w - 2, h - 2, COLOR_MENU_BORDER2);
+            image_rect(&img, 0, 0, w - 2, h - 2, COLOR_MENU_BORDER1);
+            break;
+        }
+        case MenuBackgroundNewsroom: {
+            image_rect(&img, 0, 0, w - 1, h - 1, COLOR_MENU_BORDER);
+            break;
+        }
     }
-    for(int y = 5; y < h; y += 8) {
-        image_line(&img, 0, y, w - 1, y, COLOR_MENU_LINE);
-    }
-    image_rect(&img, 0, 0, w - 1, h - 1, COLOR_MENU_BORDER);
-    surface_create_from_image(s, &img);
-    surface_set_transparency(s, COLOR_MENU_BG);
-    image_free(&img);
-}
-
-// the *other* style menu background, used on VS and MELEE
-void menu_background2_create(surface *s, int w, int h) {
-    image img;
-    image_create(&img, w, h);
-    image_clear(&img, COLOR_MENU_BG);
-    for(int x = 5; x < w; x += 5) {
-        image_line(&img, x, 0, x, h - 1, COLOR_MENU_LINE2);
-    }
-    for(int y = 4; y < h; y += 5) {
-        image_line(&img, 0, y, w - 1, y, COLOR_MENU_LINE2);
-    }
-    image_rect(&img, 1, 1, w - 2, h - 2, COLOR_MENU_BORDER2);
-    image_rect(&img, 0, 0, w - 2, h - 2, COLOR_MENU_BORDER1);
     surface_create_from_image(s, &img);
     surface_set_transparency(s, COLOR_MENU_BG);
     image_free(&img);

--- a/src/game/gui/menu_background.h
+++ b/src/game/gui/menu_background.h
@@ -3,9 +3,18 @@
 
 #include "video/surface.h"
 
+typedef enum menu_background_style_t
+{
+    // blue borders, coarse grid
+    MenuBackground,
+    // green borders, finer grid
+    MenuBackgroundMeleeVs,
+    // blue borders, no grid
+    MenuBackgroundNewsroom,
+} menu_background_style;
+
 void menu_transparent_bg_create(surface *s, int w, int h);
-void menu_background_create(surface *sur, int w, int h);
-void menu_background2_create(surface *sur, int w, int h);
+void menu_background_create(surface *sur, int w, int h, menu_background_style);
 void menu_background_border_create(surface *sur, int w, int h);
 
 #endif // MENU_BACKGROUND_H

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -353,7 +353,8 @@ void arena_har_take_hit_hook(int hittee, af_move *move, scene *scene) {
     if(h->state == STATE_RECOIL) {
         DEBUG("COMBO!");
     }
-    chr_score_hit(score, move->points);
+    bool no_points = is_demoplay(scene->gs) || !game_state_get_player(scene->gs, hitter)->selectable;
+    chr_score_hit(score, no_points ? 0 : move->points);
     chr_score_interrupt(otherscore, object_get_pos(hit_har));
 }
 
@@ -1116,13 +1117,13 @@ void arena_render_overlay(scene *scene) {
                         lang_get((player[1]->pilot->har_id) + 31));
         }
 
+        // dont render total score in demo play
+        bool render_totalscore = !is_demoplay(scene->gs);
         // Render score stuff
-        chr_score_render(game_player_get_score(player[0]));
+        chr_score_render(game_player_get_score(player[0]), render_totalscore);
 
-        // Do not render player 2 score in 1 player mode
-        if(game_player_get_selectable(player[1])) {
-            chr_score_render(game_player_get_score(player[1]));
-        }
+        // Do not render player 2 total score in 1 player mode
+        chr_score_render(game_player_get_score(player[1]), render_totalscore && game_player_get_selectable(player[1]));
 
         // render ping, if player is networked
         if(player[0]->ctrl->type == CTRL_TYPE_NETWORK) {

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -554,9 +554,11 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
         object_set_sprite_override(round_token, 1);
     }
     score->rounds++;
+    if(player_winner->ctrl->type != CTRL_TYPE_AI && player_loser->ctrl->type == CTRL_TYPE_AI) {
+        chr_score_victory(score, har_health_percent(winner_har));
+    }
     if(score->rounds >= ceilf(local->rounds / 2.0f)) {
         har_set_ani(winner, ANIM_VICTORY, 0);
-        chr_score_victory(score, har_health_percent(winner_har));
         winner_har->state = STATE_VICTORY;
         local->over = 1;
         if(is_singleplayer(gs)) {

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -211,15 +211,9 @@ void arena_end(scene *sc) {
     game_state *gs = sc->gs;
     const scene *scene = game_state_get_scene(gs);
     fight_stats *fight_stats = &gs->fight_stats;
-    int next_id;
 
     // Switch scene
-    if(is_demoplay(gs)) {
-        do {
-            next_id = rand_arena();
-        } while(next_id == sc->id);
-        game_state_set_next(gs, next_id);
-    } else if(is_singleplayer(gs) || is_tournament(gs)) {
+    if(is_singleplayer(gs) || is_tournament(gs) || is_demoplay(gs)) {
         game_player *p1 = game_state_get_player(gs, 0);
         game_player *p2 = game_state_get_player(gs, 1);
         har *p1_har = object_get_userdata(game_state_find_object(gs, game_player_get_har_obj_id(p1)));
@@ -1048,10 +1042,6 @@ void arena_input_tick(scene *scene) {
 }
 
 int arena_event(scene *scene, SDL_Event *e) {
-    // ESC during demo mode jumps you back to the main menu
-    if(e->type == SDL_KEYDOWN && is_demoplay(scene->gs) && e->key.keysym.sym == SDLK_ESCAPE) {
-        game_state_set_next(scene->gs, SCENE_MENU);
-    }
     return 0;
 }
 
@@ -1194,11 +1184,6 @@ int arena_create(scene *scene) {
 
     fight_stats *fight_stats = &scene->gs->fight_stats;
     memset(fight_stats, 0, sizeof(*fight_stats));
-
-    // Initialize Demo
-    if(is_demoplay(scene)) {
-        game_state_init_demo(scene->gs);
-    }
 
     // Handle music playback
     switch(scene->bk_data->file_id) {

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -520,7 +520,10 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
     } else if(player_winner->ctrl->type == CTRL_TYPE_NETWORK && player_loser->ctrl->type != CTRL_TYPE_NETWORK) {
         scene_youlose_anim_start(scene->gs);
     } else {
-        if(!is_singleplayer(gs)) {
+        if(is_demoplay(gs)) {
+            // in demo mode, "you lose" should always be displayed
+            scene_youlose_anim_start(scene->gs);
+        } else if(!is_singleplayer(gs)) {
             // XXX in two player mode, "you win" should always be displayed
             scene_youwin_anim_start(scene->gs);
         } else {

--- a/src/game/scenes/mainmenu/menu_main.c
+++ b/src/game/scenes/mainmenu/menu_main.c
@@ -62,7 +62,7 @@ void mainmenu_demo(component *c, void *userdata) {
 
     // Set up controllers
     game_state_init_demo(s->gs);
-    game_state_set_next(s->gs, rand_arena());
+    game_state_set_next(s->gs, SCENE_VS);
 }
 
 void mainmenu_soreboard(component *c, void *userdata) {

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -731,8 +731,8 @@ int melee_create(scene *scene) {
     palette_set_player_color(0, 8, 1);
     palette_set_player_color(0, 8, 2);
 
-    menu_background2_create(&local->bg_player_stats, 90, 61);
-    menu_background2_create(&local->bg_player_bio, 160, 43);
+    menu_background_create(&local->bg_player_stats, 90, 61, MenuBackgroundMeleeVs);
+    menu_background_create(&local->bg_player_bio, 160, 43, MenuBackgroundMeleeVs);
 
     // Create a black surface for the highlight box. We modify the palette in renderer.
     unsigned char *black = omf_calloc(1, 51 * 36);

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -329,7 +329,7 @@ int newsroom_create(scene *scene) {
     local->screen = 0;
     local->champion = false;
     menu_transparent_bg_create(&local->news_bg1, 280, 55);
-    menu_background_create(&local->news_bg2, 280, 55);
+    menu_background_create(&local->news_bg2, 280, 55, MenuBackgroundNewsroom);
 
     game_player *p1 = game_state_get_player(scene->gs, 0);
     game_player *p2 = game_state_get_player(scene->gs, 1);

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -232,6 +232,11 @@ void newsroom_input_tick(scene *scene) {
                     local->screen++;
                     newsroom_fixup_str(local);
 
+                    if(is_demoplay(scene->gs) && local->screen >= 2) {
+                        game_state_set_next(scene->gs, SCENE_VS);
+                        continue;
+                    }
+
                     if((local->screen >= 2 && !local->champion) || local->screen >= 3) {
                         if(local->won || player1->chr) {
                             // pick a new player

--- a/src/game/scenes/vs.c
+++ b/src/game/scenes/vs.c
@@ -640,7 +640,7 @@ int vs_create(scene *scene) {
     }
 
     // Background tex
-    menu_background2_create(&local->arena_select_bg, 211, 50);
+    menu_background_create(&local->arena_select_bg, 211, 50, MenuBackgroundMeleeVs);
 
     // Quit Dialog
     dialog_create(&local->quit_dialog, DIALOG_STYLE_YES_NO, "Are you sure you want to quit this game?", 72, 60);

--- a/src/game/scenes/vs.c
+++ b/src/game/scenes/vs.c
@@ -409,6 +409,11 @@ void vs_too_pathetic_dialog_clicked(dialog *dlg, dialog_result result) {
 }
 
 int vs_create(scene *scene) {
+    // Initialize Demo
+    if(is_demoplay(scene->gs)) {
+        game_state_init_demo(scene->gs);
+    }
+
     // Init local data
     vs_local *local = omf_calloc(1, sizeof(vs_local));
     scene_set_userdata(scene, local);

--- a/src/game/utils/score.c
+++ b/src/game/utils/score.c
@@ -126,25 +126,26 @@ void chr_score_tick(chr_score *score) {
     }
 }
 
-void chr_score_render(chr_score *score) {
-    // Render all texts in list to right spot
-    char tmp[50];
-    score_format(score->score, tmp, 50);
-
+void chr_score_render(chr_score *score, bool render_total_points) {
     text_settings tconf_score;
     text_defaults(&tconf_score);
     tconf_score.font = FONT_SMALL;
     tconf_score.cforeground = TEXT_COLOR;
     tconf_score.shadow = TEXT_SHADOW_RIGHT | TEXT_SHADOW_BOTTOM;
 
-    if(score->direction == OBJECT_FACE_RIGHT) {
-        text_render(&tconf_score, TEXT_DEFAULT, score->x, score->y, 200, 6, tmp);
+    if(render_total_points) {
+        char tmp[50];
+        score_format(score->score, tmp, 50);
 
-    } else {
-        int s2len = strlen(tmp) * font_small.w;
-        text_render(&tconf_score, TEXT_DEFAULT, score->x - s2len, score->y, 200, 6, tmp);
+        if(score->direction == OBJECT_FACE_RIGHT) {
+            text_render(&tconf_score, TEXT_DEFAULT, score->x, score->y, 200, 6, tmp);
+        } else {
+            int s2len = strlen(tmp) * font_small.w;
+            text_render(&tconf_score, TEXT_DEFAULT, score->x - s2len, score->y, 200, 6, tmp);
+        }
     }
 
+    // Render all texts in list to right spot
     iterator it;
     score_text *t;
     int lastage = -1;
@@ -252,8 +253,11 @@ int chr_score_interrupt(chr_score *score, vec2i pos) {
     if(score->consecutive_hits > 3) {
         char *text = omf_calloc(64, 1);
         ret = 1;
-        int len = snprintf(text, 64, "%d consecutive hits ", score->consecutive_hits);
-        score_format(score->consecutive_hit_score, text + len, 64 - len);
+        int len = snprintf(text, 64, "%d consecutive hits", score->consecutive_hits);
+        if(score->consecutive_hit_score > 0) {
+            text[len++] = ' ';
+            score_format(score->consecutive_hit_score, text + len, 64 - len);
+        }
         // XXX hardcode the y coordinate for now
         chr_score_add(score, text, score->consecutive_hit_score, vec2i_create(pos.x, 130), 1.0f);
     }
@@ -268,8 +272,11 @@ int chr_score_end_combo(chr_score *score, vec2i pos) {
     if(score->combo_hits > 1) {
         char *text = omf_calloc(64, 1);
         ret = 1;
-        int len = snprintf(text, 64, "%d hit combo ", score->combo_hits);
-        score_format(score->combo_hit_score * 4, text + len, 64 - len);
+        int len = snprintf(text, 64, "%d hit combo", score->combo_hits);
+        if(score->combo_hit_score > 0) {
+            text[len++] = ' ';
+            score_format(score->combo_hit_score * 4, text + len, 64 - len);
+        }
         // XXX hardcode the y coordinate for now
         chr_score_add(score, text, score->combo_hit_score * 4, vec2i_create(pos.x, 130), 1.0f);
     }

--- a/src/game/utils/score.h
+++ b/src/game/utils/score.h
@@ -5,6 +5,7 @@
 #include "game/protos/object.h"
 #include "utils/list.h"
 #include "video/surface.h"
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -43,7 +44,7 @@ void chr_score_set_pos(chr_score *score, int x, int y, int direction);
 unsigned int chr_score_get_num_texts(chr_score *score);
 void chr_score_free(chr_score *score);
 void chr_score_tick(chr_score *score);
-void chr_score_render(chr_score *score);
+void chr_score_render(chr_score *score, bool render_total_points);
 int chr_score_onscreen(chr_score *score);
 
 void chr_score_hit(chr_score *score, int points);


### PR DESCRIPTION
Newsroom and VS are now part of the demo sequence.
This makes it possible to see the character-vs-themselves insults in openomf =)
![image](https://github.com/user-attachments/assets/33b7c35e-be37-4a29-acef-d1bcf0cde6d6)

Scores are now handled more like the original, hiding the score points for nonhuman players (here, two ai)
![image](https://github.com/user-attachments/assets/5c87894a-cd4f-410a-9d2d-929a35cf376e)
VITALITY and PERFECT ROUND score bonuses are now awarded every round (instead of just the final round), and only when a human player defeats an AI.

not changed:
- DEMO still does not visit the MELEE scene as Player 1, unlike the original game.
- Pilots will still use the Nova in demo mode (this is done in game_state_init_demo)
- Kreissack still does not appear in demo mode (but easily could, if we wanted him to. same function.)