### PR TITLE
Show the 'new champion' text in newsroom

### DIFF
--- a/src/formats/palette.c
+++ b/src/formats/palette.c
@@ -237,7 +237,7 @@ void palette_set_player_expanded_color(int src_row, int dst_row) {
     float r = (end.r - start.r) / 32.0;
     float g = (end.g - start.g) / 32.0;
     float b = (end.b - start.b) / 32.0;
-    for (int i = 0; i < 32; i++) {
+    for(int i = 0; i < 32; i++) {
         tmp.colors[i].r = start.r + (int)(r * i);
         tmp.colors[i].g = start.g + (int)(g * i);
         tmp.colors[i].b = start.b + (int)(b * i);

--- a/src/game/scenes/cutscene.c
+++ b/src/game/scenes/cutscene.c
@@ -166,7 +166,6 @@ int cutscene_create(scene *scene) {
             for(int i = 0; i < 256; i++) {
                 if(i >= 10 && i <= 20 && i != 10 + p1->pilot->har_id) {
                     continue;
-
                 }
                 bk_info *bki = bk_get_info(scene->bk_data, i);
                 if(bki) {

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -185,6 +185,13 @@ void newsroom_overlay_render(scene *scene) {
         text_render(&tconf_yellow, TEXT_DEFAULT, 34, 155, 250, 6, str_c(&local->news_str));
     }
 
+    // If the player has just become a new champion, show the sprite on top of the photo.
+    if(local->champion && local->screen >= 2) {
+        animation *photo_overlays = &bk_get_info(scene->bk_data, 4)->ani;
+        sprite *new_champion = animation_get_sprite(photo_overlays, 1);
+        video_draw(new_champion->data, new_champion->pos.x, new_champion->pos.y);
+    }
+
     // Dialog
     if(dialog_is_visible(&local->continue_dialog)) {
         dialog_render(&local->continue_dialog);


### PR DESCRIPTION
Fixes https://github.com/omf2097/openomf/issues/755

Show the "New champion" text on top of the photo.

![screenshot_20241108_223513](https://github.com/user-attachments/assets/0a32a461-1548-47c2-892b-d96a55f1299c)
