### PR TITLE
Fix Credits, make only object_palette_copy_transform sticky

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -DDEBUGMODE -Werror -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g -O2 -fno-omit-frame-pointer -DNDEBUG")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -DNDEBUG")
     set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Os -DNDEBUG")
@@ -204,6 +204,7 @@ include_directories(${COREINCS})
 # this can then be reused in tests and main executable to speed things up
 add_library(openomf_core OBJECT ${OPENOMF_SRC})
 target_link_libraries(openomf_core PRIVATE ${XMP_LIBRARY})
+target_compile_definitions(openomf_core PUBLIC "$<$<CONFIG:Debug>:DEBUGMODE>")
 omf_target_precompile_headers(openomf_core PUBLIC
     "<SDL.h>"
     "<enet/enet.h>"

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -460,7 +460,7 @@ void object_palette_transform(object *obj) {
     }
 
     if(obj->sprite_state.pal_tricks_off) { // BPO tag is on
-        vga_state_enable_palette_transform(object_palette_copy_transform, obj);
+        vga_state_enable_palette_transform_sticky(object_palette_copy_transform, obj);
     } else if(obj->sprite_state.pal_entry_count > 0 && obj->sprite_state.duration > 0) { // BPO tag is off
         vga_state_enable_palette_transform(object_scenewide_palette_transform, obj);
     }

--- a/src/video/vga_state.h
+++ b/src/video/vga_state.h
@@ -39,6 +39,7 @@ void vga_state_set_base_palette_range(vga_index start, vga_index count, vga_colo
 void vga_state_copy_base_palette_range(vga_index dst, vga_index src, vga_index count);
 
 void vga_state_enable_palette_transform(vga_palette_transform transform_callback, void *userdata);
+void vga_state_enable_palette_transform_sticky(vga_palette_transform transform_callback, void *userdata);
 
 // Take debug snapshot of the current palette state.
 void vga_state_debug_screenshot(const char *filename);

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -207,6 +207,10 @@ void video_render_finish_offscreen(void) {
     activate_program(g_video_state.palette_prog_id);
     render_target_activate(g_video_state.target);
 
+#if DEBUGMODE
+    glClear(GL_COLOR_BUFFER_BIT);
+#endif
+
     object_array_blend_mode mode;
     while(object_array_get_batch(g_video_state.objects, &batch, &mode)) {
         video_set_blend_mode(mode);


### PR DESCRIPTION
Same goal as https://github.com/omf2097/openomf/pull/762, while only making `object_palette_copy_transform` sticky.

the `Shuffle palette repair a bit` commit didn't merge cleanly, so I didn't cherry-pick it.