### PR TITLE
Fix vcpkg-specific PNG link errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ find_package(confuse)
 find_package(argtable2)
 find_package(Argtable3 CONFIG)
 find_package(PNG)
-find_package(ZLIB)
 find_package(miniupnpc)
 find_package(natpmp)
 
@@ -142,15 +141,11 @@ set(COREINCS
     ${CONFUSE_INCLUDE_DIR}
     ${XMP_INCLUDE_DIR}
     ${ENET_INCLUDE_DIR}
-    ${PNG_INCLUDE_DIR}
-    ${ZLIB_INCLUDE_DIR}
 )
 
 set(CORELIBS
     ${CONFUSE_LIBRARY}
     ${ENET_LIBRARY}
-    ${PNG_LIBRARY}
-    ${ZLIB_LIBRARY}
 )
 
 if(ARGTABLE2_FOUND)
@@ -203,7 +198,10 @@ include_directories(${COREINCS})
 # Build core sources first as an object library
 # this can then be reused in tests and main executable to speed things up
 add_library(openomf_core OBJECT ${OPENOMF_SRC})
-target_link_libraries(openomf_core PRIVATE ${XMP_LIBRARY})
+target_link_libraries(openomf_core PRIVATE
+    ${XMP_LIBRARY}
+    PNG::PNG
+)
 omf_target_precompile_headers(openomf_core PUBLIC
     "<SDL.h>"
     "<enet/enet.h>"


### PR DESCRIPTION
A few things were being done wrong before, with no negative repercussions that I know of:
- using deprecated PNG_LIBRARY variable instead of PNG_LIBRARIES
- not consuming PNG_DEFINITIONS
- linking PNG to the exe targets (openomf, languagetool, etc..) instead of directly to openomf_core where it's used (this is a bit pedantic, but makes things easier).
- explicitly depending on ZLIB. This is unneeded when using FindPNG properly, and openomf does not directly use zlib.

this PR switches from the FindPNG variables to the PNG::PNG imported target that [FindPNG has been defining since cmake 3.5](https://cmake.org/cmake/help/latest/module/FindPNG.html)

PNG_LIBRARIES and such broke after vcpkg's PR https://github.com/microsoft/vcpkg/pull/42058, but I don't feel like debugging why PNG_FOUND was being set to 1 while PNG_LIBRARIES was entirely empty.

Closes #768 