### PR TITLE
 Document allocator.h API, fail on omf_malloc(0)

### DIFF
--- a/src/formats/internal/memreader.c
+++ b/src/formats/internal/memreader.c
@@ -16,6 +16,10 @@ memreader *memreader_open(char *buf, long len) {
 }
 
 memreader *memreader_open_from_reader(sd_reader *reader, int len) {
+    if(len == 0) {
+        return memreader_open(NULL, 0);
+    }
+
     char *buf = omf_calloc(1, len);
     sd_read_buf(reader, buf, len);
     memreader *mreader = memreader_open(buf, len);

--- a/src/formats/sprite.c
+++ b/src/formats/sprite.c
@@ -59,8 +59,8 @@ int sd_sprite_load(sd_reader *r, sd_sprite *sprite) {
     sprite->missing = sd_read_ubyte(r);
 
     // Copy sprite data, if there is any.
-    if(sprite->missing == 0) {
-        sprite->data = omf_calloc(sprite->len, 1);
+    if(sprite->missing == 0 && sprite->len != 0) {
+        sprite->data = omf_calloc(1, sprite->len);
         sd_read_buf(r, sprite->data, sprite->len);
     } else {
         sprite->data = NULL;

--- a/src/resources/sprite.c
+++ b/src/resources/sprite.c
@@ -13,10 +13,16 @@ void sprite_create(sprite *sp, void *src, int id) {
     sd_sprite *sdsprite = (sd_sprite *)src;
     sp->id = id;
     sp->pos = vec2i_create(sdsprite->pos_x, sdsprite->pos_y);
-    sp->data = omf_calloc(1, sizeof(surface));
-    sp->owned = true;
+
+    if(sdsprite->width == 0 || sdsprite->height == 0) {
+        sp->data = NULL;
+        sp->owned = false;
+        return;
+    }
 
     // Load data
+    sp->data = omf_calloc(1, sizeof(surface));
+    sp->owned = true;
     sd_vga_image raw;
     sd_sprite_vga_decode(&raw, sdsprite);
     surface_create_from_data(sp->data, raw.w, raw.h, (unsigned char *)raw.data);

--- a/src/utils/allocator.h
+++ b/src/utils/allocator.h
@@ -1,6 +1,7 @@
 #ifndef ALLOCATOR_H
 #define ALLOCATOR_H
 
+// format strings for use in platform-specific allocator header
 extern const char *_text_malloc_error;
 extern const char *_text_calloc_error;
 extern const char *_text_realloc_error;
@@ -8,8 +9,59 @@ extern const char *_text_realloc_error;
 // Add ifdefs here to include platform-specific allocators.
 #include "utils/allocator_default.h"
 
+/**
+ * @brief Allocate a buffer
+ * @details Allocates `size` bytes of un-initialized memory at an address
+ * that is suitably aligned for mundane C types (pointers, structs, etc..).
+ *
+ * Passing a size of 0 is a constraints violation.
+ *
+ * @param size the number of bytes to allocate
+ * @return the new allocation, a non-null pointer.
+ */
 #define omf_malloc(size) omf_malloc_real((size), __FILE__, __LINE__)
+
+/**
+ * @brief Allocate a zero-initialized buffer by element count
+ * @details Allocates and zero-initializes enough memory for a array
+ * of nmemb elements of size size.
+ * Note that this may be larger than nmemb*size bytes of memory because
+ * array elements might be padded to satisfy alignment.
+ *
+ * Passing a size or nmemb of 0 is a constraints violation.
+ *
+ * @param nmemb the number of elements to allocate space for
+ * @param size the size of each element
+ * @return the new allocation, a non-null pointer.
+ */
 #define omf_calloc(nmemb, size) omf_calloc_real((nmemb), (size), __FILE__, __LINE__)
-#define omf_realloc(ptr, size) omf_realloc_real((ptr), (size), __FILE__, __LINE__)
+/**
+ * @brief Resize an allocation
+ * @details Resize an allocation, either by expanding or shrinking the range of
+ * addresses that can be validly used within the allocation (if there's room); or
+ * by creating a new allocation of size size and copying as much of the old allocation's
+ * contents as will fit in the new one, and freeing the old allocation.
+ *
+ * Passing a size or nmemb of 0 is a constraints violation.
+ *
+ * @param ptr the previous allocation if there was one, else NULL. This pointer is invalidated if omf_realloc succeeds.
+ * @param size the number of bytes to allocate
+ * @return the new allocation, a non-null pointer.
+ */
+#define omf_realloc(ptr, size) omf_realloc_real((ptr), (size), __FILE__, __LINE__);
+
+/**
+ * @brief Free an allocation by pointer, and reassigns the pointer to NULL.
+ * @details Free an allocation from one of: omf_malloc, omf_calloc, or omf_realloc.
+ * If the pointer is already NULL, does nothing (well-behaved).
+ *
+ * Do not pass pointers from other allocators (strdup, SDL_malloc, etc..), doing so triggers undefined behavior!
+ * @param ptr the pointer to free & NULL.
+ */
+#define omf_free(ptr)                                                                                                  \
+    do {                                                                                                               \
+        omf_free_real(ptr);                                                                                            \
+        (ptr) = NULL;                                                                                                  \
+    } while(0)
 
 #endif // ALLOCATOR_H

--- a/src/utils/allocator_default.h
+++ b/src/utils/allocator_default.h
@@ -1,17 +1,15 @@
 #ifndef ALLOCATOR_DEFAULT_H
 #define ALLOCATOR_DEFAULT_H
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#define omf_free(ptr)                                                                                                  \
-    do {                                                                                                               \
-        free(ptr);                                                                                                     \
-        (ptr) = NULL;                                                                                                  \
-    } while(0)
+#define omf_free_real(ptr) free(ptr)
 
 static inline void *omf_malloc_real(size_t size, const char *file, int line) {
+    assert(size > 0);
     void *ret = malloc(size);
     if(ret != NULL)
         return ret;
@@ -20,6 +18,8 @@ static inline void *omf_malloc_real(size_t size, const char *file, int line) {
 }
 
 static inline void *omf_calloc_real(size_t nmemb, size_t size, const char *file, int line) {
+    assert(size > 0);
+    assert(nmemb > 0);
     void *ret = calloc(nmemb, size);
     if(ret != NULL)
         return ret;
@@ -28,9 +28,11 @@ static inline void *omf_calloc_real(size_t nmemb, size_t size, const char *file,
 }
 
 static inline void *omf_realloc_real(void *ptr, size_t size, const char *file, int line) {
+    assert(size > 0);
     void *ret = realloc(ptr, size);
-    if(ret != NULL)
+    if(ret != NULL) {
         return ret;
+    }
     fprintf(stderr, _text_realloc_error, ptr, size, file, line);
     abort();
 }


### PR DESCRIPTION
allocator.h now has doc strings for the various methods it provides.

Notably, omf_malloc(0) and similar calls now have well-specified behavior (rather than libc implementation-specified behavior): it aborts the program with an error message