### PR TITLE
Improve str strings

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1562,7 +1562,7 @@ af_move *match_move(object *obj, char *inputs) {
     size_t len;
     for(int i = 0; i < 70; i++) {
         if((move = af_get_move(h->af_data, i))) {
-            len = move->move_string.len;
+            len = str_size(&move->move_string);
             if(!strncmp(str_c(&move->move_string), inputs, len)) {
                 if(move->category == CAT_CLOSE && h->close != 1) {
                     // not standing close enough

--- a/src/utils/c_string_util.c
+++ b/src/utils/c_string_util.c
@@ -1,5 +1,6 @@
 #include "utils/c_string_util.h"
 #include "utils/allocator.h"
+#include <assert.h>
 #include <string.h>
 
 char *strncpy_or_truncate(char *dest, const char *src, size_t n) {
@@ -15,4 +16,13 @@ char *omf_strdup_real(char const *s, char const *file, int line) {
     char *new_s = omf_malloc_real(valid_range, file, line);
     memcpy(new_s, s, valid_range);
     return new_s;
+}
+
+size_t omf_strnlen_s(char const *str, size_t strsz) {
+    assert(!(!str && strsz));
+    if(!str) {
+        return 0;
+    }
+    char const *found = memchr(str, '\0', strsz);
+    return found ? (size_t)(found - str) : strsz;
 }

--- a/src/utils/c_string_util.h
+++ b/src/utils/c_string_util.h
@@ -10,4 +10,8 @@ char *strncpy_or_truncate(char *dest, const char *src, size_t n);
 char *omf_strdup_real(char const *s, char const *file, int line);
 #define omf_strdup(s) omf_strdup_real((s), __FILE__, __LINE__)
 
+// Reads up to strsz bytes of str, returning the position of the
+// first null character or strsz if it was not found.
+size_t omf_strnlen_s(char const *str, size_t strsz);
+
 #endif // C_STRING_UTIL_H

--- a/testing/misc/parser_test_strings.c
+++ b/testing/misc/parser_test_strings.c
@@ -1,4 +1,5 @@
 #include "parser_test_strings.h"
+#include <assert.h>
 
 const char *test_strings[] = {
     "A120-B20-C10-D10-E10-F10-G10-rfE10-rfF10-rfG10-rfH10-D10-C10-B20-A120",
@@ -2782,3 +2783,5 @@ const char *test_strings[] = {
     "A1-B1-C1-D1-E1-D1-C1-B1",
     "A1-B1-C1-D1-E1-F1-G1-H1",
 };
+
+static_assert(sizeof(test_strings) / sizeof(test_strings[0]) == TEST_STRING_COUNT, "array size mismatch");

--- a/testing/test_main.c
+++ b/testing/test_main.c
@@ -23,36 +23,6 @@ int main(int argc, char **argv) {
         return CU_get_error();
     }
 
-    suite = CU_add_suite("AF files", NULL, NULL);
-    if(suite == NULL)
-        goto end;
-    af_test_suite(suite);
-
-    suite = CU_add_suite("BK files", NULL, NULL);
-    if(suite == NULL)
-        goto end;
-    bk_test_suite(suite);
-
-    suite = CU_add_suite("Palettes", NULL, NULL);
-    if(suite == NULL)
-        goto end;
-    palette_test_suite(suite);
-
-    suite = CU_add_suite("REC files", NULL, NULL);
-    if(suite == NULL)
-        goto end;
-    rec_test_suite(suite);
-
-    suite = CU_add_suite("TRN files", NULL, NULL);
-    if(suite == NULL)
-        goto end;
-    trn_test_suite(suite);
-
-    suite = CU_add_suite("Script", NULL, NULL);
-    if(suite == NULL)
-        goto end;
-    script_test_suite(suite);
-
     // Init suites
     CU_pSuite str_suite = CU_add_suite("String", NULL, NULL);
     if(str_suite == NULL)
@@ -88,6 +58,36 @@ int main(int argc, char **argv) {
     if(cp437_suite == NULL)
         goto end;
     cp437_test_suite(cp437_suite);
+
+    suite = CU_add_suite("AF files", NULL, NULL);
+    if(suite == NULL)
+        goto end;
+    af_test_suite(suite);
+
+    suite = CU_add_suite("BK files", NULL, NULL);
+    if(suite == NULL)
+        goto end;
+    bk_test_suite(suite);
+
+    suite = CU_add_suite("Palettes", NULL, NULL);
+    if(suite == NULL)
+        goto end;
+    palette_test_suite(suite);
+
+    suite = CU_add_suite("REC files", NULL, NULL);
+    if(suite == NULL)
+        goto end;
+    rec_test_suite(suite);
+
+    suite = CU_add_suite("TRN files", NULL, NULL);
+    if(suite == NULL)
+        goto end;
+    trn_test_suite(suite);
+
+    suite = CU_add_suite("Script", NULL, NULL);
+    if(suite == NULL)
+        goto end;
+    script_test_suite(suite);
 
     // Run tests
     CU_basic_set_mode(CU_BRM_VERBOSE);

--- a/testing/test_str.c
+++ b/testing/test_str.c
@@ -3,9 +3,9 @@
 #include <assert.h>
 #include <utils/str.h>
 
-// NOTE: this is an implementation detail, so shouldn't really be covered by unit tests. oh well!
+// The number of bytes (including null terminating byte) that can be stored in a small string.
 #define STR_STACK_SIZE sizeof(str)
-// implementation-independent small-string detection
+// detects whether a string is currently small-string-optimized
 static bool is_small(str const *s) {
     void const *s_start = s;
     void const *s_end = s + 1;
@@ -21,6 +21,17 @@ void test_str_create(void) {
     CU_ASSERT(is_small(&m));
     CU_ASSERT(m.small[0] == 0);
     str_free(&m);
+}
+
+void test_str_free(void) {
+    str zeroed;
+    memset(&zeroed, 0, sizeof zeroed);
+    str m;
+    str_create(&m);
+    str_from_c(&m, "testdata");
+    CU_ASSERT(memcmp(&m, &zeroed, sizeof(str)) != 0);
+    str_free(&m);
+    CU_ASSERT(memcmp(&m, &zeroed, sizeof(str)) == 0);
 }
 
 void test_str_from(void) {
@@ -537,6 +548,9 @@ void test_str_insert_c_at(void) {
 
 void str_test_suite(CU_pSuite suite) {
     if(CU_add_test(suite, "Test for str_create", test_str_create) == NULL) {
+        return;
+    }
+    if(CU_add_test(suite, "Test for str_free", test_str_free) == NULL) {
         return;
     }
     if(CU_add_test(suite, "Test for str_from", test_str_from) == NULL) {


### PR DESCRIPTION
str.h strings now store more characters in a small string than before, store the heap capacity for large strings (to avoid useless reallocs), and all this without increasing the size of struct str or additional heap usage.

Heavily inspired by Facebook's fbstring as described in a 2016 CppCon talk: https://youtu.be/kPR8h4-qZdk (although that has additional bells and whistles, including CoW semantics for very large strings).