### PR TITLE
CMake: Provide path to ClangFormat.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ endif()
 
 # Formatting via clang-format
 if(USE_FORMAT)
-    include(ClangFormat)
+    include(cmake-scripts/ClangFormat.cmake)
     file(GLOB_RECURSE SRC_FILES
         LIST_DIRECTORIES OFF
         CONFIGURE_DEPENDS


### PR DESCRIPTION
Fixes regression from cmake dependencies refactor.

```
CMake Error at CMakeLists.txt:318 (include):
  include could not find requested file:

    ClangFormat


CMake Error at CMakeLists.txt:330 (clangformat_setup):
  Unknown CMake command "clangformat_setup".
```