### PR TITLE
MSVC Warning cleanup, /WX (Werror), and misc. fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,7 @@ add_definitions(-DV_MAJOR=${VERSION_MAJOR} -DV_MINOR=${VERSION_MINOR} -DV_PATCH=
 # Enable AddressSanitizer if requested
 if(USE_SANITIZERS)
     if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-        add_compile_options("-fsanitize=address")
-        add_link_options("-fsanitize=address")
+        add_compile_options("/fsanitize=address")
         message(STATUS "Development: Asan enabled. Ubsan is unsupported by MSVC.")
     else()
         add_compile_options("-fsanitize=address,undefined")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,6 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244")
     # C4267: implicit conversion from size_t, possible loss of data
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267")
-    # C4305: truncation from double to float
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4305")
     # C4389: 'equality-operator' : signed/unsigned mismatch
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4389")
     # _CRT_SECURE_NO_WARNINGS: disable warnings when calling functions like strncpy or sscanf
@@ -77,6 +75,8 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4146")
     # C4245: signed const to unsigned
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4245")
+    # C4305: truncation from double to float
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4305")
     # C4701: potentially uninitialized local variable used
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4701")
     # C4668: undefined symbol used as compiler directive (will evaluate to 0).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4013")
     # C4146: unary minus operator applied to unsigned type, result still unsigned
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4146")
+    # C4701: potentially uninitialized local variable used
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4701")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4245")
     # C4701: potentially uninitialized local variable used
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4701")
+    # C4668: undefined symbol used as compiler directive (will evaluate to 0).
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4668")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ if(MSVC)
     # Error on certain warnings:
     # C4013: call to undefined function
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4013")
+    # C4146: unary minus operator applied to unsigned type, result still unsigned
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4146")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4013")
     # C4146: unary minus operator applied to unsigned type, result still unsigned
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4146")
+    # C4245: signed const to unsigned
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4245")
     # C4701: potentially uninitialized local variable used
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4701")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,28 @@ if(MSVC)
     string(REGEX REPLACE "/W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
     # we would probably like to pass /Wall instead of /W4, but there's a lot
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4")
-    # Disable warning C4100: unreferenced formal parameter
+    # Disable select warnings:
+    # C4100: unreferenced formal parameter
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4100")
-    # Error on warning C4013: call to undefined function
+    # C4456: declaration hides previous local declaration
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4456")
+    # C4459: declaration hides previous global declaration
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4459")
+    # C4244: implicit conversion, possible loss of data
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244")
+    # C4267: implicit conversion from size_t, possible loss of data
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267")
+    # C4305: truncation from double to float
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4305")
+    # C4389: 'equality-operator' : signed/unsigned mismatch
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4389")
+    # _CRT_SECURE_NO_WARNINGS: disable warnings when calling functions like strncpy or sscanf
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
+    # _CRT_NONSTDC_NO_WARNINGS: disable warnings when calling POSIX functions like fileno
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D_CRT_NONSTDC_NO_WARNINGS")
+
+    # Error on certain warnings:
+    # C4013: call to undefined function
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4013")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,8 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4701")
     # C4668: undefined symbol used as compiler directive (will evaluate to 0).
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4668")
+    # C4702: unreachable code
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4702")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -DDEBUGMODE -Werror -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g -O2 -fno-omit-frame-pointer -DNDEBUG")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -DNDEBUG")
     set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Os -DNDEBUG")
@@ -178,6 +178,7 @@ set_source_files_properties("src/video/video.c" PROPERTIES COMPILE_DEFINITIONS "
 # Build core sources first as an object library
 # this can then be reused in tests and main executable to speed things up
 add_library(openomf_core OBJECT ${OPENOMF_SRC})
+target_compile_definitions(openomf_core PUBLIC "$<$<CONFIG:Debug>:DEBUGMODE>")
 omf_target_precompile_headers(openomf_core PUBLIC
     "<SDL.h>"
     "<enet/enet.h>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,7 @@ set(CMAKE_C_STANDARD 11)
 if(MSVC)
     # remove cmake's default /W3 to avoid warning D9025
     string(REGEX REPLACE "/W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-    # we would probably like to pass /Wall instead of /W4, but there's a lot
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4 /WX")
     # Disable select warnings:
     # C4100: unreferenced formal parameter
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4100")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ if(MSVC)
     string(REGEX REPLACE "/W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
     # we would probably like to pass /Wall instead of /W4, but there's a lot
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /permissive- /W4")
+    # Disable warning C4100: unreferenced formal parameter
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4100")
+    # Error on warning C4013: call to undefined function
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4013")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wformat -pedantic -Wvla")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -Werror -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,9 @@ include_directories(${COREINCS})
 
 # Build the game binary
 add_executable(openomf src/main.c src/engine.c ${ICON_RESOURCE})
+set_property(TARGET openomf PROPERTY
+    VS_DEBUGGER_ENVIRONMENT "OPENOMF_SHADER_DIR=${CMAKE_CURRENT_BINARY_DIR}/shaders
+OPENOMF_RESOURCE_DIR=${CMAKE_CURRENT_BINARY_DIR}/resources")
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT openomf)
 
 # This is used to copy shader files from source directory to the binary output directory during compile.

--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -797,8 +797,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = -10;
             pilot->pref_fwd = 30;
             pilot->pref_back = 10;
-            pilot->learning = 1.5;
-            pilot->forget = 0.25;
+            pilot->learning = 1.5f;
+            pilot->forget = 0.25f;
             break;
         case 1:
             // steffan
@@ -813,8 +813,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = 6;
             pilot->pref_fwd = 20;
             pilot->pref_back = -9;
-            pilot->learning = 1.0;
-            pilot->forget = 0.4;
+            pilot->learning = 1.0f;
+            pilot->forget = 0.4f;
             break;
         case 2:
             // milano
@@ -831,8 +831,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = 8;
             pilot->pref_fwd = 30;
             pilot->pref_back = -3;
-            pilot->learning = 0.9;
-            pilot->forget = 0.1;
+            pilot->learning = 0.9f;
+            pilot->forget = 0.1f;
             break;
         case 3:
             // christian
@@ -848,8 +848,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = 2;
             pilot->pref_fwd = 10;
             pilot->pref_back = -10;
-            pilot->learning = 2.5;
-            pilot->forget = 0.35;
+            pilot->learning = 2.5f;
+            pilot->forget = 0.35f;
             break;
         case 4:
             // shirro
@@ -867,8 +867,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = -20;
             pilot->pref_fwd = 10;
             pilot->pref_back = 10;
-            pilot->learning = 2.0;
-            pilot->forget = 0.2;
+            pilot->learning = 2.0f;
+            pilot->forget = 0.2f;
             break;
         case 5:
             // jean-paul
@@ -884,8 +884,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->ap_low = 100;
             pilot->ap_middle = -50;
             pilot->pref_fwd = 20;
-            pilot->learning = 1.2;
-            pilot->forget = 0.07;
+            pilot->learning = 1.2f;
+            pilot->forget = 0.07f;
             break;
         case 6:
             // ibrahim
@@ -902,8 +902,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = 2;
             pilot->pref_fwd = 10;
             pilot->pref_back = -10;
-            pilot->learning = 2.5;
-            pilot->forget = 0.05;
+            pilot->learning = 2.5f;
+            pilot->forget = 0.05f;
             break;
         case 7:
             // angel
@@ -919,8 +919,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->pref_jump = 40;
             pilot->pref_fwd = 40;
             pilot->pref_back = -9;
-            pilot->learning = 3.0;
-            pilot->forget = 0.15;
+            pilot->learning = 3.0f;
+            pilot->forget = 0.15f;
             break;
         case 8:
             // cossette
@@ -937,8 +937,8 @@ void reset_pilot_personality(sd_pilot *pilot) {
             pilot->ap_middle = -50;
             pilot->pref_jump = -10;
             pilot->pref_back = 10;
-            pilot->learning = 0.7;
-            pilot->forget = 0.2;
+            pilot->learning = 0.7f;
+            pilot->forget = 0.2f;
             break;
         case 9:
             // raven

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -695,8 +695,8 @@ void har_spawn_oil(object *obj, vec2i pos, int amount, float gravity, int layer)
 
         // Make sure the oil drops have somekind of velocity
         // (to prevent floating scrap objects)
-        if(vely < 0.1 && vely > -0.1)
-            vely += 0.21;
+        if(vely < 0.1f && vely > -0.1f)
+            vely += 0.21f;
 
         // Create the object
         object *scrap = omf_calloc(1, sizeof(object));
@@ -754,8 +754,8 @@ void har_spawn_scrap(object *obj, vec2i pos, int amount) {
 
         // Make sure scrap has somekind of velocity
         // (to prevent floating scrap objects)
-        if(vely < 0.1 && vely > -0.1)
-            vely += 0.21;
+        if(vely < 0.1f && vely > -0.1f)
+            vely += 0.21f;
 
         // Create the object
         object *scrap = omf_calloc(1, sizeof(object));

--- a/src/game/objects/scrap.c
+++ b/src/game/objects/scrap.c
@@ -16,7 +16,7 @@ void scrap_move(object *obj) {
     vel.y += obj->gravity;
     pos.y += vel.y;
 
-    float dampen = 0.4;
+    float dampen = 0.4f;
 
     if(pos.x < ARENA_LEFT_WALL) {
         pos.x = ARENA_LEFT_WALL;

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -30,7 +30,7 @@ static void player_clear_frame(object *obj) {
 
 void player_create(object *obj) {
     memset(&obj->animation_state, 0, sizeof(player_animation_state));
-    obj->animation_state.previous_tick = -1;
+    obj->animation_state.previous_tick = ~0u;
     sd_script_create(&obj->animation_state.parser);
     player_clear_frame(obj);
 }
@@ -71,7 +71,7 @@ void player_reload(object *obj) {
 }
 
 void player_reset(object *obj) {
-    obj->animation_state.previous_tick = -1;
+    obj->animation_state.previous_tick = ~0u;
     obj->animation_state.current_tick = 0;
     obj->animation_state.finished = 0;
     obj->animation_state.previous = -1;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1039,8 +1039,8 @@ void arena_dynamic_tick(scene *scene, int paused) {
 
                     // Make sure scrap has somekind of velocity
                     // (to prevent floating scrap objects)
-                    if(vely < 0.1 && vely > -0.1)
-                        vely += 0.21;
+                    if(vely < 0.1f && vely > -0.1f)
+                        vely += 0.21f;
 
                     // Create the object
                     object *scrap = omf_calloc(1, sizeof(object));

--- a/src/game/scenes/scoreboard.c
+++ b/src/game/scenes/scoreboard.c
@@ -222,7 +222,7 @@ int scoreboard_create(scene *scene) {
     }
 
     // Darken the colors for the background a bit.
-    vga_state_mul_base_palette(0, 0xEF, 0.6);
+    vga_state_mul_base_palette(0, 0xEF, 0.6f);
 
     if(local->has_pending_data) {
         text_settings small_text;

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -40,8 +40,9 @@ bool nat_create_upnp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port)
         // like overly short lifetimes
         return false;
     }
-#endif
+#else
     return false;
+#endif
 }
 
 bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
@@ -70,8 +71,9 @@ bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) 
         // TODO handle some errors here
         return false;
     }
-#endif
+#else
     return false;
+#endif
 }
 
 bool nat_create_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {

--- a/src/game/utils/score.c
+++ b/src/game/utils/score.c
@@ -23,13 +23,13 @@ typedef struct score_text {
 } score_text;
 
 float multipliers[] = {
-    0.2, // punching bag
-    0.4, // rookie
-    0.6, // veteran
-    0.8, // world class
-    1.0, // champion
-    1.2, // deadly
-    1.4  // ultimate
+    0.2f, // punching bag
+    0.4f, // rookie
+    0.6f, // veteran
+    0.8f, // world class
+    1.0f, // champion
+    1.2f, // deadly
+    1.4f  // ultimate
 };
 
 vec2i interpolate(vec2i start, vec2i end, float fraction) {

--- a/src/main.c
+++ b/src/main.c
@@ -11,9 +11,9 @@
 #include "utils/msgbox.h"
 #include "utils/random.h"
 #include <SDL.h>
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <enet/enet.h>

--- a/src/utils/compat.h
+++ b/src/utils/compat.h
@@ -3,7 +3,7 @@
 
 #include <string.h>
 
-#if __APPLE__
+#ifdef __APPLE__
 // MacOS X does not ship uchar.h
 #include <stdint.h>
 typedef uint_least16_t char16_t;

--- a/src/utils/scandir.c
+++ b/src/utils/scandir.c
@@ -10,11 +10,11 @@
 #endif
 
 static void check_valid_directory(char const *dir) {
-#if !NDEBUG
+#ifndef NDEBUG
     assert(dir != NULL);
     assert(dir[0] != '\0');
     size_t end = strlen(dir) - 1;
-#if _WIN32
+#ifdef _WIN32
     assert(dir[end] == '\\');
 #else
     assert(dir[end] == '/');

--- a/src/video/renderers/opengl3/helpers/bindings.c
+++ b/src/video/renderers/opengl3/helpers/bindings.c
@@ -7,7 +7,7 @@ static GLuint bound_vbo = 0;
 static GLuint bound_vao = 0;
 static GLuint bound_tex[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 static GLuint bound_fbo = 0;
-static GLuint active_tex = -1;
+static GLuint active_tex = ~0u;
 
 void binding_active_tex(GLuint unit_id) {
     if(active_tex != unit_id) {

--- a/src/video/renderers/opengl3/helpers/object_array.c
+++ b/src/video/renderers/opengl3/helpers/object_array.c
@@ -117,11 +117,12 @@ bool object_array_get_batch(const object_array *array, object_array_batch *state
     }
     state->start = state->end;
     object_array_blend_mode next;
-    for(; state->end < array->item_count; state->end++) {
+    do {
         next = array->modes[state->end];
         if(next != state->mode)
             break;
-    }
+        state->end++;
+    } while(state->end < array->item_count);
     *mode = state->mode;
     state->mode = next;
     return true;

--- a/testing/test_script.c
+++ b/testing/test_script.c
@@ -126,8 +126,8 @@ void test_script_get_frame_index(void) {
 }
 
 void test_script_get_frame_index_at(void) {
-    CU_ASSERT(sd_script_get_frame_index_at(NULL, -1) == -1);
-    CU_ASSERT(sd_script_get_frame_index_at(&script, -1) == -1);
+    CU_ASSERT(sd_script_get_frame_index_at(NULL, ~0u) == -1);
+    CU_ASSERT(sd_script_get_frame_index_at(&script, ~0u) == -1);
     CU_ASSERT(sd_script_get_frame_index_at(&script, 0) == 0);
     CU_ASSERT(sd_script_get_frame_index_at(&script, 99) == 0);
     CU_ASSERT(sd_script_get_frame_index_at(&script, 100) == 1);

--- a/tools/afdiff/main.c
+++ b/tools/afdiff/main.c
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/aftool/main.c
+++ b/tools/aftool/main.c
@@ -9,9 +9,9 @@
 #include "formats/af.h"
 #include "formats/error.h"
 #include <SDL.h>
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/altpaltool/main.c
+++ b/tools/altpaltool/main.c
@@ -5,9 +5,9 @@
 
 #include "formats/altpal.h"
 #include "formats/error.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/bktool/main.c
+++ b/tools/bktool/main.c
@@ -9,9 +9,9 @@
 #include "formats/bk.h"
 #include "formats/error.h"
 #include <SDL.h>
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/chrtool/main.c
+++ b/tools/chrtool/main.c
@@ -7,9 +7,9 @@
 #include "formats/bk.h"
 #include "formats/chr.h"
 #include "formats/error.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/chrtool/main.c
+++ b/tools/chrtool/main.c
@@ -103,12 +103,12 @@ int main(int argc, char *argv[]) {
 
     // Load bkfile if necessary
     sd_bk_file bk;
+    sd_bk_create(&bk);
     if(bkfile->count > 0) {
-        sd_bk_create(&bk);
         int ret = sd_bk_load(&bk, bkfile->filename[0]);
         if(ret != SD_SUCCESS) {
             printf("Unable to load BK file %s: %s.\n", bkfile->filename[0], sd_get_error(ret));
-            goto exit_2;
+            goto exit_1;
         }
     }
 
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
     if(export->count > 0 && bkfile->count > 0) {
         if(bk.palette_count < 1) {
             printf("BK file %s does not have palettes.\n", bkfile->filename[0]);
-            goto exit_2;
+            goto exit_1;
         }
 
         sd_rgba_image img;
@@ -159,11 +159,8 @@ int main(int argc, char *argv[]) {
     }
 
     // Quit
-exit_2:
-    if(bkfile->count > 0) {
-        sd_bk_free(&bk);
-    }
 exit_1:
+    sd_bk_free(&bk);
     sd_chr_free(&chr);
 exit_0:
     arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));

--- a/tools/fonttool/main.c
+++ b/tools/fonttool/main.c
@@ -7,9 +7,9 @@
 #include "formats/error.h"
 #include "formats/fonts.h"
 #include <SDL2/SDL.h>
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/languagetool/main.c
+++ b/tools/languagetool/main.c
@@ -127,7 +127,7 @@ int read_entry(FILE *file, sd_language *language, int *line_number) {
         // Check if this is the start of a new entry
         if(strncmp(line, "ID:", 3) == 0) {
             // Rewind to start of this line
-            fseek(file, -strlen(line), SEEK_CUR);
+            fseek(file, -(long)strlen(line), SEEK_CUR);
             *line_number -= 1;
             break;
         }

--- a/tools/languagetool/main.c
+++ b/tools/languagetool/main.c
@@ -14,9 +14,9 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 

--- a/tools/pcxtool/main.c
+++ b/tools/pcxtool/main.c
@@ -1,6 +1,6 @@
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include "formats/error.h"

--- a/tools/pictool/main.c
+++ b/tools/pictool/main.c
@@ -7,9 +7,9 @@
 #include "formats/bk.h"
 #include "formats/error.h"
 #include "formats/pic.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 

--- a/tools/rectool/main.c
+++ b/tools/rectool/main.c
@@ -6,9 +6,9 @@
 #include "../shared/pilot.h"
 #include "formats/error.h"
 #include "formats/rec.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/scoretool/main.c
+++ b/tools/scoretool/main.c
@@ -6,9 +6,9 @@
 
 #include "formats/error.h"
 #include "formats/score.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 

--- a/tools/setuptool/main.c
+++ b/tools/setuptool/main.c
@@ -6,9 +6,9 @@
 #include "../shared/pilot.h"
 #include "formats/error.h"
 #include "formats/setup.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/soundtool/main.c
+++ b/tools/soundtool/main.c
@@ -7,9 +7,9 @@
 #include "formats/error.h"
 #include "formats/sounds.h"
 #include <SDL.h>
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 

--- a/tools/stringparser/main.c
+++ b/tools/stringparser/main.c
@@ -6,9 +6,9 @@
 
 #include "formats/error.h"
 #include "formats/script.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>

--- a/tools/trntool/main.c
+++ b/tools/trntool/main.c
@@ -7,9 +7,9 @@
 #include "../shared/pilot.h"
 #include "formats/error.h"
 #include "formats/tournament.h"
-#if ARGTABLE2_FOUND
+#if defined(ARGTABLE2_FOUND)
 #include <argtable2.h>
-#elif ARGTABLE3_FOUND
+#elif defined(ARGTABLE3_FOUND)
 #include <argtable3.h>
 #endif
 #include <stdint.h>


### PR DESCRIPTION
- DEBUGMODE is now defined on MSVC debug builds
- VS_DEBUGGER_ENVIRONMENT now tells game where to find the resources and shaders, needed because build\resources is not next to build\Debug\openomf.exe (another solution I used previously was to copy the resources into build\Debug, but that's messy)
- Warnings are now either: silenced, treated as errors, and or fixed.

Enabling and fixing C4668 may be a bit silly, but I was feeling guilty about my habit of writing `#if XYZ` instead of `#ifdef XYZ` (where XYZ is maybe-defined, like __APPLE\_\_)

### implicit lossy conversions
The following two warnings are now be disabled, and are comparable to GCC's -Wconversion; -Wconversion is not enabled on master branch. Banning implicit lossy conversions is a good idea for another time, but fixing them will generate a **lot** of line diff noise.
```
C4244: implicit conversion, possible loss of data
C4267: implicit conversion from size_t, possible loss of data
```
