### PR TITLE
Fix some bugs, mostly crashes

### DIFF
--- a/src/console/console_cmd.c
+++ b/src/console/console_cmd.c
@@ -154,6 +154,8 @@ int console_cmd_win(game_state *gs, int argc, char **argv) {
     if(argc == 1) {
         game_player *player = game_state_get_player(gs, 1);
         object *har_obj = game_state_find_object(gs, game_player_get_har_obj_id(player));
+        if(!har_obj)
+            return 1;
         har *har = object_get_userdata(har_obj);
         har->health = 0;
         return 0;
@@ -165,6 +167,8 @@ int console_cmd_lose(game_state *gs, int argc, char **argv) {
     if(argc == 1) {
         game_player *player = game_state_get_player(gs, 0);
         object *har_obj = game_state_find_object(gs, game_player_get_har_obj_id(player));
+        if(!har_obj)
+            return 1;
         har *har = object_get_userdata(har_obj);
         har->health = 0;
         return 0;
@@ -176,6 +180,8 @@ int console_cmd_stun(game_state *gs, int argc, char **argv) {
     if(argc == 1) {
         game_player *player = game_state_get_player(gs, 1);
         object *har_obj = game_state_find_object(gs, game_player_get_har_obj_id(player));
+        if(!har_obj)
+            return 1;
         har *har = object_get_userdata(har_obj);
         har->endurance = 0;
         har->state = STATE_RECOIL;

--- a/src/engine.c
+++ b/src/engine.c
@@ -11,6 +11,7 @@
 #include "resources/sounds_loader.h"
 #include "utils/allocator.h"
 #include "utils/log.h"
+#include "utils/miscmath.h"
 #include "utils/png_writer.h"
 #include "utils/time_fmt.h"
 #include "video/vga_state.h"
@@ -20,6 +21,7 @@
 
 #define STATIC_TICKS 10
 #define MAX_TICKS_PER_FRAME 10
+#define TICK_EXPIRY_MS 100
 
 static int run = 0;
 static int start_timeout = 30;
@@ -268,6 +270,10 @@ void engine_run(engine_init_flags *init_flags) {
             static_wait += 20;
             debugger_proceed = 0;
         }
+
+        // drop ticks if it's been too long since they were due
+        dynamic_wait = min2(dynamic_wait, TICK_EXPIRY_MS);
+        static_wait = min2(static_wait, TICK_EXPIRY_MS);
 
         // In warp mode, allow more ticks to happen per vsync period.
         bool has_dynamic = true;

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1452,8 +1452,9 @@ void har_tick(object *obj) {
     // to show the sprite with animation string that interpolates opacity down
     // Mark new object as the owner of the animation, so that the animation gets
     // removed when the object is finished.
-    if(object_has_effect(obj, EFFECT_TRAIL) && obj->age % 2 == 0) {
-        sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
+    sprite *cur_sprite;
+    if(object_has_effect(obj, EFFECT_TRAIL) && obj->age % 2 == 0 &&
+       (cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id))) {
         sprite *nsp = sprite_copy(cur_sprite);
         surface_flatten_to_mask(nsp->data, 1);
         object *nobj = omf_calloc(1, sizeof(object));

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -2027,6 +2027,8 @@ void har_finished(object *obj) {
         // end the arena
         DEBUG("ending arena!");
         game_state_set_next(obj->gs, SCENE_MENU);
+        // prevent object from being freed, hold last sprite of animation indefinitely
+        obj->animation_state.finished = 0;
     } else if(h->state == STATE_RECOIL && h->health <= 0) {
         h->state = STATE_DEFEAT;
         har_set_ani(obj, ANIM_DEFEAT, 0);

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1444,7 +1444,7 @@ void har_tick(object *obj) {
     if(h->endurance < h->endurance_max &&
        !(h->executing_move || h->state == STATE_RECOIL || h->state == STATE_STUNNED || h->state == STATE_FALLEN ||
          h->state == STATE_STANDING_UP || h->state == STATE_DEFEAT)) {
-        h->endurance += 0.025f; // made up but plausible number
+        h->endurance += 0.0025f * h->endurance_max; // made up but plausible number
     }
 
     // Leave shadow trail

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -2024,9 +2024,6 @@ void har_finished(object *obj) {
         h->state = STATE_DONE;
         har_set_ani(obj, ANIM_VICTORY, 0);
     } else if(h->state == STATE_VICTORY || h->state == STATE_DONE) {
-        // end the arena
-        DEBUG("ending arena!");
-        game_state_set_next(obj->gs, SCENE_MENU);
         // prevent object from being freed, hold last sprite of animation indefinitely
         obj->animation_state.finished = 0;
     } else if(h->state == STATE_RECOIL && h->health <= 0) {

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -773,8 +773,8 @@ void object_set_vel(object *obj, vec2f vel) {
 }
 
 vec2i object_get_size(const object *obj) {
-    if(obj->cur_sprite_id >= 0) {
-        sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
+    sprite *cur_sprite = animation_get_sprite(obj->cur_animation, obj->cur_sprite_id);
+    if(cur_sprite) {
         return sprite_get_size(cur_sprite);
     }
     return vec2i_create(0, 0);

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -199,9 +199,12 @@ void player_run(object *obj) {
             player_reset(obj);
             frame = sd_script_get_frame_at(&state->parser, state->current_tick);
         } else if(obj->finish != NULL) {
-            obj->cur_sprite_id = -1;
             state->finished = 1;
             obj->finish(obj);
+            // let har_finish hold last sprite of victory animation indefinitely
+            if(state->finished) {
+                obj->cur_sprite_id = -1;
+            }
             return;
         } else {
             obj->cur_sprite_id = -1;

--- a/src/game/protos/scene.c
+++ b/src/game/protos/scene.c
@@ -201,6 +201,10 @@ void scene_input_poll(scene *scene) {
         // don't bleed to this one.
         return;
     }
+    if(scene->gs->this_id != scene->gs->next_id) {
+        // Ignore inputs during scene fadeout
+        return;
+    }
     if(scene->input_poll != NULL) {
         scene->input_poll(scene);
     }

--- a/src/game/scenes/scoreboard.c
+++ b/src/game/scenes/scoreboard.c
@@ -121,7 +121,7 @@ void scoreboard_render_overlay(scene *scene) {
     scoreboard_local *local = scene_get_userdata(scene);
     char row[128];
     char score_text[15];
-    const char *score_row_format = "%-18s%-9s%-9s%11s";
+    const char *score_row_format = "%-18.16s%-9s%-9s%11s";
 
     text_settings big_text;
     text_defaults(&big_text);

--- a/src/game/utils/har_screencap.c
+++ b/src/game/utils/har_screencap.c
@@ -75,5 +75,7 @@ void har_screencaps_capture(har_screencaps *caps, object *obj, object *obj2, int
 }
 
 void har_screencaps_compress(har_screencaps *caps, const vga_palette *pal, int id) {
-    surface_convert_to_grayscale(&caps->cap[id], pal, 0xD0, 0xDF, 0x60);
+    if(caps->ok[id]) {
+        surface_convert_to_grayscale(&caps->cap[id], pal, 0xD0, 0xDF, 0x60);
+    }
 }

--- a/src/video/vga_state.c
+++ b/src/video/vga_state.c
@@ -60,7 +60,7 @@ void vga_state_render(void) {
         for(unsigned int i = 0; i < state.transformer_count; i++) {
             state.transformers[i].callback(&tmp, &state.current, state.transformers[i].userdata);
         }
-        damage_copy(&state.dmg_current, &tmp);
+        damage_combine(&state.dmg_current, &tmp);
         damage_combine(&state.dmg_current, &state.dmg_previous);
         damage_copy(&state.dmg_previous, &tmp);
         state.transformer_count = 0;


### PR DESCRIPTION
Mostly from running demo with warp speed until it crashes, then fixing the crash and repeating.

Changes that are not related to crashes:
- "Drop ticks that are extremely late" ensures that the game doesn't try to catch up for more than 100ms worth of ticks-- this solves the issue where the game goes warpspeed after hitting a debugger breakpoint or other extreme stall.
- Make stamina regenerate about three thousand times faster than before, scaling it by the endurance_max. Neither the old code nor the new code is truly faithful to the original game, but this makes it regenerate at a somewhat similar rate to the original (whereas before, the effect was not noticable)