### PR TITLE
Separate menu input from per-player input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4146")
     # C4245: signed const to unsigned
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4245")
+    # C4255: function declaration missing arguments
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4255")
     # C4305: truncation from double to float
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4305")
     # C4701: potentially uninitialized local variable used

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -56,6 +56,11 @@ void controller_free(controller *ctrl) {
 }
 
 void controller_cmd(controller *ctrl, int action, ctrl_event **ev) {
+    ctrl->current |= action;
+    if((ctrl->last & action) && (!ctrl->repeat || action == ACT_KICK || action == ACT_PUNCH || action == ACT_ESC)) {
+        return;
+    }
+
     // fire any installed hooks
     iterator it;
     hook_function **p = 0;

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -95,8 +95,9 @@ void controller_cmd(controller *ctrl, int action, ctrl_event **ev) {
     iterator it;
     hook_function **p = 0;
     list_iter_begin(&ctrl->hooks, &it);
-    while((p = iter_next(&it)) != NULL) {
-        ((*p)->fp)((*p)->source, action);
+    while((p = iter_next(&it))) {
+        hook_function hook = **p;
+        (hook.fp)(hook.source, action);
     }
 
     ctrl_action_push(ev, action);

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -66,6 +66,8 @@ struct controller_t {
     int type;
     int rtt;
     int repeat;
+    int current;
+    int last;
 };
 
 void controller_init(controller *ctrl, game_state *gs);

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -16,7 +16,9 @@ enum
     ACT_DOWN = 0x10,
     ACT_LEFT = 0x20,
     ACT_ESC = 0x40,
-    ACT_RIGHT = 0x80
+    ACT_RIGHT = 0x80,
+
+    ACT_Mask_Dirs = (ACT_UP | ACT_DOWN | ACT_LEFT | ACT_RIGHT),
 };
 
 enum
@@ -66,6 +68,7 @@ struct controller_t {
     int type;
     int rtt;
     int repeat;
+    int repeat_tick;
     int current;
     int last;
 };

--- a/src/controller/joystick.c
+++ b/src/controller/joystick.c
@@ -238,7 +238,7 @@ void joystick_menu_poll_all(controller *menu_ctrl, ctrl_event **ev) {
         return;
 
     joystick k;
-    memset(&k, 0, sizeof k);
+    memset(&k, 0, sizeof(k));
     joystick_keys keys;
     internal_joystick_default_keys(&keys);
     k.keys = &keys;

--- a/src/controller/joystick.c
+++ b/src/controller/joystick.c
@@ -19,14 +19,8 @@ void joystick_free(controller *ctrl) {
     omf_free(k);
 }
 
-void joystick_cmd(controller *ctrl, int action, ctrl_event **ev) {
-    joystick *k = ctrl->data;
-    if(ctrl->repeat && action != ACT_KICK && action != ACT_PUNCH && action != ACT_ESC) {
-        controller_cmd(ctrl, action, ev);
-    } else if(!(k->last & action)) {
-        controller_cmd(ctrl, action, ev);
-    }
-    k->current |= action;
+static inline void joystick_cmd(controller *ctrl, int action, ctrl_event **ev) {
+    controller_cmd(ctrl, action, ev);
 }
 
 int joystick_count(void) {
@@ -87,7 +81,7 @@ int joystick_name_to_id(const char *name, int offset) {
 int joystick_poll(controller *ctrl, ctrl_event **ev) {
     joystick *k = ctrl->data;
 
-    k->current = 0;
+    ctrl->current = 0;
 
     Sint16 x_axis = SDL_GameControllerGetAxis(k->joy, k->keys->x_axis);
     Sint16 y_axis = SDL_GameControllerGetAxis(k->joy, k->keys->y_axis);
@@ -146,11 +140,11 @@ int joystick_poll(controller *ctrl, ctrl_event **ev) {
         joystick_cmd(ctrl, ACT_ESC, ev);
     }
 
-    if(k->current == 0) {
+    if(ctrl->current == 0) {
         joystick_cmd(ctrl, ACT_STOP, ev);
     }
 
-    k->last = k->current;
+    ctrl->last = ctrl->current;
     return 0;
 }
 
@@ -174,7 +168,6 @@ int joystick_create(controller *ctrl, int joystick_id) {
     k->keys->punch = SDL_CONTROLLER_BUTTON_A;
     k->keys->kick = SDL_CONTROLLER_BUTTON_B;
     k->keys->escape = SDL_CONTROLLER_BUTTON_START;
-    k->last = 0;
     k->rumble = 0;
     ctrl->data = k;
     ctrl->type = CTRL_TYPE_GAMEPAD;

--- a/src/controller/joystick.c
+++ b/src/controller/joystick.c
@@ -198,3 +198,7 @@ int joystick_create(controller *ctrl, int joystick_id) {
     PERROR("Failed to open game controller: %s", SDL_GetError());
     return 0;
 }
+
+void joystick_menu_poll_all(controller *menu_ctrl, ctrl_event **ev) {
+    // TODO: Poll all detected joysticks for menu inputs
+}

--- a/src/controller/joystick.c
+++ b/src/controller/joystick.c
@@ -79,6 +79,11 @@ int joystick_name_to_id(const char *name, int offset) {
 }
 
 static int internal_joystick_poll(joystick *k, controller *ctrl, ctrl_event **ev) {
+    if(!SDL_GameControllerGetAttached(k->joy)) {
+        controller_close(ctrl, ev);
+        return 0;
+    }
+
     Sint16 x_axis = SDL_GameControllerGetAxis(k->joy, k->keys->x_axis);
     Sint16 y_axis = SDL_GameControllerGetAxis(k->joy, k->keys->y_axis);
     int dpadup = SDL_GameControllerGetButton(k->joy, k->keys->dpad[0]);

--- a/src/controller/joystick.c
+++ b/src/controller/joystick.c
@@ -209,7 +209,7 @@ int joystick_create(controller *ctrl, int joystick_id) {
 
 static vector every_gamepad;
 
-void joystick_init() {
+void joystick_init(void) {
     int num_joysticks = SDL_NumJoysticks();
     vector_create_with_size(&every_gamepad, sizeof(SDL_GameController *), num_joysticks);
 
@@ -218,7 +218,7 @@ void joystick_init() {
     }
 }
 
-void joystick_close() {
+void joystick_close(void) {
     iterator it;
     vector_iter_begin(&every_gamepad, &it);
     SDL_GameController **gamepad;

--- a/src/controller/joystick.h
+++ b/src/controller/joystick.h
@@ -28,6 +28,10 @@ int joystick_nth_id(int n);
 int joystick_name_to_id(const char *name, int offset);
 int joystick_offset(int id, const char *name);
 
+void joystick_init();
+void joystick_close();
 void joystick_menu_poll_all(controller *menu_ctrl, ctrl_event **ev);
+void joystick_deviceadded(int sdl_joystick_index);
+void joystick_deviceremoved(int sdl_joystick_instance_id);
 
 #endif // JOYSTICK_H

--- a/src/controller/joystick.h
+++ b/src/controller/joystick.h
@@ -18,8 +18,6 @@ typedef struct {
     SDL_Haptic *haptic;
     joystick_keys *keys;
     int rumble;
-    int last;
-    int current;
 } joystick;
 
 int joystick_create(controller *ctrl, int joystick_id);

--- a/src/controller/joystick.h
+++ b/src/controller/joystick.h
@@ -28,4 +28,6 @@ int joystick_nth_id(int n);
 int joystick_name_to_id(const char *name, int offset);
 int joystick_offset(int id, const char *name);
 
+void joystick_menu_poll_all(controller *menu_ctrl, ctrl_event **ev);
+
 #endif // JOYSTICK_H

--- a/src/controller/joystick.h
+++ b/src/controller/joystick.h
@@ -28,8 +28,8 @@ int joystick_nth_id(int n);
 int joystick_name_to_id(const char *name, int offset);
 int joystick_offset(int id, const char *name);
 
-void joystick_init();
-void joystick_close();
+void joystick_init(void);
+void joystick_close(void);
 void joystick_menu_poll_all(controller *menu_ctrl, ctrl_event **ev);
 void joystick_deviceadded(int sdl_joystick_index);
 void joystick_deviceremoved(int sdl_joystick_instance_id);

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -50,10 +50,6 @@ int keyboard_poll(controller *ctrl, ctrl_event **ev) {
         keyboard_cmd(ctrl, ACT_KICK, ev);
     }
 
-    if(state[k->keys->escape]) {
-        keyboard_cmd(ctrl, ACT_ESC, ev);
-    }
-
     if(ctrl->current == 0) {
         keyboard_cmd(ctrl, ACT_STOP, ev);
     }
@@ -67,7 +63,7 @@ int keyboard_binds_key(controller *ctrl, SDL_Event *event) {
     SDL_Scancode sc = event->key.keysym.scancode;
     if(sc == k->keys->jump_up || sc == k->keys->jump_right || sc == k->keys->walk_right ||
        sc == k->keys->duck_forward || sc == k->keys->duck || sc == k->keys->duck_back || sc == k->keys->walk_back ||
-       sc == k->keys->jump_left || sc == k->keys->kick || sc == k->keys->punch || sc == k->keys->escape) {
+       sc == k->keys->jump_left || sc == k->keys->kick || sc == k->keys->punch) {
         return 1;
     }
     return 0;

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -85,27 +85,22 @@ void keyboard_create(controller *ctrl, keyboard_keys *keys, int delay) {
 void keyboard_menu_poll(controller *ctrl, ctrl_event **ev) {
     const unsigned char *state = SDL_GetKeyboardState(NULL);
 
-    if(state[SDL_SCANCODE_LEFT] && state[SDL_SCANCODE_UP]) {
-        controller_cmd(ctrl, ACT_UP | ACT_LEFT, ev);
-    } else if(state[SDL_SCANCODE_LEFT] && state[SDL_SCANCODE_DOWN]) {
-        controller_cmd(ctrl, ACT_DOWN | ACT_LEFT, ev);
-    } else if(state[SDL_SCANCODE_RIGHT] && state[SDL_SCANCODE_UP]) {
-        controller_cmd(ctrl, ACT_UP | ACT_RIGHT, ev);
-    } else if(state[SDL_SCANCODE_RIGHT] && state[SDL_SCANCODE_DOWN]) {
-        controller_cmd(ctrl, ACT_DOWN | ACT_RIGHT, ev);
-    } else if(state[SDL_SCANCODE_RIGHT]) {
+    if(state[SDL_SCANCODE_RIGHT] || state[SDL_SCANCODE_KP_6]) {
         controller_cmd(ctrl, ACT_RIGHT, ev);
-    } else if(state[SDL_SCANCODE_LEFT]) {
+    }
+    if(state[SDL_SCANCODE_LEFT] || state[SDL_SCANCODE_KP_4]) {
         controller_cmd(ctrl, ACT_LEFT, ev);
-    } else if(state[SDL_SCANCODE_UP]) {
+    }
+    if(state[SDL_SCANCODE_UP] || state[SDL_SCANCODE_KP_8]) {
         controller_cmd(ctrl, ACT_UP, ev);
-    } else if(state[SDL_SCANCODE_DOWN]) {
+    }
+    if(state[SDL_SCANCODE_DOWN] || state[SDL_SCANCODE_KP_2]) {
         controller_cmd(ctrl, ACT_DOWN, ev);
     }
-
-    if(state[SDL_SCANCODE_RETURN]) {
+    if(state[SDL_SCANCODE_RETURN] || state[SDL_SCANCODE_KP_ENTER]) {
         controller_cmd(ctrl, ACT_PUNCH, ev);
-    } else if(state[SDL_SCANCODE_RSHIFT]) {
+    }
+    if(state[SDL_SCANCODE_RSHIFT] || state[SDL_SCANCODE_KP_0]) {
         controller_cmd(ctrl, ACT_KICK, ev);
     }
 

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -81,3 +81,35 @@ void keyboard_create(controller *ctrl, keyboard_keys *keys, int delay) {
     ctrl->poll_fun = &keyboard_poll;
     ctrl->free_fun = &keyboard_free;
 }
+
+void keyboard_menu_poll(controller *ctrl, ctrl_event **ev) {
+    const unsigned char *state = SDL_GetKeyboardState(NULL);
+
+    if(state[SDL_SCANCODE_LEFT] && state[SDL_SCANCODE_UP]) {
+        controller_cmd(ctrl, ACT_UP | ACT_LEFT, ev);
+    } else if(state[SDL_SCANCODE_LEFT] && state[SDL_SCANCODE_DOWN]) {
+        controller_cmd(ctrl, ACT_DOWN | ACT_LEFT, ev);
+    } else if(state[SDL_SCANCODE_RIGHT] && state[SDL_SCANCODE_UP]) {
+        controller_cmd(ctrl, ACT_UP | ACT_RIGHT, ev);
+    } else if(state[SDL_SCANCODE_RIGHT] && state[SDL_SCANCODE_DOWN]) {
+        controller_cmd(ctrl, ACT_DOWN | ACT_RIGHT, ev);
+    } else if(state[SDL_SCANCODE_RIGHT]) {
+        controller_cmd(ctrl, ACT_RIGHT, ev);
+    } else if(state[SDL_SCANCODE_LEFT]) {
+        controller_cmd(ctrl, ACT_LEFT, ev);
+    } else if(state[SDL_SCANCODE_UP]) {
+        controller_cmd(ctrl, ACT_UP, ev);
+    } else if(state[SDL_SCANCODE_DOWN]) {
+        controller_cmd(ctrl, ACT_DOWN, ev);
+    }
+
+    if(state[SDL_SCANCODE_RETURN]) {
+        controller_cmd(ctrl, ACT_PUNCH, ev);
+    } else if(state[SDL_SCANCODE_RSHIFT]) {
+        controller_cmd(ctrl, ACT_KICK, ev);
+    }
+
+    if(state[SDL_SCANCODE_ESCAPE]) {
+        controller_cmd(ctrl, ACT_ESC, ev);
+    }
+}

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -8,19 +8,13 @@ void keyboard_free(controller *ctrl) {
     omf_free(k);
 }
 
-void keyboard_cmd(controller *ctrl, int action, ctrl_event **ev) {
-    keyboard *k = ctrl->data;
-    if(ctrl->repeat && action != ACT_KICK && action != ACT_PUNCH && action != ACT_ESC) {
-        controller_cmd(ctrl, action, ev);
-    } else if(!(k->last & action)) {
-        controller_cmd(ctrl, action, ev);
-    }
-    k->current |= action;
+static inline void keyboard_cmd(controller *ctrl, int action, ctrl_event **ev) {
+    controller_cmd(ctrl, action, ev);
 }
 
 int keyboard_poll(controller *ctrl, ctrl_event **ev) {
     keyboard *k = ctrl->data;
-    k->current = 0;
+    ctrl->current = 0;
     const unsigned char *state = SDL_GetKeyboardState(NULL);
     if(state[k->keys->jump_left]) {
         keyboard_cmd(ctrl, ACT_UP | ACT_LEFT, ev);
@@ -60,11 +54,11 @@ int keyboard_poll(controller *ctrl, ctrl_event **ev) {
         keyboard_cmd(ctrl, ACT_ESC, ev);
     }
 
-    if(k->current == 0) {
+    if(ctrl->current == 0) {
         keyboard_cmd(ctrl, ACT_STOP, ev);
     }
 
-    k->last = k->current;
+    ctrl->last = ctrl->current;
     return 0;
 }
 
@@ -82,7 +76,6 @@ int keyboard_binds_key(controller *ctrl, SDL_Event *event) {
 void keyboard_create(controller *ctrl, keyboard_keys *keys, int delay) {
     keyboard *k = omf_calloc(1, sizeof(keyboard));
     k->keys = keys;
-    k->last = 0;
     ctrl->data = k;
     ctrl->type = CTRL_TYPE_KEYBOARD;
     ctrl->poll_fun = &keyboard_poll;

--- a/src/controller/keyboard.h
+++ b/src/controller/keyboard.h
@@ -31,4 +31,6 @@ void keyboard_create(controller *ctrl, keyboard_keys *keys, int delay);
 void keyboard_free(controller *ctrl);
 int keyboard_binds_key(controller *ctrl, SDL_Event *event);
 
+void keyboard_menu_poll(controller *ctrl, ctrl_event **ev);
+
 #endif // KEYBOARD_H

--- a/src/controller/keyboard.h
+++ b/src/controller/keyboard.h
@@ -20,7 +20,6 @@ struct keyboard_keys_t {
     unsigned jump_left;
     unsigned punch;
     unsigned kick;
-    unsigned escape;
 };
 
 struct keyboard_t {

--- a/src/controller/keyboard.h
+++ b/src/controller/keyboard.h
@@ -25,8 +25,6 @@ struct keyboard_keys_t {
 
 struct keyboard_t {
     keyboard_keys *keys;
-    int last;
-    int current;
 };
 
 void keyboard_create(controller *ctrl, keyboard_keys *keys, int delay);

--- a/src/engine.c
+++ b/src/engine.c
@@ -149,6 +149,8 @@ void engine_run(engine_init_flags *init_flags) {
         return;
     }
 
+    joystick_init();
+
     // Game loop
     uint64_t frame_start = SDL_GetTicks64(); // Set game tick timer
     int dynamic_wait = 0;
@@ -184,6 +186,12 @@ void engine_run(engine_init_flags *init_flags) {
                     if(e.key.keysym.sym == SDLK_F6) {
                         debugger_render = !debugger_render;
                     }
+                    break;
+                case SDL_JOYDEVICEADDED:
+                    joystick_deviceadded(e.jdevice.which);
+                    break;
+                case SDL_JOYDEVICEREMOVED:
+                    joystick_deviceremoved(e.jdevice.which);
                     break;
                 case SDL_MOUSEMOTION:
                     mouse_visible_ticks = 1000;
@@ -322,6 +330,8 @@ void engine_run(engine_init_flags *init_flags) {
             SDL_Delay(1);
         }
     }
+
+    joystick_close();
 
     // Free scene object
     game_state_free(&gs);

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -822,7 +822,6 @@ void _setup_keyboard(game_state *gs, int player_id) {
         keys->jump_left = SDL_GetScancodeFromName(k->key1_jump_left);
         keys->punch = SDL_GetScancodeFromName(k->key1_punch);
         keys->kick = SDL_GetScancodeFromName(k->key1_kick);
-        keys->escape = SDL_GetScancodeFromName(k->key1_escape);
     } else {
         keys->jump_up = SDL_GetScancodeFromName(k->key2_jump_up);
         keys->jump_right = SDL_GetScancodeFromName(k->key2_jump_right);
@@ -834,7 +833,6 @@ void _setup_keyboard(game_state *gs, int player_id) {
         keys->jump_left = SDL_GetScancodeFromName(k->key2_jump_left);
         keys->punch = SDL_GetScancodeFromName(k->key2_punch);
         keys->kick = SDL_GetScancodeFromName(k->key2_kick);
-        keys->escape = SDL_GetScancodeFromName(k->key2_escape);
     }
 
     keyboard_create(ctrl, keys, 0);

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -86,6 +86,7 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
     gs->warp_speed = 0;
 
     gs->hide_ui = false;
+    gs->menu_ctrl = omf_calloc(1, sizeof(controller));
 
     // Set up players
     gs->sc = omf_calloc(1, sizeof(scene));
@@ -916,6 +917,15 @@ void game_state_init_demo(game_state *gs) {
     }
 }
 
+void game_state_menu_poll(game_state *gs, ctrl_event **ev) {
+    gs->menu_ctrl->last = gs->menu_ctrl->current;
+    gs->menu_ctrl->current = 0;
+    // poll keyboard
+    keyboard_menu_poll(gs->menu_ctrl, ev);
+    // poll joysticks
+    joystick_menu_poll_all(gs->menu_ctrl, ev);
+}
+
 void game_state_clone_free(game_state *gs) {
     // Free objects
     render_obj *robj;
@@ -966,6 +976,7 @@ void game_state_free(game_state **_gs) {
         game_player_free(gs->players[i]);
         omf_free(gs->players[i]);
     }
+    omf_free(gs->menu_ctrl);
     omf_free(gs);
 }
 

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -619,6 +619,7 @@ void game_state_call_move(game_state *gs) {
 }
 
 void game_state_tick_controllers(game_state *gs) {
+    controller_tick(gs->menu_ctrl, gs->int_tick, &gs->menu_ctrl->extra_events);
     for(int i = 0; i < game_state_num_players(gs); i++) {
         game_player *gp = game_state_get_player(gs, i);
         controller *c = game_player_get_ctrl(gp);

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -316,6 +316,11 @@ unsigned int game_state_is_paused(game_state *gs) {
 }
 
 void game_state_set_paused(game_state *gs, unsigned int paused) {
+    // don't pause netplay games
+    if(is_netplay(gs)) {
+        return;
+    }
+
     gs->paused = paused;
 }
 

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -11,6 +11,7 @@
 typedef struct scene_t scene;
 typedef struct game_player_t game_player;
 typedef struct object_t object;
+typedef struct ctrl_event_t ctrl_event;
 
 int game_state_create(game_state *gs, engine_init_flags *init_flags);
 void game_state_free(game_state **gs);
@@ -42,6 +43,8 @@ void _setup_keyboard(game_state *gs, int player_id);
 void _setup_ai(game_state *gs, int player_id);
 int _setup_joystick(game_state *gs, int player_id, const char *joyname, int offset);
 void reconfigure_controller(game_state *gs);
+
+void game_state_menu_poll(game_state *gs, ctrl_event **ev);
 
 int game_state_rewind(game_state *gs, int rtt);
 void game_state_replay(game_state *gs, int rtt);

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -32,6 +32,7 @@ enum
 typedef struct scene_t scene;
 typedef struct game_player_t game_player;
 typedef struct ticktimer_t ticktimer;
+typedef struct controller_t controller;
 
 typedef struct game_state_t {
     unsigned int run;
@@ -71,6 +72,8 @@ typedef struct game_state_t {
     fight_stats fight_stats;
     void *new_state;
     struct random_t rand;
+
+    controller *menu_ctrl;
 } game_state;
 
 #endif // GAME_STATE_TYPE_H

--- a/src/game/gui/menu.c
+++ b/src/game/gui/menu.c
@@ -141,18 +141,21 @@ static int menu_action(component *mc, int action) {
         return component_action(m->submenu, action);
     }
 
-    // Select last item if ESC is pressed
-    if(m->selected == sizer_size(mc) - 1 && action == ACT_ESC) {
-        // If the last item is already selected, and ESC if punched, change the action to punch
-        // This is then passed to the quit (last) component and its callback is called
-        // Hacky, but works well in menu sizer.
-        m->finished = 1;
-        action = ACT_PUNCH;
-    } else if(action == ACT_ESC) {
-        // Select last item when ESC is pressed and it's not already selected.
+    if(action == ACT_ESC) {
+        bool was_last_selected = m->selected == sizer_size(mc) - 1;
+        // Select last item when ESC is pressed
         c = sizer_get(mc, sizer_size(mc) - 1);
         menu_select(mc, c);
-        return 0;
+
+        if((m->is_submenu || was_last_selected) && action == ACT_ESC) {
+            // If the last item is already selected, and ESC if punched, change the action to punch
+            // This is then passed to the quit (last) component and its callback is called
+            // Hacky, but works well in menu sizer.
+            m->finished = 1;
+            action = ACT_PUNCH;
+        } else {
+            return 0;
+        }
     }
 
     // Handle down/up selection movement
@@ -205,6 +208,8 @@ static int menu_action(component *mc, int action) {
 
 void menu_set_submenu(component *mc, component *submenu) {
     menu *m = sizer_get_obj(mc);
+    menu *subm = sizer_get_obj(submenu);
+    subm->is_submenu = true;
     if(m->submenu) {
         component_free(m->submenu);
     }

--- a/src/game/gui/menu.c
+++ b/src/game/gui/menu.c
@@ -160,6 +160,7 @@ static int menu_action(component *mc, int action) {
     if(c != NULL && c->supports_select &&
        (((action == ACT_DOWN || action == ACT_UP) && !m->horizontal) ||
         ((action == ACT_LEFT || action == ACT_RIGHT) && m->horizontal))) {
+        component *old_c = c;
         component_select(c, 0);
         do {
             if(action == ACT_DOWN && !m->horizontal) {
@@ -184,9 +185,11 @@ static int menu_action(component *mc, int action) {
             c = sizer_get(mc, m->selected);
 
         } while(component_is_disabled(c));
-        // Play menu sound
-        audio_play_sound(19, 0.5f, 0.0f, 2.0f);
-        component_select(c, 1);
+        if(c != old_c) {
+            // Play menu sound
+            audio_play_sound(19, 0.5f, 0.0f, 2.0f);
+            component_select(c, 1);
+        }
         return 0;
     }
 

--- a/src/game/gui/menu.h
+++ b/src/game/gui/menu.h
@@ -19,10 +19,11 @@ typedef struct {
     int obj_h;
     int margin_top;
     int padding;
-    int finished;
+    bool finished;
     bool horizontal;
     bool background;
     bool centered;
+    bool is_submenu;
 
     int help_x;
     int help_y;

--- a/src/game/gui/textselector.c
+++ b/src/game/gui/textselector.c
@@ -80,34 +80,29 @@ static void textselector_render(component *c) {
 
 static int textselector_action(component *c, int action) {
     textselector *tb = widget_get_obj(c);
+    if(vector_size(&tb->options) <= 1) {
+        return 0;
+    }
+    int old_pos = *tb->pos;
+    float panning = 0.0f;
     if(action == ACT_KICK || action == ACT_PUNCH || action == ACT_RIGHT) {
-        if(vector_size(&tb->options) == 0) {
-            return 0;
-        }
+        panning = 0.5f;
         (*tb->pos)++;
         if(*tb->pos >= (int)vector_size(&tb->options)) {
             *tb->pos = 0;
         }
-        if(tb->toggle) {
-            tb->toggle(c, tb->userdata, *tb->pos);
-        }
-        audio_play_sound(20, 0.5f, 0.5f, 2.0f);
-        // reset ticks so text is bright
-        tb->ticks = 0;
-        tb->dir = 0;
-        return 0;
     } else if(action == ACT_LEFT) {
-        if(vector_size(&tb->options) == 0) {
-            return 0;
-        }
+        panning = -0.5f;
         (*tb->pos)--;
         if(*tb->pos < 0) {
             *tb->pos = vector_size(&tb->options) - 1;
         }
+    }
+    if(old_pos != *tb->pos) {
         if(tb->toggle) {
             tb->toggle(c, tb->userdata, *tb->pos);
         }
-        audio_play_sound(20, 0.5f, -0.5f, 2.0f);
+        audio_play_sound(20, 0.5f, panning, 2.0f);
         // reset ticks so text is bright
         tb->ticks = 0;
         tb->dir = 0;

--- a/src/game/gui/textslider.c
+++ b/src/game/gui/textslider.c
@@ -50,29 +50,23 @@ static void textslider_render(component *c) {
 
 static int textslider_action(component *c, int action) {
     textslider *tb = widget_get_obj(c);
+    int old_pos = *tb->pos;
+    float panning = 0.5f;
     if(action == ACT_KICK || action == ACT_PUNCH || action == ACT_RIGHT) {
         (*tb->pos)++;
         if(*tb->pos > tb->positions) {
             *tb->pos = tb->positions;
-        } else {
-            // Play menu sound
-            audio_play_sound(20, 0.5f, 0.5f, 2.0f);
         }
-        if(tb->slide) {
-            tb->slide(c, tb->userdata, *tb->pos);
-        }
-        // reset ticks so text is bright
-        tb->ticks = 0;
-        tb->dir = 0;
-        return 0;
     } else if(action == ACT_LEFT) {
+        panning = -panning;
         (*tb->pos)--;
         if(*tb->pos < 0) {
             *tb->pos = 0;
-        } else {
-            // Play menu sound
-            audio_play_sound(20, 0.5f, -0.5f, 2.0f);
         }
+    }
+    if(old_pos != *tb->pos) {
+        // Play menu sound
+        audio_play_sound(20, 0.5f, panning, 2.0f);
         if(tb->slide) {
             tb->slide(c, tb->userdata, *tb->pos);
         }

--- a/src/game/gui/textslider.h
+++ b/src/game/gui/textslider.h
@@ -11,5 +11,7 @@ component *textslider_create(const text_settings *tconf, const char *text, const
 component *textslider_create_bind(const text_settings *tconf, const char *text, const char *help,
                                   unsigned int positions, int has_off, textslider_slide_cb cb, void *userdata,
                                   int *bind);
+// by default, the "next" and "previous" item selection noises are panned; call this to disable that effect.
+void textslider_disable_panning(component *c);
 
 #endif // TEXTSLIDER_H

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -191,12 +191,6 @@ void scene_youlose_anim_start(void *userdata) {
     /*arena->state = ARENA_STATE_ENDING;*/
 }
 
-void arena_repeat_controller(void *userdata) {
-    game_state *gs = userdata;
-    game_player *player1 = game_state_get_player(gs, 0);
-    controller_set_repeat(game_player_get_ctrl(player1), 1);
-}
-
 void arena_screengrab_winner(scene *sc) {
     game_state *gs = sc->gs;
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1009,7 +1009,7 @@ void arena_static_tick(scene *scene, int paused) {
 void arena_input_tick(scene *scene) {
     arena_local *local = scene_get_userdata(scene);
 
-    if(!local->menu_visible) {
+    if(!game_state_is_paused(scene->gs)) {
         game_player *player1 = game_state_get_player(scene->gs, 0);
         game_player *player2 = game_state_get_player(scene->gs, 1);
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -90,8 +90,6 @@ void game_menu_quit(component *c, void *userdata) {
 
 void game_menu_return(component *c, void *userdata) {
     arena_local *local = scene_get_userdata((scene *)userdata);
-    game_player *player1 = game_state_get_player(((scene *)userdata)->gs, 0);
-    controller_set_repeat(game_player_get_ctrl(player1), 1);
     local->menu_visible = 0;
     game_state_set_paused(((scene *)userdata)->gs, 0);
 }
@@ -1027,8 +1025,6 @@ void arena_input_tick(scene *scene) {
             // toggle menu
             local->menu_visible = !local->menu_visible;
             game_state_set_paused(scene->gs, local->menu_visible);
-            controller_set_repeat(game_player_get_ctrl(game_state_get_player(scene->gs, 0)), !local->menu_visible);
-            controller_set_repeat(game_player_get_ctrl(game_state_get_player(scene->gs, 1)), !local->menu_visible);
         } else if(i->type == EVENT_TYPE_ACTION && local->menu_visible && i->event_data.action != ACT_ESC) {
             // menu events
             guiframe_action(local->game_menu, i->event_data.action);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1035,6 +1035,18 @@ void arena_input_tick(scene *scene) {
     arena_handle_events(scene, player2, p2);
     controller_free_chain(p1);
     controller_free_chain(p2);
+
+    if(is_demoplay(scene)) {
+        ctrl_event *p = NULL;
+        game_state_menu_poll(scene->gs, &p);
+        for(ctrl_event *i = p; i; i = i->next) {
+            if(i->type == EVENT_TYPE_ACTION && i->event_data.action == ACT_ESC) {
+                game_state_set_next(scene->gs, SCENE_MENU);
+                break;
+            }
+        }
+        controller_free_chain(p);
+    }
 }
 
 int arena_event(scene *scene, SDL_Event *e) {

--- a/src/game/scenes/credits.c
+++ b/src/game/scenes/credits.c
@@ -9,10 +9,8 @@ typedef struct credits_local_t {
 } credits_local;
 
 void credits_input_tick(scene *scene) {
-    game_player *player1 = game_state_get_player(scene->gs, 0);
-
     ctrl_event *p1 = NULL, *i;
-    controller_poll(player1->ctrl, &p1);
+    game_state_menu_poll(scene->gs, &p1);
 
     i = p1;
     if(i) {

--- a/src/game/scenes/cutscene.c
+++ b/src/game/scenes/cutscene.c
@@ -45,9 +45,9 @@ static int cutscene_next_scene(scene *scene) {
 static void cutscene_input_tick(scene *scene) {
     cutscene_local *local = scene_get_userdata(scene);
     game_player *player1 = game_state_get_player(scene->gs, 0);
-    ctrl_event *p1 = NULL, *i;
 
-    controller_poll(player1->ctrl, &p1);
+    ctrl_event *p1 = NULL, *i;
+    game_state_menu_poll(scene->gs, &p1);
 
     i = p1;
     if(i) {

--- a/src/game/scenes/intro.c
+++ b/src/game/scenes/intro.c
@@ -13,10 +13,8 @@ typedef struct intro_local_t {
 } intro_local;
 
 void intro_input_tick(scene *scene) {
-    game_player *player1 = game_state_get_player(scene->gs, 0);
-
     ctrl_event *p1 = NULL, *i;
-    controller_poll(player1->ctrl, &p1);
+    game_state_menu_poll(scene->gs, &p1);
 
     i = p1;
     if(i) {

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -761,7 +761,6 @@ void lobby_tick(scene *scene, int paused) {
                     keys->jump_left = SDL_GetScancodeFromName(k->key1_jump_left);
                     keys->punch = SDL_GetScancodeFromName(k->key1_punch);
                     keys->kick = SDL_GetScancodeFromName(k->key1_kick);
-                    keys->escape = SDL_GetScancodeFromName(k->key1_escape);
                     keyboard_create(player1_ctrl, keys, 0);
                     game_player_set_ctrl(p1, player1_ctrl);
 
@@ -880,7 +879,6 @@ void lobby_tick(scene *scene, int paused) {
                             keys->jump_left = SDL_GetScancodeFromName(k->key1_jump_left);
                             keys->punch = SDL_GetScancodeFromName(k->key1_punch);
                             keys->kick = SDL_GetScancodeFromName(k->key1_kick);
-                            keys->escape = SDL_GetScancodeFromName(k->key1_escape);
                             keyboard_create(player2_ctrl, keys, 0);
                             game_player_set_ctrl(p2, player2_ctrl);
                             game_player_set_selectable(p2, 1);

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -121,9 +121,8 @@ static int lobby_event(scene *scene, SDL_Event *e) {
 
 void lobby_input_tick(scene *scene) {
     lobby_local *local = scene_get_userdata(scene);
-    game_player *player1 = game_state_get_player(scene->gs, 0);
     ctrl_event *p1 = NULL, *i;
-    controller_poll(player1->ctrl, &p1);
+    game_state_menu_poll(scene->gs, &p1);
 
     i = p1;
     if(i) {

--- a/src/game/scenes/mainmenu/menu_audio.c
+++ b/src/game/scenes/mainmenu/menu_audio.c
@@ -102,12 +102,14 @@ component *menu_audio_create(scene *s) {
 
     // Create menu and its header
     component *menu = menu_create(11);
+    component *volume_textslider;
     menu_attach(menu, label_create(&tconf, "AUDIO"));
     menu_attach(menu, filler_create());
     menu_attach(menu,
-                textslider_create_bind(&tconf, "SOUND",
-                                       "Raise or lower the volume of all sound effects. Press right or left to change.",
-                                       10, 1, menu_audio_sound_slide, NULL, &settings_get()->sound.sound_vol));
+                volume_textslider = textslider_create_bind(
+                    &tconf, "SOUND", "Raise or lower the volume of all sound effects. Press right or left to change.",
+                    10, 1, menu_audio_sound_slide, NULL, &settings_get()->sound.sound_vol));
+    textslider_disable_panning(volume_textslider);
     menu_attach(menu, textslider_create_bind(&tconf, "MUSIC",
                                              "Raise or lower the volume of music. Press right or left to change.", 10,
                                              1, menu_audio_music_slide, NULL, &settings_get()->sound.music_vol));

--- a/src/game/scenes/mainmenu/menu_connect.c
+++ b/src/game/scenes/mainmenu/menu_connect.c
@@ -140,7 +140,6 @@ void menu_connect_tick(component *c) {
             keys->jump_left = SDL_GetScancodeFromName(k->key1_jump_left);
             keys->punch = SDL_GetScancodeFromName(k->key1_punch);
             keys->kick = SDL_GetScancodeFromName(k->key1_kick);
-            keys->escape = SDL_GetScancodeFromName(k->key1_escape);
             keyboard_create(player2_ctrl, keys, 0);
             game_player_set_ctrl(p2, player2_ctrl);
             game_player_set_selectable(p2, 1);

--- a/src/game/scenes/mainmenu/menu_listen.c
+++ b/src/game/scenes/mainmenu/menu_listen.c
@@ -79,7 +79,6 @@ void menu_listen_tick(component *c) {
             keys->jump_left = SDL_GetScancodeFromName(k->key1_jump_left);
             keys->punch = SDL_GetScancodeFromName(k->key1_punch);
             keys->kick = SDL_GetScancodeFromName(k->key1_kick);
-            keys->escape = SDL_GetScancodeFromName(k->key1_escape);
             keyboard_create(player1_ctrl, keys, 0);
             game_player_set_ctrl(p1, player1_ctrl);
 

--- a/src/game/scenes/mainmenu/menu_presskey.c
+++ b/src/game/scenes/mainmenu/menu_presskey.c
@@ -43,9 +43,6 @@ int is_key_bound(int key) {
     CHECK_KEY(k->key2_punch)
     CHECK_KEY(k->key2_kick)
 
-    CHECK_KEY(k->key1_escape)
-    CHECK_KEY(k->key2_escape)
-
     return 0;
 }
 

--- a/src/game/scenes/mechlab.c
+++ b/src/game/scenes/mechlab.c
@@ -412,7 +412,7 @@ void mechlab_input_tick(scene *scene) {
 
     // Poll the controller
     ctrl_event *p1 = NULL, *i;
-    controller_poll(player1->ctrl, &p1);
+    game_state_menu_poll(scene->gs, &p1);
     i = p1;
     if(i == NULL) {
         return;

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -391,7 +391,8 @@ void handle_action(scene *scene, int player, int action) {
     }
 
     if(old_row != *row || old_column != *column) {
-        audio_play_sound(19, 0.5f, 0.0f, 2.0f);
+        float panning = (float)(*column) * (2.0f / 5.0f) - 0.5f;
+        audio_play_sound(19, 0.5f, panning, 2.0f);
         update_har(scene, player);
     }
 

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -174,7 +174,7 @@ void melee_tick(scene *scene, int paused) {
     if(i) {
         do {
             if(i->type == EVENT_TYPE_ACTION) {
-                handle_action(scene, 1, i->event_data.action);
+                handle_action(scene, 0, i->event_data.action);
             } else if(i->type == EVENT_TYPE_CLOSE) {
                 game_state_set_next(scene->gs, SCENE_MENU);
                 return;
@@ -185,7 +185,7 @@ void melee_tick(scene *scene, int paused) {
     if(i) {
         do {
             if(i->type == EVENT_TYPE_ACTION) {
-                handle_action(scene, 2, i->event_data.action);
+                handle_action(scene, 1, i->event_data.action);
             } else if(i->type == EVENT_TYPE_CLOSE) {
                 game_state_set_next(scene->gs, SCENE_MENU);
                 return;
@@ -230,7 +230,7 @@ void update_har(scene *scene, int player) {
             har = &local->har_player2;
         }
 
-        ani = &bk_get_info(scene->bk_data, 18 + CURSOR_INDEX(local, player - 1))->ani;
+        ani = &bk_get_info(scene->bk_data, 18 + CURSOR_INDEX(local, player))->ani;
         object_set_animation(har, ani);
         object_select_sprite(har, 0);
         object_set_repeat(har, 1);
@@ -245,9 +245,9 @@ void handle_action(scene *scene, int player, int action) {
     game_player *player1 = game_state_get_player(scene->gs, 0);
     game_player *player2 = game_state_get_player(scene->gs, 1);
     melee_local *local = scene_get_userdata(scene);
-    int *row = &local->cursor[player - 1].row;
-    int *column = &local->cursor[player - 1].column;
-    bool *done = &local->cursor[player - 1].done;
+    int *row = &local->cursor[player].row;
+    int *column = &local->cursor[player].column;
+    bool *done = &local->cursor[player].done;
 
     if(*done) {
         return;
@@ -280,9 +280,9 @@ void handle_action(scene *scene, int player, int action) {
             }
             // nova selection cheat
             if(*row == 1 && *column == 0) {
-                local->katana_down_count[player - 1]++;
-                if(local->katana_down_count[player - 1] > 11) {
-                    local->katana_down_count[player - 1] = 11;
+                local->katana_down_count[player]++;
+                if(local->katana_down_count[player] > 11) {
+                    local->katana_down_count[player] = 11;
                 }
             }
             break;
@@ -295,8 +295,8 @@ void handle_action(scene *scene, int player, int action) {
                 local->cursor[1].done = 0;
                 if(local->page == PILOT_SELECT) {
                     local->page = HAR_SELECT;
+                    update_har(scene, 0);
                     update_har(scene, 1);
-                    update_har(scene, 2);
                     local->pilot_id_a = CURSOR_INDEX(local, 0);
                     local->pilot_id_b = CURSOR_INDEX(local, 1);
 
@@ -405,7 +405,7 @@ void handle_action(scene *scene, int player, int action) {
 
     // nova selection cheat
     if(local->page == HAR_SELECT) {
-        local->har_selected[player - 1][5 * (*row) + *column] = 1;
+        local->har_selected[player][5 * (*row) + *column] = 1;
     }
 
     refresh_pilot_stats(local);
@@ -422,7 +422,7 @@ void melee_input_tick(scene *scene) {
     if(i) {
         do {
             if(i->type == EVENT_TYPE_ACTION) {
-                handle_action(scene, 1, i->event_data.action);
+                handle_action(scene, 0, i->event_data.action);
             } else if(i->type == EVENT_TYPE_CLOSE) {
                 game_state_set_next(scene->gs, SCENE_MENU);
             }
@@ -433,7 +433,7 @@ void melee_input_tick(scene *scene) {
     if(i) {
         do {
             if(i->type == EVENT_TYPE_ACTION) {
-                handle_action(scene, 2, i->event_data.action);
+                handle_action(scene, 1, i->event_data.action);
             } else if(i->type == EVENT_TYPE_CLOSE) {
                 game_state_set_next(scene->gs, SCENE_MENU);
             }

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -253,34 +253,26 @@ void handle_action(scene *scene, int player, int action) {
         return;
     }
 
+    int old_row = *row;
+    int old_column = *column;
+
     switch(action) {
         case ACT_LEFT:
             (*column)--;
             if(*column < 0) {
                 *column = 4;
             }
-
-            audio_play_sound(19, 0.5f, 0.0f, 2.0f);
-            update_har(scene, player);
-
             break;
         case ACT_RIGHT:
             (*column)++;
             if(*column > 4) {
                 *column = 0;
             }
-
-            audio_play_sound(19, 0.5f, 0.0f, 2.0f);
-            update_har(scene, player);
-
             break;
         case ACT_UP:
             if(*row == 1) {
                 *row = 0;
             }
-
-            audio_play_sound(19, 0.5f, 0.0f, 2.0f);
-            update_har(scene, player);
             break;
         case ACT_DOWN:
             if(*row == 0) {
@@ -293,9 +285,6 @@ void handle_action(scene *scene, int player, int action) {
                     local->katana_down_count[player - 1] = 11;
                 }
             }
-
-            audio_play_sound(19, 0.5f, 0.0f, 2.0f);
-            update_har(scene, player);
             break;
         case ACT_KICK:
         case ACT_PUNCH:
@@ -399,6 +388,11 @@ void handle_action(scene *scene, int player, int action) {
                 }
             }
             break;
+    }
+
+    if(old_row != *row || old_column != *column) {
+        audio_play_sound(19, 0.5f, 0.0f, 2.0f);
+        update_har(scene, player);
     }
 
     if(local->page == PILOT_SELECT) {

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -71,8 +71,7 @@ typedef struct {
     portrait pilot_portraits[10];
     portrait har_portraits[10];
 
-    object har_player1;
-    object har_player2;
+    object har[2];
 
     component *bar_power[2];
     component *bar_agility[2];
@@ -112,10 +111,8 @@ void melee_free(scene *scene) {
         component_free(local->bar_endurance[i]);
     }
 
-    object_free(&local->har_player1);
-    if(player2->selectable) {
-        object_free(&local->har_player2);
-    }
+    object_free(&local->har[0]);
+    object_free(&local->har[1]);
 
     for(int i = 0; i < 10; i++) {
         surface_free(&local->har_portraits[i].enabled);
@@ -203,9 +200,9 @@ void melee_tick(scene *scene, int paused) {
     }
 
     if(local->page == HAR_SELECT && local->ticks % 10 == 1) {
-        object_dynamic_tick(&local->har_player1);
+        object_dynamic_tick(&local->har[0]);
         if(player2->selectable) {
-            object_dynamic_tick(&local->har_player2);
+            object_dynamic_tick(&local->har[1]);
         }
     }
 
@@ -233,10 +230,7 @@ void update_har(scene *scene, int player) {
     if(local->page == HAR_SELECT) {
         game_player *player2 = game_state_get_player(scene->gs, 1);
         animation *ani;
-        object *har = &local->har_player1;
-        if(player == 2) {
-            har = &local->har_player2;
-        }
+        object *har = &local->har[player];
 
         ani = &bk_get_info(scene->bk_data, 18 + CURSOR_INDEX(local, player))->ani;
         object_set_animation(har, ani);
@@ -597,7 +591,7 @@ static void render_har_select(melee_local *local, bool player2_is_selectable) {
 
     // currently selected HAR
     render_enabled_portrait(local->har_portraits, &local->cursor[0], 0);
-    object_render(&local->har_player1);
+    object_render(&local->har[0]);
 
     text_settings tconf_green;
     text_defaults(&tconf_green);
@@ -627,7 +621,7 @@ static void render_har_select(melee_local *local, bool player2_is_selectable) {
 
         // currently selected HAR
         render_enabled_portrait(local->har_portraits, &local->cursor[1], 1);
-        object_render(&local->har_player2);
+        object_render(&local->har[1]);
 
         // render HAR name (Har1 VS. Har2)
         text_render(&tconf_black, TEXT_DEFAULT, 80, 107, 150, 6, str_c(&local->vs_text));
@@ -721,20 +715,20 @@ static void load_har_portraits(scene *scene, melee_local *local) {
 static void load_hars(scene *scene, melee_local *local, bool player2_is_selectable) {
     animation *ani;
     ani = &bk_get_info(scene->bk_data, 18)->ani;
-    object_create(&local->har_player1, scene->gs, vec2i_create(110, 95), vec2f_create(0, 0));
-    object_set_animation(&local->har_player1, ani);
-    object_select_sprite(&local->har_player1, 0);
-    object_set_repeat(&local->har_player1, 1);
+    object_create(&local->har[0], scene->gs, vec2i_create(110, 95), vec2f_create(0, 0));
+    object_set_animation(&local->har[0], ani);
+    object_select_sprite(&local->har[0], 0);
+    object_set_repeat(&local->har[0], 1);
 
     if(player2_is_selectable) {
         ani = &bk_get_info(scene->bk_data, 18 + 4)->ani;
-        object_create(&local->har_player2, scene->gs, vec2i_create(210, 95), vec2f_create(0, 0));
-        object_set_animation(&local->har_player2, ani);
-        object_select_sprite(&local->har_player2, 0);
-        object_set_repeat(&local->har_player2, 1);
-        object_set_direction(&local->har_player2, OBJECT_FACE_LEFT);
-        object_set_pal_offset(&local->har_player2, 48);
-        object_set_pal_limit(&local->har_player2, 96);
+        object_create(&local->har[1], scene->gs, vec2i_create(210, 95), vec2f_create(0, 0));
+        object_set_animation(&local->har[1], ani);
+        object_select_sprite(&local->har[1], 0);
+        object_set_repeat(&local->har[1], 1);
+        object_set_direction(&local->har[1], OBJECT_FACE_LEFT);
+        object_set_pal_offset(&local->har[1], 48);
+        object_set_pal_limit(&local->har[1], 96);
     }
 }
 

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -422,24 +422,7 @@ void melee_input_tick(scene *scene) {
     if(i) {
         do {
             if(i->type == EVENT_TYPE_ACTION) {
-                if(i->event_data.action == ACT_ESC) {
-                    audio_play_sound(20, 0.5f, 0.0f, 2.0f);
-                    if(local->page == HAR_SELECT) {
-                        // restore the player selection
-                        local->cursor[0].column = local->pilot_id_a % 5;
-                        local->cursor[0].row = local->pilot_id_a / 5;
-                        local->cursor[0].done = 0;
-                        local->cursor[1].column = local->pilot_id_b % 5;
-                        local->cursor[1].row = local->pilot_id_b / 5;
-                        local->cursor[1].done = 0;
-                        local->page = PILOT_SELECT;
-                        load_pilot_portraits_palette(scene);
-                    } else {
-                        game_state_set_next(scene->gs, SCENE_MENU);
-                    }
-                } else {
-                    handle_action(scene, 1, i->event_data.action);
-                }
+                handle_action(scene, 1, i->event_data.action);
             } else if(i->type == EVENT_TYPE_CLOSE) {
                 game_state_set_next(scene->gs, SCENE_MENU);
             }
@@ -457,6 +440,29 @@ void melee_input_tick(scene *scene) {
         } while((i = i->next) != NULL);
     }
     controller_free_chain(p2);
+
+    ctrl_event *menu_ev = NULL;
+    game_state_menu_poll(scene->gs, &menu_ev);
+
+    for(i = menu_ev; i; i = i->next) {
+        if(i->type == EVENT_TYPE_ACTION && i->event_data.action == ACT_ESC) {
+            audio_play_sound(20, 0.5f, 0.0f, 2.0f);
+            if(local->page == HAR_SELECT) {
+                // restore the player selection
+                local->cursor[0].column = local->pilot_id_a % 5;
+                local->cursor[0].row = local->pilot_id_a / 5;
+                local->cursor[0].done = 0;
+                local->cursor[1].column = local->pilot_id_b % 5;
+                local->cursor[1].row = local->pilot_id_b / 5;
+                local->cursor[1].done = 0;
+                local->page = PILOT_SELECT;
+                load_pilot_portraits_palette(scene);
+            } else {
+                game_state_set_next(scene->gs, SCENE_MENU);
+            }
+        }
+    }
+    controller_free_chain(menu_ev);
 }
 
 static void draw_highlight(const melee_local *local, const cursor_data *cursor, int offset) {

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -218,9 +218,11 @@ void newsroom_continue_dialog_clicked(dialog *dlg, dialog_result result) {
 void newsroom_input_tick(scene *scene) {
     newsroom_local *local = scene_get_userdata(scene);
 
-    game_player *player1 = game_state_get_player(scene->gs, 0);
+    game_player *p1 = game_state_get_player(scene->gs, 0);
+    game_player *p2 = game_state_get_player(scene->gs, 1);
+
     ctrl_event *event = NULL, *i;
-    controller_poll(player1->ctrl, &event);
+    game_state_menu_poll(scene->gs, &event);
     i = event;
     if(i) {
         do {
@@ -238,10 +240,8 @@ void newsroom_input_tick(scene *scene) {
                     }
 
                     if((local->screen >= 2 && !local->champion) || local->screen >= 3) {
-                        if(local->won || player1->chr) {
+                        if(local->won || p1->chr) {
                             // pick a new player
-                            game_player *p1 = game_state_get_player(scene->gs, 0);
-                            game_player *p2 = game_state_get_player(scene->gs, 1);
                             if(p1->chr) {
                                 // clear the opponent as a signal to display plug on the VS
                                 p2->pilot = NULL;

--- a/src/game/scenes/openomf.c
+++ b/src/game/scenes/openomf.c
@@ -10,10 +10,8 @@ typedef struct openomf_local_t {
 } openomf_local;
 
 void openomf_input_tick(scene *scene) {
-    game_player *player1 = game_state_get_player(scene->gs, 0);
-
     ctrl_event *p1 = NULL, *i;
-    controller_poll(player1->ctrl, &p1);
+    game_state_menu_poll(scene->gs, &p1);
 
     i = p1;
     if(i) {

--- a/src/game/scenes/scoreboard.c
+++ b/src/game/scenes/scoreboard.c
@@ -82,9 +82,8 @@ void scoreboard_tick(scene *scene, int paused) {
 
 void scoreboard_input_tick(scene *scene) {
     scoreboard_local *local = scene_get_userdata(scene);
-    game_player *player1 = game_state_get_player(scene->gs, 0);
     ctrl_event *p1 = NULL, *i;
-    controller_poll(player1->ctrl, &p1);
+    game_state_menu_poll(scene->gs, &p1);
     i = p1;
     if(i) {
         do {

--- a/src/game/utils/settings.c
+++ b/src/game/utils/settings.c
@@ -121,7 +121,6 @@ const field f_keyboard[] = {
     F_STRING(settings_keyboard, key1_jump_left, "Home"),
     F_STRING(settings_keyboard, key1_kick, "Right Shift"),
     F_STRING(settings_keyboard, key1_punch, "Return"),
-    F_STRING(settings_keyboard, key1_escape, "Escape"),
 
     // Player two
     F_INT(settings_keyboard, ctrl_type2, CTRL_TYPE_KEYBOARD),
@@ -137,7 +136,7 @@ const field f_keyboard[] = {
     F_STRING(settings_keyboard, key2_jump_left, "Q"),
     F_STRING(settings_keyboard, key2_kick, "Left Shift"),
     F_STRING(settings_keyboard, key2_punch, "Left Ctrl"),
-    F_STRING(settings_keyboard, key2_escape, "Escape")};
+};
 
 const field f_net[] = {
     F_STRING(settings_network, net_connect_ip, "localhost"),

--- a/src/game/utils/settings.h
+++ b/src/game/utils/settings.h
@@ -90,7 +90,6 @@ typedef struct {
     char *key1_jump_left;
     char *key1_kick;
     char *key1_punch;
-    char *key1_escape;
 
     // Player two
     int ctrl_type2;
@@ -106,7 +105,6 @@ typedef struct {
     char *key2_jump_left;
     char *key2_kick;
     char *key2_punch;
-    char *key2_escape;
 } settings_keyboard;
 
 typedef struct {

--- a/src/utils/vector.c
+++ b/src/utils/vector.c
@@ -109,11 +109,23 @@ int vector_delete_at(vector *vec, unsigned index) {
     }
 
     // We deleted an entry, so blocks-1
-    if(vec->blocks > 0) {
-        vec->blocks--;
-    }
+    vec->blocks--;
 
     // Return success
+    return 0;
+}
+
+int vector_swapdelete_at(vector *vec, unsigned index) {
+    if(vec->blocks == 0)
+        return 1;
+
+    unsigned last = vec->blocks - 1;
+    if(index != last) {
+        memcpy(vector_get(vec, index), vector_get(vec, last), vec->block_size);
+    }
+
+    vec->blocks--;
+
     return 0;
 }
 

--- a/src/utils/vector.h
+++ b/src/utils/vector.h
@@ -23,6 +23,8 @@ int vector_prepend(vector *vector, const void *value);
 void vector_sort(vector *vector, vector_compare_func cf);
 unsigned int vector_size(const vector *vector);
 int vector_delete_at(vector *vec, unsigned index);
+// removes an element by swapping it with the last element before popping.
+int vector_swapdelete_at(vector *vec, unsigned index);
 int vector_delete(vector *vector, iterator *iterator);
 void vector_pop(vector *vector);
 void *vector_back(const vector *vector);


### PR DESCRIPTION
The only things that are still controlled by per-player input (controller_poll) are Melee, Vs, and Arena.
Everything else now uses `game_state_menu_poll`, a drop-in replacement for `controller_poll` that lets all detected input devices control the menus.

Users are unable to rebind the keyboard menu controls, to avoid complications around textinput, multiple keys performing the same action, and ensuring no single key performs multiple actions.
 
All detected game controllers/joysticks generate menu input events, even when no player has a joystick bound.

Closes #499 
Closes #266 
Closes #265