### PR TITLE
Fix P2 pilot portrait regression

### DIFF
--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -554,7 +554,7 @@ static void render_pilot_select(melee_local *local, bool player2_is_selectable) 
     render_enabled_portrait(local->pilot_portraits, &local->cursor[0], -1);
     object_render(&local->big_portrait_1);
     if(player2_is_selectable) {
-        render_enabled_portrait(local->pilot_portraits, &local->cursor[0], -1);
+        render_enabled_portrait(local->pilot_portraits, &local->cursor[1], -1);
         object_render(&local->big_portrait_2);
     }
 }


### PR DESCRIPTION
Fixes a bug where player 2's portrait doesn't render.

Occured because i made a typo a pr or two ago, where the game renders p1's portrait a second time instead of rendering p2's.