### PR TITLE
Don't fail to parse the config file due to an unknown option

### DIFF
--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -47,7 +47,7 @@ void conf_addstring(char *name, char *default_val) {
 
 int conf_init_internal(const char *filename) {
     conf_ensure_opt_init();
-    cfg = cfg_init((cfg_opt_t *)cfg_opts.data, 0);
+    cfg = cfg_init((cfg_opt_t *)cfg_opts.data, CFGF_IGNORE_UNKNOWN);
     int ret = cfg_parse(cfg, filename);
     if(ret == CFG_FILE_ERROR) {
         PERROR("Error while attempting to read config file '%s' !", filename);


### PR DESCRIPTION
If we add or remove config options, confuse will throw an error loading the config file, and replace it with a default one. This patch enables the confuse option to not do that, and allow the config to load.

See https://github.com/libconfuse/libconfuse/pull/41