### PR TITLE
Fix pilot gender in tournament mode

### DIFF
--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -195,7 +195,7 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
         chr->enemies[i]->photo_id = memread_ubyte(mr);
         memread_buf(mr, chr->enemies[i]->unknown_b, 15);
         if(trn_loaded) {
-            chr->enemies[i]->pilot.sex = pic.photos[(uint8_t)chr->enemies[i]->photo_id]->sex;
+            chr->enemies[i]->pilot.sex = pic.photos[(uint16_t)chr->enemies[i]->photo_id]->sex;
         }
         for(int m = 0; m < 10; m++) {
             if(trn_loaded && trn.enemies[i]->quotes[m]) {

--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -190,9 +190,13 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
             chr->enemies[i]->pilot.winnings = trn.enemies[i]->winnings;
             chr->enemies[i]->pilot.total_value = trn.enemies[i]->total_value;
             chr->enemies[i]->pilot.photo_id = trn.enemies[i]->photo_id;
-            chr->enemies[i]->pilot.sex = pic.photos[(uint8_t)chr->enemies[i]->unknown[9]]->sex;
         }
-        memread_buf(mr, chr->enemies[i]->unknown, 25);
+        memread_buf(mr, chr->enemies[i]->unknown_a, 9);
+        chr->enemies[i]->photo_id = memread_ubyte(mr);
+        memread_buf(mr, chr->enemies[i]->unknown_b, 15);
+        if(trn_loaded) {
+            chr->enemies[i]->pilot.sex = pic.photos[(uint8_t)chr->enemies[i]->photo_id]->sex;
+        }
         for(int m = 0; m < 10; m++) {
             if(trn_loaded && trn.enemies[i]->quotes[m]) {
                 chr->enemies[i]->pilot.quotes[m] = omf_strdup(trn.enemies[i]->quotes[m]);
@@ -269,7 +273,8 @@ int sd_chr_save(sd_chr_file *chr, const char *filename) {
     mw = memwriter_open();
     for(int i = 0; i < chr->pilot.enemies_inc_unranked; i++) {
         sd_pilot_save_player_to_mem(mw, &chr->enemies[i]->pilot);
-        memwrite_buf(mw, chr->enemies[i]->unknown, 25);
+        memwrite_buf(mw, chr->enemies[i]->unknown_a, 9);
+        memwrite_ubyte(mw, chr->enemies[i]->photo_id);
     }
     memwriter_xor(mw, (chr->pilot.enemies_inc_unranked * 68) & 0xFF);
     memwriter_save(mw, w);

--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -177,6 +177,7 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
             chr->enemies[i]->pilot.photo_id = trn.enemies[i]->photo_id;
         }
         memread_buf(mr, chr->enemies[i]->unknown, 25);
+        chr->enemies[i]->pilot.sex = pic.photos[(uint8_t)chr->enemies[i]->unknown[9]]->sex;
         for(int m = 0; m < 10; m++) {
             if(trn_loaded && trn.enemies[i]->quotes[m]) {
                 chr->enemies[i]->pilot.quotes[m] = omf_strdup(trn.enemies[i]->quotes[m]);

--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -275,6 +275,7 @@ int sd_chr_save(sd_chr_file *chr, const char *filename) {
         sd_pilot_save_player_to_mem(mw, &chr->enemies[i]->pilot);
         memwrite_buf(mw, chr->enemies[i]->unknown_a, 9);
         memwrite_ubyte(mw, chr->enemies[i]->photo_id);
+        memwrite_buf(mw, chr->enemies[i]->unknown_b, 15);
     }
     memwriter_xor(mw, (chr->pilot.enemies_inc_unranked * 68) & 0xFF);
     memwriter_save(mw, w);

--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -74,7 +74,7 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
     str pic_file;
     str trn_file;
     sd_tournament_file trn;
-    sd_pic_file pic;
+    sd_pic_file pic, players;
     bool trn_loaded = false;
 
     if(dirname) {
@@ -84,6 +84,21 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
         str_free(&pic_file);
         sd_pic_create(&pic);
         sd_pic_load(&pic, tmp);
+
+        const char *players_filename = pm_get_resource_path(PIC_PLAYERS);
+        if(players_filename) {
+            DEBUG("trying to load players.pic from %s", players_filename);
+            // Load PIC file and make a surface
+            sd_pic_create(&players);
+            int ret = sd_pic_load(&players, players_filename);
+            if(ret == SD_SUCCESS) {
+                // Load player gender from PLAYERS.PIC
+                DEBUG("loading %d from players.pic", chr->pilot.photo_id);
+                const sd_pic_photo *photo = sd_pic_get(&players, chr->pilot.photo_id);
+                chr->pilot.sex = photo->sex;
+                sd_pic_free(&players);
+            }
+        }
 
         if(*chr->pilot.trn_name != '\0') {
             str_from_c(&trn_file, chr->pilot.trn_name);
@@ -175,9 +190,9 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
             chr->enemies[i]->pilot.winnings = trn.enemies[i]->winnings;
             chr->enemies[i]->pilot.total_value = trn.enemies[i]->total_value;
             chr->enemies[i]->pilot.photo_id = trn.enemies[i]->photo_id;
+            chr->enemies[i]->pilot.sex = pic.photos[(uint8_t)chr->enemies[i]->unknown[9]]->sex;
         }
         memread_buf(mr, chr->enemies[i]->unknown, 25);
-        chr->enemies[i]->pilot.sex = pic.photos[(uint8_t)chr->enemies[i]->unknown[9]]->sex;
         for(int m = 0; m < 10; m++) {
             if(trn_loaded && trn.enemies[i]->quotes[m]) {
                 chr->enemies[i]->pilot.quotes[m] = omf_strdup(trn.enemies[i]->quotes[m]);

--- a/src/formats/chr.h
+++ b/src/formats/chr.h
@@ -22,8 +22,10 @@
  * Contains information about the current state of an enemy in the selected tournament.
  */
 typedef struct {
-    sd_pilot pilot;   ///< Enemy pilot data
-    char unknown[25]; ///< Unknown data TODO: Find out what this does
+    sd_pilot pilot;    ///< Enemy pilot data
+    char unknown_a[9]; ///< Unknown data TODO: Find out what this does
+    uint8_t photo_id;
+    char unknown_b[15];
 } sd_chr_enemy;
 
 /*! \brief CHR Saved game

--- a/src/formats/pilot.h
+++ b/src/formats/pilot.h
@@ -108,6 +108,8 @@ typedef struct {
 
     char *quotes[10]; ///< Pilot quotes for each supported language
 
+    int sex;
+
     sd_sprite *photo; ///< Pilot photo, in tournament mode only
 } sd_pilot;
 

--- a/src/game/common_defines.h
+++ b/src/game/common_defines.h
@@ -104,4 +104,10 @@ enum
     NUMBER_OF_ROUND_TYPES,
 };
 
+enum
+{
+    PILOT_SEX_MALE,
+    PILOT_SEX_FEMALE
+};
+
 #endif // COMMON_DEFINES_H

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -322,6 +322,7 @@ void handle_action(scene *scene, int player, int action) {
                     player1->pilot->endurance = p_a.endurance;
                     player1->pilot->power = p_a.power;
                     player1->pilot->agility = p_a.agility;
+                    player1->pilot->sex = p_a.sex;
                     sd_pilot_set_player_color(player1->pilot, TERTIARY, p_a.colors[0]);
                     sd_pilot_set_player_color(player1->pilot, SECONDARY, p_a.colors[1]);
                     sd_pilot_set_player_color(player1->pilot, PRIMARY, p_a.colors[2]);
@@ -334,6 +335,7 @@ void handle_action(scene *scene, int player, int action) {
                         player2->pilot->endurance = p_a.endurance;
                         player2->pilot->power = p_a.power;
                         player2->pilot->agility = p_a.agility;
+                        player2->pilot->sex = p_a.sex;
                         sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.colors[0]);
                         sd_pilot_set_player_color(player2->pilot, SECONDARY, p_a.colors[1]);
                         sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.colors[2]);
@@ -388,6 +390,7 @@ void handle_action(scene *scene, int player, int action) {
                         player2->pilot->endurance = p_a.endurance;
                         player2->pilot->power = p_a.power;
                         player2->pilot->agility = p_a.agility;
+                        player2->pilot->sex = p_a.sex;
                         sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.colors[0]);
                         sd_pilot_set_player_color(player2->pilot, SECONDARY, p_a.colors[1]);
                         sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.colors[2]);

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -301,18 +301,6 @@ void newsroom_input_tick(scene *scene) {
     controller_free_chain(event);
 }
 
-int pilot_sex(int pilot_id) {
-    switch(pilot_id) {
-        case PILOT_CRYSTAL:
-        case PILOT_ANGEL:
-        case PILOT_COSSETTE:
-            return PILOT_SEX_FEMALE;
-        default:
-            // everyone else is male
-            return PILOT_SEX_MALE;
-    }
-}
-
 void newsroom_startup(scene *scene, int id, int *m_load, int *m_repeat) {
     switch(id) {
         case 5:
@@ -380,17 +368,14 @@ int newsroom_create(scene *scene) {
         local->news_id = 42 + rand_int(3) * 2;
     }
 
-    // XXX TODO get the real sex of pilot
     // XXX TODO strip spaces from the end of the pilots name
     // XXX TODO set winner/loser names properly
     if(p1->chr) {
-        // TODO pilot genders
         newsroom_set_names(local, p1->pilot->name, p2->pilot->name, p1->pilot->har_id, p2->pilot->har_id,
-                           pilot_sex(p1->pilot->pilot_id), pilot_sex(p2->pilot->pilot_id));
+                           p1->pilot->sex, p2->pilot->sex);
     } else {
         newsroom_set_names(local, lang_get(20 + p1->pilot->pilot_id), lang_get(20 + p2->pilot->pilot_id),
-                           p1->pilot->har_id, p2->pilot->har_id, pilot_sex(p1->pilot->pilot_id),
-                           pilot_sex(p2->pilot->pilot_id));
+                           p1->pilot->har_id, p2->pilot->har_id, p1->pilot->sex, p2->pilot->sex);
     }
     newsroom_fixup_str(local);
 

--- a/src/game/scenes/newsroom.h
+++ b/src/game/scenes/newsroom.h
@@ -3,12 +3,6 @@
 
 #include "game/protos/scene.h"
 
-enum
-{
-    PILOT_SEX_MALE,
-    PILOT_SEX_FEMALE
-};
-
 int newsroom_create(scene *scene);
 
 #endif // NEWSROOM_H

--- a/src/resources/pilots.c
+++ b/src/resources/pilots.c
@@ -4,17 +4,20 @@
 void pilot_get_info(pilot *pilot, int id) {
     // TODO read this from MASTER.DAT
     // XXX the colors are eyeballed
+    pilot->sex = 0;
     switch(id) {
         case 0:
+            // CRYSTAL
             pilot->power = 5;
             pilot->agility = 16;
             pilot->endurance = 9;
             pilot->colors[0] = 5;
             pilot->colors[1] = 11;
             pilot->colors[2] = 8;
+            pilot->sex = 1;
             break;
         case 1:
-
+            // STEFFAN
             pilot->power = 13;
             pilot->agility = 9;
             pilot->endurance = 8;
@@ -23,6 +26,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 7;
             break;
         case 2:
+            // MILANO
             pilot->power = 7;
             pilot->agility = 20;
             pilot->endurance = 4;
@@ -31,6 +35,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 7;
             break;
         case 3:
+            // CHRISTIAN
             pilot->power = 9;
             pilot->agility = 7;
             pilot->endurance = 15;
@@ -39,6 +44,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 6;
             break;
         case 4:
+            // SHIRRO
             pilot->power = 20;
             pilot->agility = 1;
             pilot->endurance = 8;
@@ -47,6 +53,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 14;
             break;
         case 5:
+            // JEAN-PAUL
             pilot->power = 9;
             pilot->agility = 10;
             pilot->endurance = 11;
@@ -55,6 +62,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 6;
             break;
         case 6:
+            // IBRAHIM
             pilot->power = 10;
             pilot->agility = 1;
             pilot->endurance = 20;
@@ -63,22 +71,27 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 14;
             break;
         case 7:
+            // CRYSTAL
             pilot->power = 7;
             pilot->agility = 10;
             pilot->endurance = 13;
             pilot->colors[0] = 0;
             pilot->colors[1] = 15;
             pilot->colors[2] = 7;
+            pilot->sex = 1;
             break;
         case 8:
+            // COSSETTE
             pilot->power = 14;
             pilot->agility = 8;
             pilot->endurance = 8;
             pilot->colors[0] = 0;
             pilot->colors[1] = 8;
             pilot->colors[2] = 2;
+            pilot->sex = 1;
             break;
         case 9:
+            // RAVEN
             pilot->power = 14;
             pilot->agility = 4;
             pilot->endurance = 12;
@@ -87,6 +100,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[2] = 4;
             break;
         case 10:
+            // MAJOR KREISSACK
             // totally made up shit here
             pilot->power = 14;
             pilot->agility = 14;

--- a/src/resources/pilots.c
+++ b/src/resources/pilots.c
@@ -1,23 +1,22 @@
 
 #include "resources/pilots.h"
+#include "game/common_defines.h"
 
 void pilot_get_info(pilot *pilot, int id) {
     // TODO read this from MASTER.DAT
     // XXX the colors are eyeballed
-    pilot->sex = 0;
+    pilot->sex = PILOT_SEX_MALE;
     switch(id) {
-        case 0:
-            // CRYSTAL
+        case PILOT_CRYSTAL:
             pilot->power = 5;
             pilot->agility = 16;
             pilot->endurance = 9;
             pilot->colors[0] = 5;
             pilot->colors[1] = 11;
             pilot->colors[2] = 8;
-            pilot->sex = 1;
+            pilot->sex = PILOT_SEX_FEMALE;
             break;
-        case 1:
-            // STEFFAN
+        case PILOT_STEFFAN:
             pilot->power = 13;
             pilot->agility = 9;
             pilot->endurance = 8;
@@ -25,8 +24,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 15;
             pilot->colors[2] = 7;
             break;
-        case 2:
-            // MILANO
+        case PILOT_MILANO:
             pilot->power = 7;
             pilot->agility = 20;
             pilot->endurance = 4;
@@ -34,8 +32,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 12;
             pilot->colors[2] = 7;
             break;
-        case 3:
-            // CHRISTIAN
+        case PILOT_CHRISTIAN:
             pilot->power = 9;
             pilot->agility = 7;
             pilot->endurance = 15;
@@ -43,8 +40,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 15;
             pilot->colors[2] = 6;
             break;
-        case 4:
-            // SHIRRO
+        case PILOT_SHIRRO:
             pilot->power = 20;
             pilot->agility = 1;
             pilot->endurance = 8;
@@ -52,8 +48,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 7;
             pilot->colors[2] = 14;
             break;
-        case 5:
-            // JEAN-PAUL
+        case PILOT_JEANPAUL:
             pilot->power = 9;
             pilot->agility = 10;
             pilot->endurance = 11;
@@ -61,8 +56,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 7;
             pilot->colors[2] = 6;
             break;
-        case 6:
-            // IBRAHIM
+        case PILOT_IBRAHIM:
             pilot->power = 10;
             pilot->agility = 1;
             pilot->endurance = 20;
@@ -70,28 +64,25 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 6;
             pilot->colors[2] = 14;
             break;
-        case 7:
-            // CRYSTAL
+        case PILOT_ANGEL:
             pilot->power = 7;
             pilot->agility = 10;
             pilot->endurance = 13;
             pilot->colors[0] = 0;
             pilot->colors[1] = 15;
             pilot->colors[2] = 7;
-            pilot->sex = 1;
+            pilot->sex = PILOT_SEX_FEMALE;
             break;
-        case 8:
-            // COSSETTE
+        case PILOT_COSSETTE:
             pilot->power = 14;
             pilot->agility = 8;
             pilot->endurance = 8;
             pilot->colors[0] = 0;
             pilot->colors[1] = 8;
             pilot->colors[2] = 2;
-            pilot->sex = 1;
+            pilot->sex = PILOT_SEX_FEMALE;
             break;
-        case 9:
-            // RAVEN
+        case PILOT_RAVEN:
             pilot->power = 14;
             pilot->agility = 4;
             pilot->endurance = 12;
@@ -99,8 +90,7 @@ void pilot_get_info(pilot *pilot, int id) {
             pilot->colors[1] = 10;
             pilot->colors[2] = 4;
             break;
-        case 10:
-            // MAJOR KREISSACK
+        case PILOT_KREISSACK:
             // totally made up shit here
             pilot->power = 14;
             pilot->agility = 14;

--- a/src/resources/pilots.h
+++ b/src/resources/pilots.h
@@ -5,6 +5,7 @@ typedef struct pilot_t {
     int power, agility, endurance;
     char colors[3];
     void *userdata;
+    int sex;
 } pilot;
 
 void pilot_get_info(pilot *pilot, int id);

--- a/tools/chrtool/main.c
+++ b/tools/chrtool/main.c
@@ -38,7 +38,7 @@ void print_enemy_info(sd_chr_file *chr, int i) {
     print_bytes(chr->enemies[i]->unknown_a, sizeof(chr->enemies[i]->unknown_a), 10, 5);
     printf("\n  - PIC ID: %d\n", chr->enemies[i]->photo_id);
     printf("  - Some unknown thingy: \n");
-    print_bytes(chr->enemies[i]->unknown_a, sizeof(chr->enemies[i]->unknown_a), 10, 5);
+    print_bytes(chr->enemies[i]->unknown_b, sizeof(chr->enemies[i]->unknown_b), 10, 5);
     printf("\n");
 }
 

--- a/tools/chrtool/main.c
+++ b/tools/chrtool/main.c
@@ -35,7 +35,10 @@ void print_enemy_info(sd_chr_file *chr, int i) {
     printf("Enemy %d:\n", i);
     print_pilot_info(&chr->enemies[i]->pilot);
     printf("  - Some unknown thingy: \n");
-    print_bytes(chr->enemies[i]->unknown, sizeof(chr->enemies[i]->unknown), 10, 5);
+    print_bytes(chr->enemies[i]->unknown_a, sizeof(chr->enemies[i]->unknown_a), 10, 5);
+    printf("\n  - PIC ID: %d\n", chr->enemies[i]->photo_id);
+    printf("  - Some unknown thingy: \n");
+    print_bytes(chr->enemies[i]->unknown_a, sizeof(chr->enemies[i]->unknown_a), 10, 5);
     printf("\n");
 }
 


### PR DESCRIPTION
When loading the CHR file, load the gender from the PIC file using the 10th byte of the unknown enemy footer.

For the tournament player, consult the PLAYERS.PIC for the gender.