### PR TITLE
PR-on-PR: Remove extraneous u16-to-u16 cast

### DIFF
--- a/src/formats/chr.c
+++ b/src/formats/chr.c
@@ -195,7 +195,7 @@ int sd_chr_load(sd_chr_file *chr, const char *filename) {
         chr->enemies[i]->photo_id = memread_ubyte(mr);
         memread_buf(mr, chr->enemies[i]->unknown_b, 15);
         if(trn_loaded) {
-            chr->enemies[i]->pilot.sex = pic.photos[(uint16_t)chr->enemies[i]->photo_id]->sex;
+            chr->enemies[i]->pilot.sex = pic.photos[chr->enemies[i]->photo_id]->sex;
         }
         for(int m = 0; m < 10; m++) {
             if(trn_loaded && trn.enemies[i]->quotes[m]) {


### PR DESCRIPTION
PR targets PR #823's branch (adt/pilot-genders), not master.

Removes the extraneous uint16-to-uint16 cast.

Using a pull request here to run a clang/gcc build in CI, so I can see the warning (if it is still generated).