### PR TITLE
Simplify netplay and remove bugs

### DIFF
--- a/src/console/console_cmd.c
+++ b/src/console/console_cmd.c
@@ -195,7 +195,7 @@ int console_cmd_stun(game_state *gs, int argc, char **argv) {
 
 int console_cmd_rein(game_state *gs, int argc, char **argv) {
     scene *sc = game_state_get_scene(gs);
-    if(is_arena(sc->id)) {
+    if(scene_is_arena(sc)) {
         arena_toggle_rein(sc);
         return 0;
     }

--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -2598,7 +2598,7 @@ int ai_controller_poll(controller *ctrl, ctrl_event **ev) {
     // Do not run AI while match is starting or ending
     // XXX this prevents the AI from doing scrap/destruction moves
     // XXX this could be fixed by providing a "scene changed" event
-    if(is_arena(game_state_get_scene(o->gs)->id) &&
+    if(scene_is_arena(game_state_get_scene(o->gs)) &&
        arena_get_state(game_state_get_scene(o->gs)) != ARENA_STATE_FIGHTING) {
 
         // null out selected move to fix the "AI not moving problem"

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -15,8 +15,8 @@ enum
     ACT_UP = 0x08,
     ACT_DOWN = 0x10,
     ACT_LEFT = 0x20,
-    ACT_ESC = 0x40,
-    ACT_RIGHT = 0x80,
+    ACT_RIGHT = 0x40,
+    ACT_ESC = 0x80,
 
     ACT_Mask_Dirs = (ACT_UP | ACT_DOWN | ACT_LEFT | ACT_RIGHT),
 };

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -1,5 +1,6 @@
 #include "controller/keyboard.h"
 #include "utils/allocator.h"
+#include "utils/log.h"
 #include <stdlib.h>
 
 void keyboard_free(controller *ctrl) {
@@ -13,6 +14,7 @@ static inline void keyboard_cmd(controller *ctrl, int action, ctrl_event **ev) {
 }
 
 int keyboard_poll(controller *ctrl, ctrl_event **ev) {
+    DEBUG("keyboard poll");
     keyboard *k = ctrl->data;
     ctrl->current = 0;
     const unsigned char *state = SDL_GetKeyboardState(NULL);

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -425,7 +425,8 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
         // controller_cmd(ctrl, action, ev);
     }
 
-    DEBUG("game state is %" PRIu32 ", want %" PRIu32, gs->int_tick - data->local_proposal, data->last_tick - data->local_proposal);
+    DEBUG("game state is %" PRIu32 ", want %" PRIu32, gs->int_tick - data->local_proposal,
+          data->last_tick - data->local_proposal);
     uint32_t ticks = data->last_tick - gs->int_tick;
     // tick the number of required times
     for(int dynamic_wait = (int)ticks; dynamic_wait > 0; dynamic_wait--) {

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -871,10 +871,6 @@ void controller_hook(controller *ctrl, int action) {
         if(action == ACT_STOP && har->state == data->last_har_state) {
             return;
         }
-        // int arena_state = arena_get_state(game_state_get_scene(ctrl->gs));
-        // if(arena_state != ARENA_STATE_FIGHTING) {
-        //     return;
-        // }
         data->last_har_state = har->state;
         data->last_action = action;
     }

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -145,7 +145,7 @@ bool has_event(wtf *data, uint32_t tick) {
     list_iter_begin(&data->transcript, &it);
     tick_events *ev = NULL;
     while((ev = (tick_events *)list_iter_next(&it))) {
-        if(ev->tick == tick - data->local_proposal && ev->events[data->id]) {
+        if(ev->tick == tick - data->local_proposal && ev->events[data->id][0]) {
             return true;
         }
     }
@@ -230,7 +230,7 @@ void send_events(wtf *data) {
     int last_sent = 0;
 
     while((ev = (tick_events *)list_iter_next(&it))) {
-        if(ev->events[data->id] != 0 && ev->tick > data->last_acked_tick &&
+        if(ev->events[data->id][0] != 0 && ev->tick > data->last_acked_tick &&
            ev->tick < data->last_tick - data->local_proposal) {
             serial_write_uint32(&ser, ev->tick);
             int i = 0;
@@ -366,7 +366,7 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
 
         arena_hash = arena_state_hash(gs);
 
-        if(data->trace_file && (ev->events[0] || ev->events[1]) && ev->tick <= last_agreed &&
+        if(data->trace_file && (ev->events[0][0] || ev->events[1][0]) && ev->tick <= last_agreed &&
            ev->tick > data->last_traced_tick) {
             data->last_traced_tick = ev->tick;
             char buf0[12];

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -354,8 +354,6 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
                 game_player *player = game_state_get_player(gs, player_id);
                 int k = 0;
                 while(ev->events[j][k]) {
-                    DEBUG("replaying input %d from player %d at tick %d %d", ev->events[j][k], player_id, ev->tick,
-                          gs->int_tick - data->local_proposal);
                     object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ev->events[j][k]);
                     k++;
                 }
@@ -427,7 +425,7 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
         // controller_cmd(ctrl, action, ev);
     }
 
-    DEBUG("game state is %" PRIu32 ", want %" PRIu32, gs->int_tick, data->last_tick);
+    DEBUG("game state is %" PRIu32 ", want %" PRIu32, gs->int_tick - data->local_proposal, data->last_tick - data->local_proposal);
     uint32_t ticks = data->last_tick - gs->int_tick;
     // tick the number of required times
     for(int dynamic_wait = (int)ticks; dynamic_wait > 0; dynamic_wait--) {

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -539,9 +539,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
     int last_received = 0;
     int has_received = 0;
 
-    int receive_count = 0;
-    while(receive_count < 3 && enet_host_service(host, &event, 0) > 0) {
-        receive_count++;
+    while(enet_host_service(host, &event, 0) > 0) {
         switch(event.type) {
             case ENET_EVENT_TYPE_RECEIVE:
                 serial_create_from(&ser, (const char *)event.packet->data, event.packet->dataLength);
@@ -721,6 +719,11 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                 if(data->gs_bak) {
                     game_state_clone_free(data->gs_bak);
                     omf_free(data->gs_bak);
+                }
+                if(data->lobby) {
+                    game_state_set_next(ctrl->gs, SCENE_LOBBY);
+                } else {
+                    game_state_set_next(ctrl->gs, SCENE_MENU);
                 }
                 controller_close(ctrl, ev);
                 return 1; // bail the fuck out

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -565,7 +565,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
         DEBUG("missed synchronize tick %" PRIu32 " -- @ %" PRIu32, data->local_proposal, ticks);
     }
 
-    if(data->gs_bak == NULL && data->disconnected == 0 && is_arena(game_state_get_scene(ctrl->gs)->id) &&
+    if(data->gs_bak == NULL && data->disconnected == 0 && scene_is_arena(game_state_get_scene(ctrl->gs)) &&
        (ticks - data->local_proposal) % 7 == 0 &&
        game_state_find_object(ctrl->gs, game_player_get_har_obj_id(game_state_get_player(ctrl->gs, 1)))) {
         arena_reset(ctrl->gs->sc);
@@ -578,7 +578,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
         data->local_proposal = ticks; // reset the tick offset to the start of the match
         data->last_hash_tick = data->gs_bak->int_tick - data->local_proposal;
         data->last_hash = arena_state_hash(data->gs_bak);
-    } else if(data->gs_bak != NULL && !is_arena(game_state_get_scene(ctrl->gs)->id)) {
+    } else if(data->gs_bak != NULL && !scene_is_arena(game_state_get_scene(ctrl->gs))) {
         // changed scene and no longer need a game state backup, release it
         game_state_clone_free(data->gs_bak);
         omf_free(data->gs_bak);

--- a/src/engine.c
+++ b/src/engine.c
@@ -295,22 +295,6 @@ void engine_run(engine_init_flags *init_flags) {
                     // gs->new_state = NULL;
                     game_state_clone_free(old_gs);
                     omf_free(old_gs);
-                    frame_dt = SDL_GetTicks64() - frame_start;
-                    frame_start = SDL_GetTicks64();
-                    if(!visual_debugger) {
-                        dynamic_wait += frame_dt;
-                        static_wait += frame_dt;
-                    } else if(debugger_proceed) {
-                        dynamic_wait += 20;
-                        static_wait += 20;
-                        debugger_proceed = 0;
-                    }
-                    // drop ticks if it's been too long since they were due
-                    dynamic_wait = min2(dynamic_wait, TICK_EXPIRY_MS);
-                    static_wait = min2(static_wait, TICK_EXPIRY_MS);
-                    tick_limit = MAX_TICKS_PER_FRAME;
-
-                    continue;
                 }
                 console_tick(gs);
                 static_wait -= STATIC_TICKS;

--- a/src/engine.c
+++ b/src/engine.c
@@ -311,7 +311,6 @@ void engine_run(engine_init_flags *init_flags) {
                     tick_limit = MAX_TICKS_PER_FRAME;
 
                     continue;
-
                 }
                 console_tick(gs);
                 static_wait -= STATIC_TICKS;

--- a/src/engine.c
+++ b/src/engine.c
@@ -285,7 +285,7 @@ void engine_run(engine_init_flags *init_flags) {
             if(has_static) {
                 game_state_static_tick(gs, false);
                 // check if we need to replace the game state
-                while(gs->new_state) {
+                if(gs->new_state) {
                     // one of the controllers wants to replace the game state
                     game_state *old_gs = gs;
                     game_state *new_gs = gs->new_state;
@@ -295,6 +295,23 @@ void engine_run(engine_init_flags *init_flags) {
                     // gs->new_state = NULL;
                     game_state_clone_free(old_gs);
                     omf_free(old_gs);
+                    frame_dt = SDL_GetTicks64() - frame_start;
+                    frame_start = SDL_GetTicks64();
+                    if(!visual_debugger) {
+                        dynamic_wait += frame_dt;
+                        static_wait += frame_dt;
+                    } else if(debugger_proceed) {
+                        dynamic_wait += 20;
+                        static_wait += 20;
+                        debugger_proceed = 0;
+                    }
+                    // drop ticks if it's been too long since they were due
+                    dynamic_wait = min2(dynamic_wait, TICK_EXPIRY_MS);
+                    static_wait = min2(static_wait, TICK_EXPIRY_MS);
+                    tick_limit = MAX_TICKS_PER_FRAME;
+
+                    continue;
+
                 }
                 console_tick(gs);
                 static_wait -= STATIC_TICKS;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -282,12 +282,12 @@ void game_state_get_projectiles(game_state *gs, vector *obj_proj) {
     }
 }
 
-void game_state_clear_hazards_projectiles(game_state *gs) {
+void game_state_clear_objects(game_state *gs, int mask) {
     iterator it;
     render_obj *robj;
     vector_iter_begin(&gs->objects, &it);
     while((robj = iter_next(&it)) != NULL) {
-        if(object_get_group(robj->obj) == GROUP_PROJECTILE) {
+        if(object_get_group(robj->obj) & mask) {
             object_free(robj->obj);
             omf_free(robj->obj);
             vector_delete(&gs->objects, &it);
@@ -591,7 +591,7 @@ void game_state_call_collide(game_state *gs) {
         a = ((render_obj *)vector_get(&gs->objects, i))->obj;
         for(unsigned k = i + 1; k < size; k++) {
             b = ((render_obj *)vector_get(&gs->objects, k))->obj;
-            if(a->group != b->group || a->group == OBJECT_NO_GROUP || b->group == OBJECT_NO_GROUP) {
+            if(a->group != b->group || a->group == GROUP_UNKNOWN || b->group == GROUP_UNKNOWN) {
                 if(a->layers & b->layers) {
                     object_collide(a, b);
                 }

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -58,7 +58,7 @@ int game_state_add_object(game_state *gs, object *obj, int layer, int singleton,
 void game_state_del_object(game_state *gs, object *obj);
 void game_state_del_animation(game_state *gs, int anim_id);
 void game_state_get_projectiles(game_state *gs, vector *obj_proj);
-void game_state_clear_hazards_projectiles(game_state *gs);
+void game_state_clear_objects(game_state *gs, int mask);
 
 bool is_netplay(game_state *gs);
 bool is_singleplayer(game_state *gs);

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -755,6 +755,7 @@ void har_spawn_scrap(object *obj, vec2i pos, int amount) {
         object_set_pal_offset(scrap, object_get_pal_offset(obj));
         object_set_pal_limit(obj, object_get_pal_limit(obj));
         object_set_layers(scrap, LAYER_SCRAP);
+        object_set_group(scrap, GROUP_SCRAP);
         object_dynamic_tick(scrap);
         object_set_shadow(scrap, 1);
         scrap_create(scrap);

--- a/src/game/objects/har.h
+++ b/src/game/objects/har.h
@@ -21,8 +21,6 @@
 #define LAYER_PROJECTILE 0x20
 #define LAYER_HAZARD 0x40
 
-#define GROUP_PROJECTILE 2
-
 enum
 {
     CAT_MISC = 0,

--- a/src/game/objects/hazard.c
+++ b/src/game/objects/hazard.c
@@ -34,7 +34,8 @@ void hazard_tick(object *obj) {
             float mag;
             int limit = 10;
             do {
-                obj->orbit_dest = vec2f_create(random_float(&obj->gs->rand) * 320.0f, random_float(&obj->gs->rand) * 200.0f);
+                obj->orbit_dest =
+                    vec2f_create(random_float(&obj->gs->rand) * 320.0f, random_float(&obj->gs->rand) * 200.0f);
                 obj->orbit_dest_dir = vec2f_sub(obj->orbit_dest, obj->orbit_pos);
                 mag = sqrtf(obj->orbit_dest_dir.x * obj->orbit_dest_dir.x +
                             obj->orbit_dest_dir.y * obj->orbit_dest_dir.y);
@@ -77,9 +78,11 @@ void hazard_spawn_cb(object *parent, int id, vec2i pos, vec2f vel, uint8_t mp_fl
 
 vec2f generate_destination(object *obj) {
     vec2f old = obj->orbit_dest;
-    vec2f new = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
+    vec2f new =
+        vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
     while(vec2f_dist(old, new) < 100) {
-        new = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
+        new = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f,
+                           (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
     }
     return new;
 }
@@ -183,7 +186,8 @@ int hazard_create(object *obj, scene *scene) {
 
     obj->orbit_pos.x = obj->pos.x;
     obj->orbit_pos.y = obj->pos.y;
-    obj->orbit_dest = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
+    obj->orbit_dest =
+        vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
     DEBUG("new position is %f, %f", obj->orbit_dest.x, obj->orbit_dest.y);
 
     return 0;

--- a/src/game/objects/hazard.c
+++ b/src/game/objects/hazard.c
@@ -34,7 +34,7 @@ void hazard_tick(object *obj) {
             float mag;
             int limit = 10;
             do {
-                obj->orbit_dest = vec2f_create(rand_float() * 320.0f, rand_float() * 200.0f);
+                obj->orbit_dest = vec2f_create(random_float(&obj->gs->rand) * 320.0f, random_float(&obj->gs->rand) * 200.0f);
                 obj->orbit_dest_dir = vec2f_sub(obj->orbit_dest, obj->orbit_pos);
                 mag = sqrtf(obj->orbit_dest_dir.x * obj->orbit_dest_dir.x +
                             obj->orbit_dest_dir.y * obj->orbit_dest_dir.y);
@@ -75,10 +75,11 @@ void hazard_spawn_cb(object *parent, int id, vec2i pos, vec2f vel, uint8_t mp_fl
     }
 }
 
-vec2f generate_destination(vec2f old) {
-    vec2f new = vec2f_create((rand_float() * 280.0f) + 20.0f, (rand_float() * 160.0f) + 20.0f);
+vec2f generate_destination(object *obj) {
+    vec2f old = obj->orbit_dest;
+    vec2f new = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
     while(vec2f_dist(old, new) < 100) {
-        new = vec2f_create((rand_float() * 280.0f) + 20.0f, (rand_float() * 160.0f) + 20.0f);
+        new = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
     }
     return new;
 }
@@ -121,7 +122,7 @@ void hazard_move(object *obj) {
            (dist(obj->pos.y, obj->orbit_pos.y) >= dist(obj->orbit_dest.y, obj->orbit_pos.y))) {
             obj->orbit_pos.x = obj->pos.x;
             obj->orbit_pos.y = obj->pos.y;
-            obj->orbit_dest = generate_destination(obj->orbit_dest);
+            obj->orbit_dest = generate_destination(obj);
             DEBUG("new position is %f, %f", obj->orbit_dest.x, obj->orbit_dest.y);
         }
 
@@ -182,7 +183,7 @@ int hazard_create(object *obj, scene *scene) {
 
     obj->orbit_pos.x = obj->pos.x;
     obj->orbit_pos.y = obj->pos.y;
-    obj->orbit_dest = vec2f_create((rand_float() * 280.0f) + 20.0f, (rand_float() * 160.0f) + 20.0f);
+    obj->orbit_dest = vec2f_create((random_float(&obj->gs->rand) * 280.0f) + 20.0f, (random_float(&obj->gs->rand) * 160.0f) + 20.0f);
     DEBUG("new position is %f, %f", obj->orbit_dest.x, obj->orbit_dest.y);
 
     return 0;

--- a/src/game/objects/hazard.c
+++ b/src/game/objects/hazard.c
@@ -12,12 +12,12 @@ int orb_almost_there(vec2f a, vec2f b) {
 }
 
 void hazard_tick(object *obj) {
-    bk *bk_data = (bk *)object_get_userdata(obj);
+    scene *sc = obj->gs->sc;
 
     if(obj->animation_state.finished) {
-        bk_info *anim = bk_get_info(bk_data, obj->cur_animation->id);
+        bk_info *anim = bk_get_info(sc->bk_data, obj->cur_animation->id);
         if(anim->chain_no_hit) {
-            object_set_animation(obj, &bk_get_info(bk_data, anim->chain_no_hit)->ani);
+            object_set_animation(obj, &bk_get_info(sc->bk_data, anim->chain_no_hit)->ani);
             object_set_repeat(obj, 0);
             obj->animation_state.finished = 0;
         }
@@ -49,7 +49,7 @@ void hazard_tick(object *obj) {
 }
 
 void hazard_spawn_cb(object *parent, int id, vec2i pos, vec2f vel, uint8_t mp_flags, int s, int g, void *userdata) {
-    scene *sc = (scene *)userdata;
+    scene *sc = parent->gs->sc;
 
     // Get next animation
     bk_info *info = bk_get_info(sc->bk_data, id);
@@ -179,8 +179,8 @@ void hazard_move(object *obj) {
 
 int hazard_create(object *obj, scene *scene) {
 
-    object_set_spawn_cb(obj, hazard_spawn_cb, (void *)scene);
-    object_set_destroy_cb(obj, cb_scene_destroy_object, (void *)scene);
+    object_set_spawn_cb(obj, hazard_spawn_cb, NULL);
+    object_set_destroy_cb(obj, cb_scene_destroy_object, NULL);
     object_set_move_cb(obj, hazard_move);
     object_set_dynamic_tick_cb(obj, hazard_tick);
 

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -39,7 +39,7 @@ void object_create(object *obj, game_state *gs, vec2i pos, vec2f vel) {
 
     // Physics
     obj->layers = OBJECT_DEFAULT_LAYER;
-    obj->group = OBJECT_NO_GROUP;
+    obj->group = GROUP_UNKNOWN;
     obj->gravity = 0.0f;
 
     // Video effect stuff

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -12,7 +12,6 @@
 #include "video/vga_state.h"
 
 #define OBJECT_DEFAULT_LAYER 0x01
-#define OBJECT_NO_GROUP -1
 
 #define OBJECT_EVENT_BUFFER_SIZE 16
 
@@ -32,6 +31,16 @@ enum
 {
     PLAY_BACKWARDS,
     PLAY_FORWARDS
+};
+
+enum
+{
+    GROUP_UNKNOWN = 0x1,
+    GROUP_HAR = 0x2,
+    GROUP_SCRAP = 0x4,
+    GROUP_PROJECTILE = 0x8,
+    GROUP_HAZARD = 0x10,
+    GROUP_ANNOUNCEMENT = 0x20,
 };
 
 enum

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -384,7 +384,7 @@ void player_run(object *obj) {
             if(sd_script_isset(frame, "mrx")) {
                 int mrx = sd_script_get(frame, "mrx");
                 int mm = sd_script_isset(frame, "mm") ? sd_script_get(frame, "mm") : mrx;
-                mx = random_int(&obj->rand_state, 320 - 2 * mm) + mrx;
+                mx = random_int(&obj->gs->rand, 320 - 2 * mm) + mrx;
                 DEBUG("randomized mx as %d", mx);
             } else if(sd_script_isset(frame, "mx")) {
                 mx = obj->start.x + (sd_script_get(frame, "mx") * object_get_direction(obj));
@@ -394,7 +394,7 @@ void player_run(object *obj) {
             if(sd_script_isset(frame, "mry")) {
                 int mry = sd_script_get(frame, "mry");
                 int mm = sd_script_isset(frame, "mm") ? sd_script_get(frame, "mm") : mry;
-                my = random_int(&obj->rand_state, 320 - 2 * mm) + mry;
+                my = random_int(&obj->gs->rand, 320 - 2 * mm) + mry;
                 DEBUG("randomized my as %d", my);
             } else if(sd_script_isset(frame, "my")) {
                 my = obj->start.y + sd_script_get(frame, "my");

--- a/src/game/protos/scene.c
+++ b/src/game/protos/scene.c
@@ -117,6 +117,7 @@ void scene_init(scene *scene) {
 
 int scene_clone(scene *src, scene *dst, game_state *gs) {
     memcpy(dst, src, sizeof(scene));
+    ticktimer_clone(&src->tick_timer, &dst->tick_timer);
     dst->gs = gs;
     if(src->clone) {
         src->clone(src, dst);
@@ -128,6 +129,7 @@ int scene_clone_free(scene *sc) {
     if(sc->clone_free) {
         sc->clone_free(sc);
     }
+    ticktimer_close(&sc->tick_timer);
     omf_free(sc);
     return 0;
 }

--- a/src/game/protos/scene.c
+++ b/src/game/protos/scene.c
@@ -261,6 +261,10 @@ void scene_set_anim_prio_override_cb(scene *scene, scene_anim_prio_override_cb c
     scene->prio_override = cbfunc;
 }
 
+bool scene_is_arena(scene *scene) {
+    return (scene->id >= SCENE_ARENA0 && scene->id <= SCENE_ARENA4);
+}
+
 void scene_set_input_poll_cb(scene *scene, scene_input_poll_cb cbfunc) {
     scene->input_poll = cbfunc;
 }

--- a/src/game/protos/scene.h
+++ b/src/game/protos/scene.h
@@ -61,6 +61,7 @@ void scene_static_tick(scene *scene, int paused);
 void scene_input_poll(scene *scene);
 void scene_startup(scene *scene, int id, int *m_load, int *m_startup);
 int scene_anim_prio_override(scene *scene, int anim_id);
+bool scene_is_arena(scene *scene);
 
 int scene_clone(scene *src, scene *dst, game_state *gs);
 int scene_clone_free(scene *sc);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -717,14 +717,16 @@ uint32_t arena_state_hash(game_state *gs) {
     return hash;
 }
 
-void arena_state_dump(game_state *gs) {
+void arena_state_dump(game_state *gs, char *buf) {
+    int off = 0;
     for(int i = 0; i < 2; i++) {
         object *obj_har = game_state_find_object(gs, game_player_get_har_obj_id(game_state_get_player(gs, i)));
         har *har = obj_har->userdata;
         vec2i pos = object_get_pos(obj_har);
         vec2f vel = object_get_vel(obj_har);
-        DEBUG("har %d pos %d,%d, health %d, endurance %f, velocity %f,%f, state %d, executing_move %d", i, pos.x, pos.y,
-              har->health, (float)har->endurance, vel.x, vel.y, har->state, har->executing_move);
+        off = snprintf(buf + off, 255 - off,
+                       "har %d pos %d,%d, health %d, endurance %f, velocity %f,%f, state %d, executing_move %d\n", i,
+                       pos.x, pos.y, har->health, (float)har->endurance, vel.x, vel.y, har->state, har->executing_move);
     }
 }
 
@@ -893,8 +895,6 @@ void arena_spawn_hazard(scene *scene) {
 void arena_dynamic_tick(scene *scene, int paused) {
     arena_local *local = scene_get_userdata(scene);
     game_state *gs = scene->gs;
-    game_player *player1 = game_state_get_player(gs, 0);
-    game_player *player2 = game_state_get_player(gs, 1);
 
     if(!paused) {
         object *obj_har[2];
@@ -987,10 +987,6 @@ void arena_dynamic_tick(scene *scene, int paused) {
             }
         }
     } // if(!paused)
-
-    // allow enemy HARs to move during a network game
-    arena_handle_events(scene, player1, player1->ctrl->extra_events);
-    arena_handle_events(scene, player2, player2->ctrl->extra_events);
 }
 
 void arena_static_tick(scene *scene, int paused) {

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -739,7 +739,7 @@ uint32_t arena_state_hash(game_state *gs) {
     return hash;
 }
 
-char* state_name(int state) {
+char *state_name(int state) {
     switch(state) {
         case STATE_STANDING:
             return "standing";
@@ -771,7 +771,7 @@ char* state_name(int state) {
             return "destruction";
         case STATE_WALLDAMAGE: // Took damage from wall (electrocution)
             return "wall_damage";
-        case STATE_DONE:        // destruction or scrap has completed
+        case STATE_DONE: // destruction or scrap has completed
             return "done";
         default:
             return "unknown!!!";
@@ -787,7 +787,8 @@ void arena_state_dump(game_state *gs, char *buf) {
         vec2f vel = object_get_vel(obj_har);
         off = snprintf(buf + off, 255 - off,
                        "har %d pos %d,%d, health %d, endurance %f, velocity %f,%f, state %s, executing_move %d\n", i,
-                       pos.x, pos.y, har->health, (float)har->endurance, vel.x, vel.y, state_name(har->state), har->executing_move);
+                       pos.x, pos.y, har->health, (float)har->endurance, vel.x, vel.y, state_name(har->state),
+                       har->executing_move);
     }
 }
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -301,6 +301,10 @@ void arena_reset(scene *sc) {
         chr_score_clear_done(&player->score);
     }
 
+    // wipe any tick timers
+    ticktimer_close(&sc->tick_timer);
+    ticktimer_init(&sc->tick_timer);
+
     sc->bk_data->sound_translation_table[3] = 23 + local->round; // NUMBER
     // ROUND animation
     animation *round_ani = &bk_get_info(sc->bk_data, 6)->ani;
@@ -717,6 +721,45 @@ uint32_t arena_state_hash(game_state *gs) {
     return hash;
 }
 
+char* state_name(int state) {
+    switch(state) {
+        case STATE_STANDING:
+            return "standing";
+        case STATE_WALKTO:
+            return "walk_to";
+        case STATE_WALKFROM:
+            return "walk_from";
+        case STATE_CROUCHING:
+            return "crouching";
+        case STATE_CROUCHBLOCK:
+            return "crouchblock";
+        case STATE_JUMPING:
+            return "jumping";
+        case STATE_RECOIL:
+            return "recoil";
+        case STATE_FALLEN:
+            return "fallen";
+        case STATE_STANDING_UP:
+            return "standing_up";
+        case STATE_STUNNED:
+            return "stunned";
+        case STATE_VICTORY:
+            return "victory";
+        case STATE_DEFEAT:
+            return "defeat";
+        case STATE_SCRAP:
+            return "scrap";
+        case STATE_DESTRUCTION:
+            return "destruction";
+        case STATE_WALLDAMAGE: // Took damage from wall (electrocution)
+            return "wall_damage";
+        case STATE_DONE:        // destruction or scrap has completed
+            return "done";
+        default:
+            return "unknown!!!";
+    }
+}
+
 void arena_state_dump(game_state *gs, char *buf) {
     int off = 0;
     for(int i = 0; i < 2; i++) {
@@ -725,8 +768,8 @@ void arena_state_dump(game_state *gs, char *buf) {
         vec2i pos = object_get_pos(obj_har);
         vec2f vel = object_get_vel(obj_har);
         off = snprintf(buf + off, 255 - off,
-                       "har %d pos %d,%d, health %d, endurance %f, velocity %f,%f, state %d, executing_move %d\n", i,
-                       pos.x, pos.y, har->health, (float)har->endurance, vel.x, vel.y, har->state, har->executing_move);
+                       "har %d pos %d,%d, health %d, endurance %f, velocity %f,%f, state %s, executing_move %d\n", i,
+                       pos.x, pos.y, har->health, (float)har->endurance, vel.x, vel.y, state_name(har->state), har->executing_move);
     }
 }
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1287,6 +1287,11 @@ int arena_create(scene *scene) {
             local->rounds = 1;
             break;
     }
+
+    if(is_netplay(scene->gs)) {
+        // XXX hardcode netplay rounds to 3 for now
+        local->rounds = 3;
+    }
     local->tournament = false;
     local->over = 0;
 

--- a/src/game/scenes/arena.h
+++ b/src/game/scenes/arena.h
@@ -17,7 +17,7 @@ vga_palette *arena_get_player_palette(scene *scene, int player);
 void arena_toggle_rein(scene *scene);
 void maybe_install_har_hooks(scene *scene);
 uint32_t arena_state_hash(game_state *gs);
-void arena_state_dump(game_state *gs);
+void arena_state_dump(game_state *gs, char *buf);
 void arena_reset(scene *sc);
 
 #endif // ARENA_H

--- a/src/game/scenes/mainmenu.c
+++ b/src/game/scenes/mainmenu.c
@@ -134,11 +134,6 @@ int mainmenu_create(scene *scene) {
         component_action(guiframe_find(local->frame, NETWORK_BUTTON_ID), ACT_PUNCH);
         component_action(guiframe_find(local->frame, NETWORK_LOBBY_BUTTON_ID), ACT_PUNCH);
     }
-#ifndef DEBUGMODE
-    if(scene->gs->net_mode == NET_MODE_NONE) {
-        component_disable(guiframe_find(local->frame, NETWORK_BUTTON_ID), 1);
-    }
-#endif
 
     // clear it, so this only happens the first time
     scene->gs->net_mode = NET_MODE_NONE;

--- a/src/game/utils/ticktimer.c
+++ b/src/game/utils/ticktimer.c
@@ -37,3 +37,13 @@ void ticktimer_run(ticktimer *tt, void *scenedata) {
         }
     }
 }
+
+void ticktimer_clone(ticktimer *src, ticktimer *dst) {
+    ticktimer_init(dst);
+    iterator it;
+    vector_iter_begin(&src->units, &it);
+    ticktimer_unit *unit;
+    while((unit = iter_next(&it)) != NULL) {
+        vector_append(&dst->units, unit);
+    }
+}

--- a/src/game/utils/ticktimer.h
+++ b/src/game/utils/ticktimer.h
@@ -14,4 +14,6 @@ void ticktimer_add(ticktimer *tt, int ticks, ticktimer_cb cb, void *userdata);
 void ticktimer_run(ticktimer *tt, void *scenedata);
 void ticktimer_close(ticktimer *tt);
 
+void ticktimer_clone(ticktimer *src, ticktimer *dst);
+
 #endif // TICKTIMER_H


### PR DESCRIPTION
Fixed an unsafe clone of the scene ticktimer, removed some more obsolete code, removed overcomplicated 'seen_peer' event tracking and made sure when we save the game state we've applied any inputs for that frame.