### PR TITLE
Experiment with auto versioning

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -6,13 +6,19 @@ runs:
       shell: bash
       run: |
         VERSION=$(git describe --tags --match "[0-9].[0-9].[0-9]" --match "[0-9].[0-9].[0-9][0-9]" --match "[0-9].[0-9].[0-9][0-9]-*" --match "[0-9].[0-9].[0-9]-*")
+        VERSION_NO_ABBREV=$(git describe --tags --match "[0-9].[0-9].[0-9]" --match "[0-9].[0-9].[0-9][0-9]" --match "[0-9].[0-9].[0-9][0-9]-*" --match "[0-9].[0-9].[0-9]-*" --no-abbrev)
         if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$ ]]; then
           MAJOR="${BASH_REMATCH[1]}"
           MINOR="${BASH_REMATCH[2]}"
           PATCH="${BASH_REMATCH[3]}"
           LABEL="${BASH_REMATCH[4]}"
+          LABEL_NO_ABBREV="$LABEL"
 
-          if [ ! -z "$LABEL" ]; then
+          if [[ $VERSION_NO_ABBREV =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+            LABEL_NO_ABBREV="${BASH_REMATCH[1]}"
+          fi
+
+          if [[ ! -z "$LABEL" && -z "$LABEL_NO_ABBREV" ]]; then
             PATCH=$((PATCH + 1))
           fi
 

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -1,0 +1,20 @@
+name: OpenOMF Version
+runs:
+  using: "composite"
+  steps:
+    - name: Set OPENOMF_VERSION
+      shell: bash
+      run: |
+        VERSION=$(git describe --tags --match "[0-9].[0-9].[0-9]" --match "[0-9].[0-9].[0-9][0-9]" --match "[0-9].[0-9].[0-9][0-9]-*" --match "[0-9].[0-9].[0-9]-*")
+        if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$ ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          LABEL="${BASH_REMATCH[4]}"
+
+          if [ ! -z "$LABEL" ]; then
+            PATCH=$((PATCH + 1))
+          fi
+
+          echo "OPENOMF_VERSION=$MAJOR.$MINOR.$PATCH$LABEL"
+        fi >> $GITHUB_ENV

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -10,7 +10,6 @@ on:
     types: [run_build]
 
 env:
-  OPENOMF_VERSION: '0.8.0'
   OPENOMF_ASSETS_URL: 'https://www.omf2097.com/pub/files/omf/omf2097-assets.zip'
 
 jobs:
@@ -25,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
 
     - name: Install dependencies
       uses: Eeems-Org/apt-cache-action@v1.3
@@ -107,7 +108,15 @@ jobs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+
+    - name: Set OPENOMF_VERSION
+      # git describe uses glob to match the tag, so no repeated character classes.
+      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
+
     - name: Check out VCPKG
       # must be checked out *after* openomf.git
       uses: actions/checkout@v4
@@ -155,21 +164,16 @@ jobs:
     - name: Install openomf
       run: cmake --install build-msvc --config Release --prefix install
 
-    - name: Get short SHA
-      shell: bash
-      id: slug
-      run: echo "sha8=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_OUTPUT
-
     - name: Generate ZIP package
       run: |
         cd install
-        Compress-Archive -Path openomf -DestinationPath openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_windows_msvc_${{ matrix.config.arch }}.zip -PassThru
+        Compress-Archive -Path openomf -DestinationPath openomf_${{ env.OPENOMF_VERSION }}_windows_msvc_${{ matrix.config.arch }}.zip -PassThru
 
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v4
       with:
-        name: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_windows_msvc_${{ matrix.config.arch }}
-        path: install/openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_windows_msvc_${{ matrix.config.arch }}.zip
+        name: openomf_${{ env.OPENOMF_VERSION }}_windows_msvc_${{ matrix.config.arch }}
+        path: install/openomf_${{ env.OPENOMF_VERSION }}_windows_msvc_${{ matrix.config.arch }}.zip
         if-no-files-found: error
 
   # Build ubuntu package, release artifact
@@ -182,6 +186,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+
+    - name: Set OPENOMF_VERSION
+      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
 
     - name: Install Ubuntu Dependencies
       uses: Eeems-Org/apt-cache-action@v1.3
@@ -196,10 +205,6 @@ jobs:
         cmake -DUSE_NATPMP=ON -DUSE_MINIUPNPC=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=release/usr ..
         make -j $(getconf _NPROCESSORS_ONLN)
         make -j $(getconf _NPROCESSORS_ONLN) install
-
-    - name: Get short SHA
-      id: slug
-      run: echo "sha8=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_OUTPUT
 
     - name: Restore omf2097-assets.zip
       id: cache-assets
@@ -223,13 +228,13 @@ jobs:
       run: unzip -j omf2097-assets.zip -d build-release/release/usr/share/games/openomf
 
     - name: Generate TGZ package
-      run: tar cvfz ${GITHUB_WORKSPACE}/openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_linux_amd64.tar.gz -C build-release/release/ .
+      run: tar cvfz ${GITHUB_WORKSPACE}/openomf_${{ env.OPENOMF_VERSION }}_linux_amd64.tar.gz -C build-release/release/ .
 
     - name: Upload TGZ artifact
       uses: actions/upload-artifact@v4
       with:
-        name: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_linux_amd64
-        path: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_linux_amd64.tar.gz
+        name: openomf_${{ env.OPENOMF_VERSION }}_linux_amd64
+        path: openomf_${{ env.OPENOMF_VERSION }}_linux_amd64.tar.gz
         if-no-files-found: error
 
     - name: Generate DEB package
@@ -238,19 +243,19 @@ jobs:
         package: openomf
         package_root: build-release/release
         maintainer: ${{ github.repository_owner }}
-        version: ${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}
+        version: ${{ env.OPENOMF_VERSION }}
         arch: 'amd64'
         depends: 'libargtable2-0, libsdl2-mixer-2.0-0, libconfuse2, libenet7, libsdl2-2.0-0, libxmp4, libpng16-16, libepoxy0, libminiupnpc17, libnatpmp1'
         desc: 'One Must Fall 2097 Remake'
 
     - name: Install the DEB package
-      run: sudo apt install ./openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_amd64.deb
+      run: sudo apt install ./openomf_${{ env.OPENOMF_VERSION }}_amd64.deb
 
     - name: Upload DEB artifact
       uses: actions/upload-artifact@v4
       with:
-        name: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_deb_amd64
-        path: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_amd64.deb
+        name: openomf_${{ env.OPENOMF_VERSION }}_deb_amd64
+        path: openomf_${{ env.OPENOMF_VERSION }}_amd64.deb
         if-no-files-found: error
 
   # Build macos package, release artifact
@@ -263,6 +268,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+
+    - name: Set OPENOMF_VERSION
+      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
 
     - name: Install Mac Dependencies
       run: |
@@ -297,20 +307,16 @@ jobs:
     - name: Extract omf 2097 assets
       run: unzip -j omf2097-assets.zip -d build-release/release/usr/share/games/openomf
 
-    - name: Get short SHA
-      id: slug
-      run: echo "sha8=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_OUTPUT
-
     - name: Generate ZIP package
       run: |
         cd build-release/release
-        zip -r ${GITHUB_WORKSPACE}/openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_macos14_arm.zip .
+        zip -r ${GITHUB_WORKSPACE}/openomf_${{ env.OPENOMF_VERSION }}_macos14_arm.zip .
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_macos14_arm
-        path: openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_macos14_arm.zip
+        name: openomf_${{ env.OPENOMF_VERSION }}_macos14_arm
+        path: openomf_${{ env.OPENOMF_VERSION }}_macos14_arm.zip
         if-no-files-found: error
 
   # Build MinGW, just so we know it still compiles
@@ -323,6 +329,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
 
     - name: Install apt Dependencies
       uses: Eeems-Org/apt-cache-action@v1.3
@@ -363,14 +371,13 @@ jobs:
       with:
         fetch-depth: '0'
 
+    - name: Set OPENOMF_VERSION
+      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
+
     - uses: actions/download-artifact@v4
       with:
         path: artifacts/
 
-    - name: Get short SHA
-      id: slug
-      run: echo "sha8=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_OUTPUT
-    
     - name: Advance tag
       uses: actions/github-script@v7
       with:
@@ -416,7 +423,7 @@ jobs:
         combine_windows artifacts/openomf_*_windows_msvc_x64/*.zip openomf.exe
 
         cd windows_all/
-        zip -r ${GITHUB_WORKSPACE}/upload/openomf_${{ env.OPENOMF_VERSION }}-${{ steps.slug.outputs.sha8 }}_windows.zip *
+        zip -r ${GITHUB_WORKSPACE}/upload/openomf_${{ env.OPENOMF_VERSION }}_windows.zip *
         cd ..
 
         shopt -s globstar

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -113,9 +113,8 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - name: Set OPENOMF_VERSION
-      # git describe uses glob to match the tag, so no repeated character classes.
-      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
+    - name: Get OpenOMF Version
+      uses: ./.github/actions/version
 
     - name: Check out VCPKG
       # must be checked out *after* openomf.git
@@ -189,8 +188,8 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - name: Set OPENOMF_VERSION
-      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
+    - name: Get OpenOMF Version
+      uses: ./.github/actions/version
 
     - name: Install Ubuntu Dependencies
       uses: Eeems-Org/apt-cache-action@v1.3
@@ -271,8 +270,8 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - name: Set OPENOMF_VERSION
-      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
+    - name: Get OpenOMF Version
+      uses: ./.github/actions/version
 
     - name: Install Mac Dependencies
       run: |
@@ -371,8 +370,8 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - name: Set OPENOMF_VERSION
-      run: echo "OPENOMF_VERSION=$(git describe --tags --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_ENV"
+    - name: Get OpenOMF Version
+      uses: ./.github/actions/version
 
     - uses: actions/download-artifact@v4
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(VERSION_MAJOR "0")
-set(VERSION_MINOR "6")
-set(VERSION_PATCH "6")
-set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
-
 # Options
 OPTION(USE_TESTS "Build unittests" OFF)
 OPTION(USE_TOOLS "Build tools" OFF)
@@ -92,7 +87,6 @@ else()
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -DNDEBUG")
     set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Os -DNDEBUG")
 endif()
-add_definitions(-DV_MAJOR=${VERSION_MAJOR} -DV_MINOR=${VERSION_MINOR} -DV_PATCH=${VERSION_PATCH})
 
 # Enable AddressSanitizer if requested
 if(USE_SANITIZERS)
@@ -132,6 +126,24 @@ if(GIT_FOUND)
     )
     message(STATUS "Git SHA1 Hash: ${SHA1_HASH}")
     set_source_files_properties(src/main.c PROPERTIES COMPILE_DEFINITIONS SHA1_HASH="${SHA1_HASH}")
+
+    # git describe uses glob to match the tag, so no repeated character classes.
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} "describe" "--tags" "--match" "[0-9]*.[0-9]*.[0-9]*"
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-.*)?" GIT_VERSION ${GIT_VERSION})
+    set(VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(VERSION_MINOR ${CMAKE_MATCH_2})
+    set(VERSION_PATCH ${CMAKE_MATCH_3})
+    set(VERSION_LABEL ${CMAKE_MATCH_4})
+    add_definitions(-DV_MAJOR=${VERSION_MAJOR} -DV_MINOR=${VERSION_MINOR}
+                    -DV_PATCH=${VERSION_PATCH} -DV_LABEL=${VERSION_LABEL})
+
+    set(VERSION ${GIT_VERSION})
+    message(STATUS "Version: ${VERSION}")
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if(GIT_FOUND)
 
     # git describe uses glob to match the tag, so no repeated character classes.
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} "describe" "--tags" "--match" "[0-9]*.[0-9]*.[0-9]*"
+        COMMAND ${GIT_EXECUTABLE} "describe" "--tags" "--match" "[0-9].[0-9].[0-9]" "--match" "[0-9].[0-9].[0-9][0-9]" "--match" "[0-9].[0-9].[0-9]-*" "--match" "[0-9].[0-9].[0-9][0-9]-*"
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         OUTPUT_VARIABLE GIT_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -139,10 +139,13 @@ if(GIT_FOUND)
     set(VERSION_MINOR ${CMAKE_MATCH_2})
     set(VERSION_PATCH ${CMAKE_MATCH_3})
     set(VERSION_LABEL ${CMAKE_MATCH_4})
+    if(NOT "${VERSION_LABEL}" STREQUAL "")
+        math(EXPR VERSION_PATCH "${VERSION_PATCH} + 1")
+    endif()
     add_definitions(-DV_MAJOR=${VERSION_MAJOR} -DV_MINOR=${VERSION_MINOR}
                     -DV_PATCH=${VERSION_PATCH} -DV_LABEL=${VERSION_LABEL})
 
-    set(VERSION ${GIT_VERSION})
+    set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_LABEL})
     message(STATUS "Version: ${VERSION}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,12 +134,22 @@ if(GIT_FOUND)
         OUTPUT_VARIABLE GIT_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} "describe" "--tags" "--match" "[0-9].[0-9].[0-9]" "--match" "[0-9].[0-9].[0-9][0-9]" "--match" "[0-9].[0-9].[0-9]-*" "--match" "[0-9].[0-9].[0-9][0-9]-*" "--no-abbrev"
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_VERSION_NO_ABBREV
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
     string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-.*)?" GIT_VERSION ${GIT_VERSION})
     set(VERSION_MAJOR ${CMAKE_MATCH_1})
     set(VERSION_MINOR ${CMAKE_MATCH_2})
     set(VERSION_PATCH ${CMAKE_MATCH_3})
     set(VERSION_LABEL ${CMAKE_MATCH_4})
-    if(NOT "${VERSION_LABEL}" STREQUAL "")
+
+    string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+(-.*)?" GIT_VERSION_NO_ABBREV ${GIT_VERSION_NO_ABBREV})
+    set(VERSION_NO_ABBREV_LABEL ${CMAKE_MATCH_1})
+    if(NOT "${VERSION_LABEL}" STREQUAL "" AND "${VERSION_NO_ABBREV_LABEL}" STREQUAL "")
         math(EXPR VERSION_PATCH "${VERSION_PATCH} + 1")
     endif()
     add_definitions(-DV_MAJOR=${VERSION_MAJOR} -DV_MINOR=${VERSION_MINOR}


### PR DESCRIPTION
    If git describe version has a label, increment patch version

    The goal here is to keep versions built from branches past the last
    release tag to always have a newer version relative to the last tag.
    This is done by incrementing the patch component of the version if
    there's a 'label' on the version git describe returns.
