### PR TITLE
Use Mix_PlayChannelTimed instead of Mix_PlayChannel

### DIFF
--- a/src/audio/backends/sdl/sdl_backend.c
+++ b/src/audio/backends/sdl/sdl_backend.c
@@ -240,7 +240,7 @@ static void play_sound(void *userdata, const char *src_buf, size_t src_len, floa
         return;
     }
     Mix_SetPanning(channel, clamp(pan_left * 255, 0, 255), clamp(pan_right * 255, 0, 255));
-    if(Mix_PlayChannel(channel, &ctx->channel_chunks[channel], 0) == -1) {
+    if(Mix_PlayChannelTimed(channel, &ctx->channel_chunks[channel], 0, -1) == -1) {
         PERROR("Unable to play sound: %s", Mix_GetError());
     }
 }


### PR DESCRIPTION
This is to avoid a linking issue in the packages if the SDL2 Mixer package is older than 2.6.0.

See https://wiki.libsdl.org/SDL2_mixer/Mix_PlayChannel for more details. The bug was reported on Ubuntu 22.04 LTS which has SDL2 Mixer 2.0.4.