### PR TITLE
Rewrite expanded colors to use the pilot's palette

### DIFF
--- a/src/formats/palette.h
+++ b/src/formats/palette.h
@@ -73,7 +73,7 @@ void palette_remaps_save(sd_writer *writer, const vga_remap_tables *remaps);
 void palette_load_player_colors(vga_palette *src, int player);
 void palette_load_altpal_player_color(vga_palette *dst, int player, int src_color, int dst_color);
 void palette_set_player_color(int player, int src_color, int dst_color);
-void palette_set_player_expanded_color(int src_row, int dst_row);
+void palette_set_player_expanded_color(vga_palette *pal);
 void palette_copy(vga_palette *dst, const vga_palette *src, int index_start, int index_count);
 
 #endif // PALETTE_H

--- a/src/game/scenes/cutscene.c
+++ b/src/game/scenes/cutscene.c
@@ -182,10 +182,7 @@ int cutscene_create(scene *scene) {
         case SCENE_WAR:
             // Load colors for the HAR -- note that cutscenes use an expanded HAR color slides.
             // World championship does not use these.
-            palette_set_player_expanded_color(p1->chr->pilot.color_3, PRIMARY);
-            palette_set_player_expanded_color(p1->chr->pilot.color_2, SECONDARY);
-            palette_set_player_expanded_color(p1->chr->pilot.color_1, TERTIARY);
-
+            palette_set_player_expanded_color(&p1->chr->pilot.palette);
             // Fall through!
         case SCENE_WORLD:
             audio_play_music(PSM_END);


### PR DESCRIPTION
Don't use the altpals indices, as those are not used in tournament mode, instead use the palette stored in the CHR file.