### PR TITLE
Improvements to joining the network lobby

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -718,7 +718,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 data->guesses++;
                             } else {
                                 if(!data->synchronized) {
-                                    log_debug("peer @ %d guessed our ticks INcorrectly! %d %d %d, actually  %d",
+                                    log_debug("peer %d @ %d guessed our ticks INcorrectly! %d %d %d, actually  %d", id,
                                               peerticks, start, peerguess, peerguess - start, ticks - start);
                                 }
                                 data->guesses--;

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -798,7 +798,7 @@ void lobby_tick(scene *scene, int paused) {
         }
     }
 
-    if(local->nat_tries < 10 && local->nat->type != NAT_TYPE_NONE) {
+    if(local->client && local->nat_tries < 10 && local->nat->type != NAT_TYPE_NONE) {
         uint16_t ext_port;
         if(settings_get()->net.net_ext_port_start == 0) {
             ext_port = rand_int(65535 - 1024) + 1024;

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -103,20 +103,18 @@ typedef struct lobby_user_t {
 } lobby_user;
 
 typedef struct lobby_local_t {
-    char name[16];
-    char helptext[80];
+    ENetHost *client;
+    ENetPeer *peer;
+    ENetPeer *opponent_peer;
     uint32_t id;
     list log;
     list users;
     bool named;
     uint8_t mode;
-    ENetHost *client;
-    ENetPeer *peer;
-    ENetPeer *opponent_peer;
     uint8_t connection_count;
     uint8_t active_user;
-    lobby_user *opponent;
     bool controllers_created;
+    lobby_user *opponent;
 
     dialog *dialog;
 
@@ -124,9 +122,11 @@ typedef struct lobby_local_t {
 
     guiframe *frame;
     uint8_t role;
-    nat_ctx *nat;
     uint8_t nat_tries;
     bool disconnected;
+    nat_ctx *nat;
+    char name[16];
+    char helptext[80];
 } lobby_local;
 
 typedef struct log_event_t {
@@ -854,6 +854,7 @@ void lobby_tick(scene *scene, int paused) {
             // TODO dialog and exit
             log_debug("No available peers for initiating an ENet connection.\n");
             local->disconnected = true;
+            return;
         }
     }
 

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -107,7 +107,7 @@ bool nat_create_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
 void nat_try_upnp(nat_ctx *ctx) {
 #ifdef MINIUPNPC_FOUND
     int error = 0;
-    ctx->upnp_dev = upnpDiscover(2000,    // time to wait (milliseconds)
+    ctx->upnp_dev = upnpDiscover(500,    // time to wait (milliseconds)
                                  NULL,    // multicast interface (or null defaults to 239.255.255.250)
                                  NULL,    // path to minissdpd socket (or null defaults to /var/run/minissdpd.sock)
                                  0,       // source port to use (or zero defaults to port 1900)

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -76,11 +76,13 @@ bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) 
         ctx->int_port = response.pnu.newportmapping.privateport;
         ctx->ext_port = response.pnu.newportmapping.mappedpublicport;
         return true;
+    } else if(r == NATPMP_ERR_NOGATEWAYSUPPORT) {
+        closenatpmp(&ctx->natpmp);
+        ctx->type = NAT_TYPE_NONE;
+        return false;
     } else {
         log_debug("NAT-PMP %d -> %d failed with error %d", int_port, ext_port, r);
         // TODO handle some errors here
-
-        closenatpmp(&ctx->natpmp);
         return false;
     }
 #else
@@ -112,23 +114,25 @@ void nat_try_upnp(nat_ctx *ctx) {
                                  0,       // 0==IPv4, 1==IPv6
                                  2,       // TTL
                                  &error); // error condition
-    // TODO check error here?
-    // try to look up our lan address, to test it
-    #if(MINIUPNPC_API_VERSION >= 18)
+    if(ctx->upnp_dev) {
+        // TODO check error here?
+        // try to look up our lan address, to test it
+#if(MINIUPNPC_API_VERSION >= 18)
         int status = UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, ctx->lan_address,
-                                      sizeof(ctx->lan_address), NULL, 0);
-    #else
+                sizeof(ctx->lan_address), NULL, 0);
+#else
         int status =
             UPNP_GetValidIGD(ctx->upnp_dev, &ctx->upnp_urls, &ctx->upnp_data, ctx->lan_address, sizeof(ctx->lan_address));
-    #endif
+#endif
 
-    // look up possible "status" values, the number "1" indicates a valid IGD was found
-    if(status == 1) {
-        log_debug("discovered uPNP server");
-        ctx->type = NAT_TYPE_UPNP;
-    } else {
-        FreeUPNPUrls(&ctx->upnp_urls);
-        freeUPNPDevlist(ctx->upnp_dev);
+        // look up possible "status" values, the number "1" indicates a valid IGD was found
+        if(ctx->upnp_dev && status == 1) {
+            log_debug("discovered uPNP server %d");
+            ctx->type = NAT_TYPE_UPNP;
+        } else {
+            FreeUPNPUrls(&ctx->upnp_urls);
+            freeUPNPDevlist(ctx->upnp_dev);
+        }
     }
 #else
     log_debug("NAT-uPNP support not available");

--- a/src/game/utils/settings.c
+++ b/src/game/utils/settings.c
@@ -140,6 +140,7 @@ const field f_keyboard[] = {
 
 const field f_net[] = {
     F_STRING(settings_network, net_connect_ip, "localhost"),
+    F_STRING(settings_network, net_lobby_address, "lobby.openomf.org"),
     F_STRING(settings_network, net_username, ""),
     F_STRING(settings_network, trace_file, NULL),
     F_INT(settings_network, net_connect_port, 2097),

--- a/src/game/utils/settings.h
+++ b/src/game/utils/settings.h
@@ -109,6 +109,7 @@ typedef struct {
 
 typedef struct {
     char *net_connect_ip;
+    char *net_lobby_address;
     char *trace_file;
     char *net_username;
     int net_connect_port;


### PR DESCRIPTION
* Lobby joining doesn't block the game anymore and can be cancelled
* NAT uPNP and NAT-PMP can be cancelled if they hang
* Connection errors are displayed as dialog boxes
* The address of the lobby server can be provided on the command line or in the config file
* Fix a bug in NAT-PMP detection where it would try a non-existant server multiple times