### PR TITLE
Make netplay startup faster and more reliable, fix win tracking in netplay

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -697,7 +697,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                     log_debug("peer @ %d guessed our ticks INcorrectly! %d %d %d, actually  %d",
                                               peerticks, start, peerguess, peerguess - start, ticks - start);
                                 }
-                                data->guesses = 0;
+                                data->guesses--;
                             }
                             int newrtt = udist(ticks, start);
                             if(data->guesses >= 10 &&
@@ -722,7 +722,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 serial_write_uint32(&start_ser, seed);
 
                                 start_packet = enet_packet_create(start_ser.data, serial_len(&start_ser),
-                                                                  ENET_PACKET_FLAG_UNSEQUENCED);
+                                                                  ENET_PACKET_FLAG_RELIABLE);
                                 enet_peer_send(peer, 0, start_packet);
                                 enet_host_flush(host);
                                 serial_free(&start_ser);
@@ -781,8 +781,8 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                             serial_write_int8(&start_ser, EVENT_TYPE_CONFIRM_START);
                             serial_write_uint32(&start_ser, peer_proposal);
 
-                            start_packet = enet_packet_create(start_ser.data, serial_len(&start_ser),
-                                                              ENET_PACKET_FLAG_UNSEQUENCED);
+                            start_packet =
+                                enet_packet_create(start_ser.data, serial_len(&start_ser), ENET_PACKET_FLAG_RELIABLE);
                             enet_peer_send(peer, 0, start_packet);
                             enet_host_flush(host);
                             serial_free(&start_ser);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -598,6 +598,7 @@ void arena_har_defeat_hook(int player_id, scene *scene) {
         winner_har->state = STATE_VICTORY;
         local->over = 1;
         local->winner = player_id;
+        game_player_get_score(player_winner)->wins++;
 
         if(is_singleplayer(gs)) {
             player_winner->sp_wins |= 2 << player_loser->pilot->pilot_id;


### PR DESCRIPTION
In peer to peer netplay, you return to MELEE after the fight, so make sure the wins/losses are tracked properly, like in 2 player mode.

Additionally, set the reliable flag on the propose/accept start packets, so they cannot be lost.