### PR TITLE
Make rollback perfectly consistent with local play & improve dedup

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -375,21 +375,18 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
         assert(gs->int_tick - data->local_proposal == ev->tick);
 
         // feed in the inputs
-        int arena_state = arena_get_state(game_state_get_scene(gs));
-        if(arena_state == ARENA_STATE_FIGHTING) {
-            for(int j = 0; j < 2; j++) {
-                int player_id = j;
-                game_player *player = game_state_get_player(gs, player_id);
-                int k = 0;
-                do {
-                    object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ev->events[j][k]);
-                    k++;
-                } while(ev->events[j][k]);
+        for(int j = 0; j < 2; j++) {
+            int player_id = j;
+            game_player *player = game_state_get_player(gs, player_id);
+            int k = 0;
+            do {
+                object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ev->events[j][k]);
+                k++;
+            } while(ev->events[j][k]);
 
-                // write_rec_move(gs->sc, player, ev->events[j]);
-                //} else {
-                //    object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ACT_STOP);
-            }
+            // write_rec_move(gs->sc, player, ev->events[j]);
+            //} else {
+            //    object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ACT_STOP);
         }
 
         arena_hash = arena_state_hash(gs);

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -109,7 +109,6 @@ void insert_event(wtf *data, uint32_t tick, uint16_t action, int id, int directi
     event.direction[id] = direction;
     int i = 0;
 
-
     foreach(it, ev) {
         if(id == data->id && ev->events[id][0]) {
             // we had events this tick, so get the last action and direction
@@ -125,7 +124,8 @@ void insert_event(wtf *data, uint32_t tick, uint16_t action, int id, int directi
             list_prepend(transcript, &event, sizeof(tick_events));
             goto done;
         } else if(ev->tick == tick) {
-            if(id == data->id && action == data->last_action && data->last_direction && data->last_direction == direction) {
+            if(id == data->id && action == data->last_action && data->last_direction &&
+               data->last_direction == direction) {
                 // dedup;
                 return;
             }
@@ -141,7 +141,8 @@ void insert_event(wtf *data, uint32_t tick, uint16_t action, int id, int directi
         }
         nev = iter_peek(&it);
         if(ev->tick < tick && nev && nev->tick > tick) {
-            if(id == data->id && action == data->last_action && data->last_direction && data->last_direction == direction) {
+            if(id == data->id && action == data->last_action && data->last_direction &&
+               data->last_direction == direction) {
                 // dedup
                 return;
             }
@@ -693,7 +694,8 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 if(action) {
                                     if(data->synchronized && data->gs_bak) {
                                         if(remote_tick > data->last_received_tick) {
-                                            insert_event(data, remote_tick, action, abs(data->id - 1), OBJECT_FACE_NONE);
+                                            insert_event(data, remote_tick, action, abs(data->id - 1),
+                                                         OBJECT_FACE_NONE);
                                         }
                                         last_received = remote_tick;
                                         if(action != 0) {
@@ -940,7 +942,8 @@ void controller_hook(controller *ctrl, int action) {
     if(peer) {
         // log_debug("Local event %d at %d", action, data->last_tick - data->local_proposal);
         if(data->synchronized && data->gs_bak) {
-            insert_event(data, ctrl->gs->int_tick - data->local_proposal /*+ (ctrl->rtt / 2)*/, action, data->id, direction);
+            insert_event(data, ctrl->gs->int_tick - data->local_proposal /*+ (ctrl->rtt / 2)*/, action, data->id,
+                         direction);
         } else {
             serial ser;
             ENetPacket *packet;

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -22,7 +22,6 @@ typedef struct {
     ENetPeer *lobby;
     int id;
     uint32_t last_hb;
-    int last_action;
     uint32_t outstanding_hb;
     int disconnected;
     int rttbuf[100];
@@ -46,6 +45,8 @@ typedef struct {
     uint32_t peer_last_hash_tick;
     uint32_t last_hash;
     uint32_t last_hash_tick;
+    uint8_t last_action;
+    int8_t last_direction;
     SDL_RWops *trace_file;
     game_state *gs_bak;
     int winner;
@@ -54,6 +55,7 @@ typedef struct {
 typedef struct {
     uint32_t tick;
     uint8_t events[2][11];
+    int8_t direction[2];
 } tick_events;
 
 // simple standard deviation calculation
@@ -91,58 +93,74 @@ int avg_rtt(int data[], int n) {
 }
 
 // insert an event into the event trace
-void insert_event(wtf *data, uint32_t tick, uint16_t action, int id) {
+void insert_event(wtf *data, uint32_t tick, uint16_t action, int id, int direction) {
 
     iterator it;
     list *transcript = &data->transcript;
     list_iter_begin(transcript, &it);
     tick_events *ev = NULL;
     tick_events *nev = NULL;
-    tick_events *last = NULL;
+    tick_events *last_ev = NULL;
     tick_events event;
     event.tick = tick;
     memset(event.events[id], 0, 11);
     memset(event.events[abs(id - 1)], 0, 11);
     event.events[id][0] = action;
+    event.direction[id] = direction;
     int i = 0;
 
+
     foreach(it, ev) {
-        last = ev;
+        if(id == data->id && ev->events[id][0]) {
+            // we had events this tick, so get the last action and direction
+            last_ev = ev;
+            data->last_direction = last_ev->direction[id];
+            int j = 0;
+            while(last_ev->events[id][j] != 0) {
+                data->last_action = last_ev->events[id][j];
+                j++;
+            }
+        }
         if(i == 0 && ev->tick > tick) {
             list_prepend(transcript, &event, sizeof(tick_events));
-            return;
+            goto done;
         } else if(ev->tick == tick) {
-            int last = 0;
-            for(int i = 0; i < 11; i++) {
-                if(ev->events[id][i] == 0) {
-                    if(action == last) {
-                        // dedup;
-                        break;
-                    }
-                    log_debug("appending %d at tick %d, last was %d", action, tick, last);
-                    ev->events[id][i] = action;
+            if(id == data->id && action == data->last_action && data->last_direction && data->last_direction == direction) {
+                // dedup;
+                return;
+            }
+
+            for(int j = 0; j < 11; j++) {
+                if(ev->events[id][j] == 0) {
+                    ev->events[id][j] = action;
+                    ev->direction[id] = direction;
                     break;
-                } else {
-                    last = ev->events[id][i];
                 }
             }
-            log_debug("merging event on tick %d: action 0 %d action 1 %d id %d action %d", tick, ev->events[0][0],
-                      ev->events[1][0], id, action);
-            return;
+            goto done;
         }
         nev = iter_peek(&it);
         if(ev->tick < tick && nev && nev->tick > tick) {
+            if(id == data->id && action == data->last_action && data->last_direction && data->last_direction == direction) {
+                // dedup
+                return;
+            }
             list_iter_append(&it, &event, sizeof(tick_events));
-            return;
+            goto done;
         }
         i++;
     }
     // either the list is empty, or this tick is later than anything else
-    if(last && last->events[id][0] == action) {
-        // dedup, this is not needed
+    if(id == data->id && action == data->last_action && data->last_direction && data->last_direction == direction) {
+        // dedup;
         return;
     }
     list_append(transcript, &event, sizeof(tick_events));
+done:
+    if(id == data->id) {
+        data->last_action = action;
+        data->last_direction = direction;
+    }
 }
 
 // check if we have any events for this tick
@@ -610,7 +628,8 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
         // changed scene and no longer need a game state backup, release it
         game_state_clone_free(data->gs_bak);
         omf_free(data->gs_bak);
-        data->last_action = ACT_STOP;
+        data->last_action = ACT_NONE;
+        data->last_direction = OBJECT_FACE_NONE;
         data->synchronized = false;
         data->local_proposal = 0;
         data->peer_proposal = 0;
@@ -674,7 +693,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 if(action) {
                                     if(data->synchronized && data->gs_bak) {
                                         if(remote_tick > data->last_received_tick) {
-                                            insert_event(data, remote_tick, action, abs(data->id - 1));
+                                            insert_event(data, remote_tick, action, abs(data->id - 1), OBJECT_FACE_NONE);
                                         }
                                         last_received = remote_tick;
                                         if(action != 0) {
@@ -861,7 +880,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
             return 0;
         }
     }
-    if(data->last_acked_tick < ticks - 50 && has_received) {
+    if(data->last_acked_tick < (ticks - data->local_proposal) - 50 && has_received) {
         // if we haven't sent an event in a while, send a dummy event to force the peer to
         // rewind/replay
         log_debug("sending blank events in response");
@@ -908,19 +927,20 @@ void controller_hook(controller *ctrl, int action) {
 
     game_player *player = game_state_get_player(ctrl->gs, data->id);
     object *har_obj = game_state_find_object(ctrl->gs, game_player_get_har_obj_id(player));
+    int direction = OBJECT_FACE_NONE;
     if(har_obj) {
         har *har = object_get_userdata(har_obj);
         // if(action == ACT_STOP && har->state == data->last_har_state) {
         //     return;
         // }
         data->last_har_state = har->state;
-        data->last_action = action;
+        direction = object_get_direction(har_obj);
     }
 
     if(peer) {
         // log_debug("Local event %d at %d", action, data->last_tick - data->local_proposal);
         if(data->synchronized && data->gs_bak) {
-            insert_event(data, ctrl->gs->int_tick - data->local_proposal /*+ (ctrl->rtt / 2)*/, action, data->id);
+            insert_event(data, ctrl->gs->int_tick - data->local_proposal /*+ (ctrl->rtt / 2)*/, action, data->id, direction);
         } else {
             serial ser;
             ENetPacket *packet;
@@ -954,7 +974,6 @@ void net_controller_create(controller *ctrl, ENetHost *host, ENetPeer *peer, ENe
     data->peer = peer;
     data->lobby = lobby; // this is null in a peer-to-peer game
     data->last_hb = 0;
-    data->last_action = ACT_STOP;
     data->outstanding_hb = 0;
     data->disconnected = 0;
     data->rttpos = 0;
@@ -973,6 +992,8 @@ void net_controller_create(controller *ctrl, ENetHost *host, ENetPeer *peer, ENe
     data->trace_file = NULL;
     data->last_traced_tick = 0;
     data->winner = -1;
+    data->last_action = ACT_NONE;
+    data->last_direction = OBJECT_FACE_NONE;
     char *trace_file = settings_get()->net.trace_file;
     if(trace_file) {
         data->trace_file = SDL_RWFromFile(trace_file, "w");

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -320,7 +320,6 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
         }
     }
 
-    // int gs_start = gs->int_tick - data->local_proposal;
     uint64_t replay_start = SDL_GetTicks64();
     int tick_count = 0;
 
@@ -339,7 +338,6 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
         // for future replays
         if(gs_new == NULL && ev->tick > last_agreed && gs->int_tick - data->local_proposal <= last_agreed &&
            gs->int_tick > gs_old->int_tick) {
-            // log_debug("tick %" PRIu32 " is newer than last acked tick %" PRIu32, ev->tick, data->last_acked_tick);
             log_debug("saving game state at last agreed on tick %d with hash %" PRIu32,
                       gs->int_tick - data->local_proposal, arena_state_hash(gs));
             // save off the game state at the point we last agreed
@@ -383,10 +381,6 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
                 object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ev->events[j][k]);
                 k++;
             } while(ev->events[j][k]);
-
-            // write_rec_move(gs->sc, player, ev->events[j]);
-            //} else {
-            //    object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ACT_STOP);
         }
 
         arena_hash = arena_state_hash(gs);
@@ -731,8 +725,6 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                             uint32_t peerguess = serial_read_int32(&ser);
 
                             if(udist(peerguess, ticks) < 2) {
-                                // log_debug("peer @ %d guessed our ticks correctly! %d %d %d", peerticks, start,
-                                // peerguess,// peerguess - start);
                                 data->guesses++;
                             } else {
                                 if(!data->synchronized) {
@@ -768,7 +760,6 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 enet_peer_send(peer, 0, start_packet);
                                 enet_host_flush(host);
                                 serial_free(&start_ser);
-                                // enet_packet_destroy(start_packet);
                             }
 
                             // log_debug("RTT was %d ticks", newrtt);
@@ -778,12 +769,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 data->rttpos = 0;
                                 data->rttfilled = 1;
                             }
-                            if(data->rttfilled == 1) {
-                                ctrl->rtt = peer->roundTripTime;
-                                // data->tick_offset = (peerticks + (ctrl->rtt / 2)) - ticks;
-                                // log_debug("I am %d ticks away from server: %d %d RTT %d", data->tick_offset, ticks,
-                                // peerticks, ctrl->rtt);
-                            }
+                            ctrl->rtt = peer->roundTripTime;
                             data->outstanding_hb = 0;
                             data->last_hb = ticks;
                         } else {
@@ -828,7 +814,6 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                             enet_peer_send(peer, 0, start_packet);
                             enet_host_flush(host);
                             serial_free(&start_ser);
-                            // enet_packet_destroy(start_packet);
                         }
                     } break;
                     case EVENT_TYPE_CONFIRM_START: {
@@ -913,9 +898,6 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
         }
     }
 
-    /*if(!handled) {*/
-    /*controller_cmd(ctrl, ACT_STOP, ev);*/
-    /*}*/
     return 0;
 }
 
@@ -929,9 +911,6 @@ void controller_hook(controller *ctrl, int action) {
     int direction = OBJECT_FACE_NONE;
     if(har_obj) {
         har *har = object_get_userdata(har_obj);
-        // if(action == ACT_STOP && har->state == data->last_har_state) {
-        //     return;
-        // }
         data->last_har_state = har->state;
         direction = object_get_direction(har_obj);
     }
@@ -955,7 +934,6 @@ void controller_hook(controller *ctrl, int action) {
             serial_write_int8(&ser, action);
             serial_write_int8(&ser, 0);
             log_debug("controller hook fired with %d", action);
-            /*sprintf(buf, "k%d", action);*/
             // non gameplay events are not repeated, so they need to be reliable
             packet = enet_packet_create(ser.data, serial_len(&ser), ENET_PACKET_FLAG_RELIABLE);
             serial_free(&ser);

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -2011,14 +2011,13 @@ void har_finished(object *obj) {
             // never get fired.
             h->state = STATE_JUMPING;
             har_set_ani(obj, ANIM_JUMPING, 0);
-        } else if(h->state != STATE_JUMPING) {
-            h->state = STATE_STANDING;
-            har_set_ani(obj, ANIM_IDLE, 1);
         } else {
+            h->state = STATE_NONE;
             har_set_ani(obj, ANIM_IDLE, 1);
             har_act(obj, ACT_NONE);
         }
     } else {
+        h->state = STATE_NONE;
         har_set_ani(obj, ANIM_CROUCHING, 1);
         har_act(obj, ACT_NONE);
     }

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -18,6 +18,7 @@
 enum
 {
     OBJECT_FACE_LEFT = -1,
+    OBJECT_FACE_NONE = 0,
     OBJECT_FACE_RIGHT = 1
 };
 

--- a/src/game/scenes/vs.c
+++ b/src/game/scenes/vs.c
@@ -149,13 +149,6 @@ void vs_handle_action(scene *scene, int action) {
             case ACT_PUNCH:
                 if(game_state_get_player(scene->gs, 1)->pilot) {
                     game_state_set_next(scene->gs, SCENE_ARENA0 + local->arena);
-                    if(vs_is_netplay(scene)) {
-                        game_player *player2 = game_state_get_player(scene->gs, 1);
-                        if(player2->ctrl->type == CTRL_TYPE_NETWORK) {
-                            log_debug("delaying arena start for %d ticks", player2->ctrl->rtt / 2);
-                            scene->gs->next_wait_ticks += player2->ctrl->rtt;
-                        }
-                    }
                 } else {
                     game_state_get_player(scene->gs, 1)->pilot = NULL;
                     game_state_set_next(scene->gs, SCENE_MECHLAB);


### PR DESCRIPTION
When we were deduping inputs, we were not considering the direction the
HAR was facing. This led to a case where if you jumped over the opponent
and kept holding the forward and jump keys, once you landed the HAR, on
rollback, would start jumping the other way. This is because we were
encoding the direction into the input buffer, but not when deduping, so
because the direction of the HAR changed, we need to allow the new input
to come through.

Additionally, the dedup has been corrected so that if the last event the
player has not changed, and the HAR's direction has not changed, there
is no need to store or send any input events. This significantly reduces
the network events sent and thus the rollbacks that need to be done.