### PR TITLE
Fix various bugs when entering tournament mode with no character

### DIFF
--- a/src/game/scenes/mechlab.h
+++ b/src/game/scenes/mechlab.h
@@ -23,6 +23,8 @@ typedef enum
 int mechlab_create(scene *scene);
 void mechlab_update(scene *scene);
 
+void mechlab_load_har(scene *scene, sd_pilot *pilot);
+
 void mechlab_enter_trnselect_menu(scene *s);
 component *mechlab_chrload_menu_create(scene *scene);
 component *mechlab_chrdelete_menu_create(scene *scene);

--- a/src/game/scenes/mechlab/lab_dash_main.c
+++ b/src/game/scenes/mechlab/lab_dash_main.c
@@ -142,6 +142,9 @@ void lab_dash_main_chr_init(component *menu, component *submenu) {
     dw->index = 0;
     chr = list_get(dw->savegames, 0);
     p1->pilot = &chr->pilot;
+    if(!p1->chr) {
+        mechlab_load_har(dw->scene, p1->pilot);
+    }
     mechlab_update(dw->scene);
 }
 
@@ -203,9 +206,7 @@ void lab_dash_main_chr_done(component *menu, component *submenu) {
         // no character is loaded, we need to go back to nothing
         sd_sprite_free(dw->pilot->photo);
         omf_free(dw->pilot->photo);
-        sd_pilot_free(p1->pilot);
-        omf_free(p1->pilot);
-        // p1->pilot = NULL;
+        p1->pilot = NULL; // freed below
     }
 
     if(dw->savegames) {

--- a/src/game/scenes/mechlab/lab_menu_main.c
+++ b/src/game/scenes/mechlab/lab_menu_main.c
@@ -249,10 +249,10 @@ static const spritebutton_tick_cb tick_cbs[] = {
     lab_menu_tick_in_tournament, // lab_menu_tick_sell,
     NULL,                        // lab_menu_tick_load,
     NULL,                        // lab_menu_tick_new,
-    NULL,                        // lab_menu_tick_delete,
+    lab_menu_tick_in_tournament, // lab_menu_tick_delete,
     lab_menu_tick_in_tournament, // lab_menu_tick_sim,
     NULL,                        // lab_menu_tick_quit,
-    NULL,                        // lab_menu_tick_tournament,
+    lab_menu_tick_in_tournament, // lab_menu_tick_tournament,
 };
 
 component *lab_menu_main_create(scene *s, bool character_loaded) {


### PR DESCRIPTION
If there's no 'last' character found, and you try to load one, without this patch the HARs would not display in the character select.

Additionally, if you cancelled the har load, the game would crash going back to the main mechlab menu.