### PR TITLE
Try to make fight rounds end smoother:

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -620,14 +620,14 @@ void har_move(object *obj) {
 
                 h->state = STATE_DEFEAT;
                 har_set_ani(obj, ANIM_DEFEAT, 0);
-                har_event_defeat(h, ctrl);
+                // har_event_defeat(h, ctrl);
             } else if(pos.y >= (ARENA_FLOOR - 5) && IS_ZERO(vel.x) && player_is_last_frame(obj)) {
                 if(h->state == STATE_FALLEN) {
                     if(h->health <= 0) {
                         // fallen, but done bouncing
                         h->state = STATE_DEFEAT;
                         har_set_ani(obj, ANIM_DEFEAT, 0);
-                        har_event_defeat(h, ctrl);
+                        // har_event_defeat(h, ctrl);
                     } else {
                         h->state = STATE_STANDING_UP;
                         har_set_ani(obj, ANIM_STANDUP, 0);
@@ -732,6 +732,9 @@ void har_take_damage(object *obj, const str *string, float damage, float stun) {
         object_set_animation(obj, &af_get_move(h->af_data, ANIM_DAMAGE)->ani);
         object_set_repeat(obj, 0);
         if(h->health <= 0) {
+            controller *ctrl = game_player_get_ctrl(game_state_get_player(obj->gs, h->player_id));
+            // trigger the defeat hook immediately
+            har_event_defeat(h, ctrl);
             // taken from MASTER.DAT
             size_t last_line = 0;
             if(!str_last_of(string, '-', &last_line)) {
@@ -1653,6 +1656,10 @@ af_move *match_move(object *obj, char *inputs) {
                     continue;
                 }
 
+                if(move->category != CAT_DESTRUCTION && h->state == STATE_SCRAP) {
+                    continue;
+                }
+
                 if(move->category == CAT_FIRE_ICE) {
                     continue;
                 }
@@ -2017,7 +2024,9 @@ void har_finished(object *obj) {
 
     h->executing_move = 0;
 
-    if(h->state == STATE_SCRAP || h->state == STATE_DESTRUCTION) {
+    if(h->state == STATE_VICTORY || h->state == STATE_DONE) {
+        har_set_ani(obj, ANIM_VICTORY, 0);
+    } else if(h->state == STATE_SCRAP || h->state == STATE_DESTRUCTION) {
         // play vistory animation again, but do not allow any more moves to be executed
         h->state = STATE_DONE;
         har_set_ani(obj, ANIM_VICTORY, 0);
@@ -2027,7 +2036,6 @@ void har_finished(object *obj) {
     } else if(h->state == STATE_RECOIL && h->health <= 0) {
         h->state = STATE_DEFEAT;
         har_set_ani(obj, ANIM_DEFEAT, 0);
-        har_event_defeat(h, ctrl);
     } else if((h->state == STATE_RECOIL || h->state == STATE_STANDING_UP) && h->endurance < 1.0f) {
         if(h->state == STATE_RECOIL) {
             har_event_recover(h, ctrl);

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1656,10 +1656,6 @@ af_move *match_move(object *obj, char *inputs) {
                     continue;
                 }
 
-                if(move->category != CAT_DESTRUCTION && h->state == STATE_SCRAP) {
-                    continue;
-                }
-
                 if(move->category == CAT_FIRE_ICE) {
                     continue;
                 }

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -650,6 +650,7 @@ void player_run(object *obj) {
     if(sd_script_isset(frame, "d") && !obj->animation_state.disable_d) {
         state->previous_tick = state->current_tick;
         state->current_tick = sd_script_get(frame, "d") + 1;
+        state->looping = true;
         return;
     }
 
@@ -716,4 +717,9 @@ char player_get_frame_letter(const object *obj) {
 int player_is_last_frame(const object *obj) {
     const player_animation_state *state = &obj->animation_state;
     return sd_script_is_last_frame_at(&state->parser, state->current_tick);
+}
+
+bool player_is_looping(const object *obj) {
+    const player_animation_state *state = &obj->animation_state;
+    return state->looping;
 }

--- a/src/game/protos/player.h
+++ b/src/game/protos/player.h
@@ -59,6 +59,7 @@ typedef struct player_animation_state_t {
     uint8_t finished;
     uint8_t disable_d;
     uint8_t shadow_corner_hack;
+    bool looping;
 
     uint8_t pal_copy_entries; // ba
     uint8_t pal_copy_start;   // bi
@@ -90,6 +91,7 @@ char player_get_frame_letter(const object *obj);
 unsigned int player_get_len_ticks(const object *obj);
 void player_set_delay(object *obj, int delay);
 int player_is_last_frame(const object *obj);
+bool player_is_looping(const object *obj);
 uint32_t player_get_current_tick(const object *obj);
 
 #endif // PLAYER_H


### PR DESCRIPTION
* Count the round over as soon as a player has 0 health
* Defer the you lose/win animation until both hars are at rest

The goal here is to be more like the original, where you instantly lose input control (other than scrap/destruction) and there's not a weird gap before the round starts to end.