### PR TITLE
Implement "walk to HAR" used in several scrap animations

### DIFF
--- a/src/game/objects/har.h
+++ b/src/game/objects/har.h
@@ -166,6 +166,10 @@ typedef struct har_t {
 
     uint32_t linked_obj;
 
+    int walk_destination;
+
+    int walk_done_anim;
+
     list har_hooks;
 
 #ifdef DEBUGMODE
@@ -178,6 +182,7 @@ void har_install_hook(har *h, har_hook_cb hook, void *data);
 void har_bootstrap(object *obj);
 int har_create(object *obj, af *af_data, int dir, int har_id, int pilot_id, int player_id);
 void har_set_ani(object *obj, int animation_id, int repeat);
+void har_walk_to(object *obj, int destination);
 int har_is_active(object *obj);
 int har_is_crouching(har *h);
 int har_is_walking(har *h);

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -258,20 +258,14 @@ void player_run(object *obj) {
             int destination = 160;
             if(sd_script_isset(frame, "am") && sd_script_isset(frame, "e")) {
                 // destination is the enemy's position
-                destination = enemy->pos.x;
-                if(sd_script_isset(frame, "x")) {
-                    if(object_get_direction(obj) == OBJECT_FACE_RIGHT) {
-                        destination += sd_script_get(frame, "x");
-                    } else {
-                        destination -= sd_script_get(frame, "x");
-                    }
-                }
+                log_debug("adjusting walkto %d by %d", destination, trans_x);
+                destination = enemy->pos.x - trans_x;
                 if(obj->pos.x > enemy->pos.x) {
                     object_set_direction(obj, OBJECT_FACE_LEFT);
                 } else {
                     object_set_direction(obj, OBJECT_FACE_RIGHT);
                 }
-                destination = max2(ARENA_LEFT_WALL, min2(ARENA_RIGHT_WALL, (int)enemy->pos.x));
+                destination = max2(ARENA_LEFT_WALL, min2(ARENA_RIGHT_WALL, destination));
             } else if(sd_script_isset(frame, "cf")) {
                 // shadow's scrap, position is in the corner behind shadow
                 if(object_get_direction(enemy) == OBJECT_FACE_RIGHT) {
@@ -279,19 +273,15 @@ void player_run(object *obj) {
                 } else {
                     destination = ARENA_LEFT_WALL;
                 }
-                if(sd_script_isset(frame, "x")) {
-                    if(object_get_direction(obj) == OBJECT_FACE_RIGHT) {
-                        destination += sd_script_get(frame, "x");
-                    } else {
-                        destination -= sd_script_get(frame, "x");
-                    }
-                }
+                destination += trans_x;
                 object_set_direction(obj, object_get_direction(enemy));
                 // flip the HAR's position for this animation
                 obj->animation_state.shadow_corner_hack = 1;
             } else {
                 destination = -1;
             }
+            // clear this
+            trans_x = 0;
             if(sd_script_get(frame, "bm") == 10 && destination > 0 && fabsf(obj->pos.x - destination) > 5.0) {
                 log_debug("HAR walk to %d from %d", destination, obj->pos.x);
                 har_walk_to(obj, destination);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1046,7 +1046,8 @@ void arena_dynamic_tick(scene *scene, int paused) {
             chr_score *s1 = game_player_get_score(game_state_get_player(scene->gs, 0));
             chr_score *s2 = game_player_get_score(game_state_get_player(scene->gs, 1));
             if(player_frame_isset(obj_har[0], "be") || player_frame_isset(obj_har[1], "be") || chr_score_onscreen(s1) ||
-               chr_score_onscreen(s2)) {
+               chr_score_onscreen(s2) ||
+               (obj_har[0]->cur_animation->id != ANIM_VICTORY && obj_har[1]->cur_animation->id != ANIM_VICTORY)) {
             } else {
                 local->ending_ticks++;
             }


### PR DESCRIPTION
Many of the scrap animations have the winner walk over to where the loser is lying on the ground and pick them up, or ruin them where they lay, etc.

Shadow's scrap has the winner walk to the far arena wall and lean against it.

Both of these are now implemented.

Additionally several bugs with the ez-destruct cheat were fixed, and going to non-scrap/destruction moves during scrap/destruction are now properly disallowed.