### PR TITLE
Netplay Connection fixes

### DIFF
--- a/.github/actions/build_macos_arm/action.yaml
+++ b/.github/actions/build_macos_arm/action.yaml
@@ -16,7 +16,7 @@ runs:
       shell: bash
       run: |
         mkdir build-release && cd build-release
-        cmake -DUSE_NATPMP=ON -DUSE_MINIUPNPC=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=release/usr ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=release/usr ..
         make -j $(getconf _NPROCESSORS_ONLN)
         make -j $(getconf _NPROCESSORS_ONLN) install
 

--- a/.github/actions/build_mingw/action.yaml
+++ b/.github/actions/build_mingw/action.yaml
@@ -28,7 +28,5 @@ runs:
               -DCMAKE_LIBRARY_PATH="${GITHUB_WORKSPACE}/openomf-win-build-main/lib/" \
               -DCMAKE_FIND_ROOT_PATH="${GITHUB_WORKSPACE}/openomf-win-build-main/" \
               -DBUILD_LANGUAGES=OFF \
-              -DUSE_NATPMP=ON \
-              -DUSE_MINIUPNPC=ON \
               -S . -B build
         cmake --build build -j $(getconf _NPROCESSORS_ONLN)

--- a/.github/actions/build_msvc/action.yaml
+++ b/.github/actions/build_msvc/action.yaml
@@ -41,8 +41,6 @@ runs:
         -DVCPKG_TARGET_TRIPLET="${{ inputs.arch }}-windows-static"
         -A ${{ inputs.arch }}
         -DBUILD_LANGUAGES=${{ inputs.build_languages }}
-        -DUSE_NATPMP=ON
-        -DUSE_MINIUPNPC=ON
 
     - name: Build openomf
       shell: pwsh

--- a/.github/actions/build_ubuntu/action.yaml
+++ b/.github/actions/build_ubuntu/action.yaml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         mkdir build-release && cd build-release
-        cmake -DUSE_NATPMP=ON -DUSE_MINIUPNPC=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=release/usr ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=release/usr ..
         make -j $(getconf _NPROCESSORS_ONLN)
         make -j $(getconf _NPROCESSORS_ONLN) install
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -44,6 +44,8 @@ jobs:
               -DUSE_SANITIZERS=On \
               -DUSE_FATAL_SANITIZERS=On \
               -DUSE_TOOLS=On \
+              -DUSE_MINIUPNPC=Off \
+              -DUSE_NATPMP=Off \
               -G "Ninja Multi-Config" \
               -S . -B build-test
         cmake --build build-test -j $(getconf _NPROCESSORS_ONLN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ OPTION(USE_FORMAT "Use clang-format for checks" OFF)
 OPTION(BUILD_LANGUAGES "Build Language Files" ON)
 OPTION(USE_COLORS "Use colors in log output" ON)
 
-OPTION(USE_MINIUPNPC "Use miniupnpc for port forwarding" OFF)
-OPTION(USE_NATPMP "Use natpmp for port forwarding" OFF)
+OPTION(USE_MINIUPNPC "Use miniupnpc for port forwarding" ON)
+OPTION(USE_NATPMP "Use natpmp for port forwarding" ON)
 
 # vcpkg features must be set before project()
 if(USE_TESTS)

--- a/src/game/gui/textinput.c
+++ b/src/game/gui/textinput.c
@@ -227,6 +227,11 @@ void textinput_set_done_cb(component *c, textinput_done_cb done_cb, void *userda
     tb->userdata = userdata;
 }
 
+void textinput_set_text(component *c, char const *value) {
+    textinput *tb = widget_get_obj(c);
+    str_set_c(&tb->text, value);
+}
+
 component *textinput_create(const text_settings *tconf, int max_chars, const char *help, const char *initialvalue) {
     component *c = widget_create();
 

--- a/src/game/gui/textinput.h
+++ b/src/game/gui/textinput.h
@@ -11,5 +11,6 @@ const char *textinput_value(const component *c);
 void textinput_clear(component *c);
 void textinput_enable_background(component *c, int enabled);
 void textinput_set_done_cb(component *c, textinput_done_cb done_cb, void *userdata);
+void textinput_set_text(component *c, char const *value);
 
 #endif // TEXTINPUT_H

--- a/src/game/scenes/mainmenu/menu_connect.c
+++ b/src/game/scenes/mainmenu/menu_connect.c
@@ -25,7 +25,7 @@ typedef struct {
 
 enum
 {
-    lowest_port = 1,
+    lowest_port = 1025,
     highest_port = 65535,
     highest_port_digits = 5, // 65535 is 5 digits long
 };

--- a/src/game/scenes/mainmenu/menu_listen.c
+++ b/src/game/scenes/mainmenu/menu_listen.c
@@ -203,8 +203,13 @@ component *menu_listen_create(scene *s) {
     component *menu = menu_create(11);
     menu_attach(menu, label_create(&tconf, "START SERVER"));
     menu_attach(menu, filler_create());
-    char buf[80];
-    snprintf(buf, sizeof(buf), "Waiting for connections to port %d.", ext_port ? ext_port : address.port);
+    char buf[200];
+    if(local->nat.type != NAT_TYPE_NONE) {
+        snprintf(buf, sizeof(buf), "Waiting for local connections to port %d and external connections to %s port %d.",
+                 address.port, local->nat.wan_address, local->nat.ext_port);
+    } else {
+        snprintf(buf, sizeof(buf), "Waiting for connections to port %d.", ext_port ? ext_port : address.port);
+    }
     menu_attach(menu, label_create(&tconf, buf));
     menu_attach(menu, filler_create());
     local->cancel_button =

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -6,62 +6,109 @@
 #include "nat.h"
 #include "utils/log.h"
 
+#ifdef MINIUPNPC_FOUND
+uint16_t upnp_find_wildcard_port(nat_ctx *ctx, uint16_t int_port) {
+    // Retrieve port mappings list
+    struct PortMappingParserData portMappings;
+    memset(&portMappings, 0, sizeof(portMappings));
+
+    int result = UPNP_GetListOfPortMappings(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype,
+                                            "0",     // startPort
+                                            "65535", // endPort
+                                            "UDP",   // protocol
+                                            "0",     // numberOfPorts (0 = all)
+                                            &portMappings);
+
+    if(result != UPNPCOMMAND_SUCCESS) {
+        log_debug("GetListOfPortMappings failed: %d, cannot obtain wildcard port", result);
+        return 0;
+    }
+
+    uint16_t ext_port = 0;
+
+    // Search for our mapping
+    struct PortMapping *pm;
+    for(pm = portMappings.l_head; pm != NULL; pm = pm->l_next) {
+        if(strcmp(pm->internalClient, ctx->lan_address) == 0 && pm->internalPort == int_port &&
+           strcmp(pm->description, "OpenOMF") == 0 && strcmp(pm->protocol, "UDP") == 0) {
+            ext_port = pm->externalPort;
+            break;
+        }
+    }
+
+    // Cleanup
+    FreePortListing(&portMappings);
+    return ext_port;
+}
+#endif
+
 bool nat_create_upnp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
 #ifdef MINIUPNPC_FOUND
     char int_portstr[6];
     snprintf(int_portstr, sizeof(int_portstr), "%d", int_port);
 
     char ext_portstr[6];
-    snprintf(ext_portstr, sizeof(ext_portstr), "%d", ext_port);
+    snprintf(ext_portstr, sizeof(ext_portstr), "%d", ctx->wildcard_ext_port ? 0 : ext_port);
 
     bool use_permanent_lease = false;
 
-    // get the external (WAN) IP address
-    // char wan_address[64];
-    // UPNP_GetExternalIPAddress(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype, wan_address);
+    char const *lease_duration = use_permanent_lease ? "0" : "86400";
 
-    for(;;) {
+    int error =
+        UPNP_AddPortMapping(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype,
+                            ext_portstr,      // external (WAN) port requested
+                            int_portstr,      // internal (LAN) port to which packets will be redirected
+                            ctx->lan_address, // internal (LAN) address to which packets will be redirected
+                            "OpenOMF", // text description to indicate why or who is responsible for the port mapping
+                            "UDP",     // protocol must be either TCP or UDP
+                            NULL,      // remote (peer) host address or nullptr for no restriction
+                            lease_duration); // port map lease duration (in seconds) or zero for "as long as possible"
 
-        char const *lease_duration = use_permanent_lease ? "0" : "86400";
+    if(error == 0) {
+        log_debug("NAT-uPNP Port map successfully created from %d to %d!", int_port, ext_port);
 
-        int error = UPNP_AddPortMapping(
-            ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype,
-            ext_portstr,      // external (WAN) port requested
-            int_portstr,      // internal (LAN) port to which packets will be redirected
-            ctx->lan_address, // internal (LAN) address to which packets will be redirected
-            "OpenOMF",        // text description to indicate why or who is responsible for the port mapping
-            "UDP",            // protocol must be either TCP or UDP
-            NULL,             // remote (peer) host address or nullptr for no restriction
-            lease_duration);  // port map lease duration (in seconds) or zero for "as long as possible"
-
-        if(error == 0) {
-            log_debug("NAT-uPNP Port map successfully created from %d to %d!", int_port, ext_port);
-
-            ctx->int_port = int_port;
-            ctx->ext_port = ext_port;
-            return true;
+        ctx->int_port = int_port;
+        if(ctx->wildcard_ext_port) {
+            // we are not given our wildcard port in the response, so we have to wallow in uPNP some more to get it
+            ctx->ext_port = upnp_find_wildcard_port(ctx, int_port);
         } else {
-            log_debug("NAT-uPNP port %d -> %d mapping failed with %d", int_port, ext_port, error);
-            if(error == 725 /* OnlyPermanentLeasesSupported */ && !use_permanent_lease) {
-                log_debug("NAT-uPNP error 725 is 'OnlyPermanentLeasesSupported', so retrying for a permanent lease.");
-                use_permanent_lease = true;
-                continue; // try again
-            }
-            // TODO there are more errors we can work around here
-            // like overly short lifetimes
-            return false;
+            ctx->ext_port = ext_port;
         }
+        return true;
+    } else {
+        log_debug("NAT-uPNP port %d -> %d mapping failed with %d", int_port, ext_port, error);
+        if(error == 725 /* OnlyPermanentLeasesSupported */ && !ctx->use_permanent_lease) {
+            log_debug("NAT-uPNP error 725 is 'OnlyPermanentLeasesSupported', so retrying for a permanent lease.");
+            ctx->use_permanent_lease = true;
+            return false; // try again
+        } else if(error == 718) {
+            log_debug("NAT-uPNP error 718 is 'ConflictInMappingEntry', so retrying with a different external port.");
+            return false; // try again
+        } else if(error == 727 && !ctx->wildcard_ext_port) {
+            log_debug(
+                "NAT-uPNP error 718 is 'ExternalPortOnlySupportsWildcard', so retrying with a wildcard external port.");
+            ctx->wildcard_ext_port = true;
+            return false; // try again
+        } else if(error == 724) {
+            log_debug("NAT-uPNP error 724 is 'SamePortValuesRequired', but handling this is not yet implemented");
+        } else {
+            log_debug("NAT-uPNP error %d is unhandled", error);
+        }
+        // give up, these errors are not recoverable
+        FreeUPNPUrls(&ctx->upnp_urls);
+        freeUPNPDevlist(ctx->upnp_dev);
+        ctx->type = NAT_TYPE_NONE;
+        return false;
     }
 #else
     return false;
 #endif
 }
 
-bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
 #ifdef NATPMP_FOUND
+// helper function
+int readpmpresponse(nat_ctx *ctx, natpmpresp_t *response) {
     int r;
-    natpmpresp_t response;
-    sendnewportmappingrequest(&ctx->natpmp, NATPMP_PROTOCOL_UDP, int_port, ext_port, 3600);
     do {
         fd_set fds;
         struct timeval timeout;
@@ -77,8 +124,17 @@ bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) 
 #endif
         getnatpmprequesttimeout(&ctx->natpmp, &timeout);
         select(FD_SETSIZE, &fds, NULL, NULL, &timeout);
-        r = readnatpmpresponseorretry(&ctx->natpmp, &response);
+        r = readnatpmpresponseorretry(&ctx->natpmp, response);
     } while(r == NATPMP_TRYAGAIN);
+    return r;
+}
+#endif
+
+bool nat_create_pmp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port) {
+#ifdef NATPMP_FOUND
+    natpmpresp_t response;
+    sendnewportmappingrequest(&ctx->natpmp, NATPMP_PROTOCOL_UDP, int_port, ext_port, 3600);
+    int r = readpmpresponse(ctx, &response);
 
     if(r == 0) {
         log_debug("mapped public port %hu to localport %hu lifetime %u", response.pnu.newportmapping.mappedpublicport,
@@ -138,6 +194,13 @@ void nat_try_upnp(nat_ctx *ctx) {
         // look up possible "status" values, the number "1" indicates a valid IGD was found
         if(ctx->upnp_dev && status == 1) {
             log_debug("discovered uPNP server %d");
+            // get the external (WAN) IP address
+            if(UPNP_GetExternalIPAddress(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype, ctx->wan_address)) {
+                // if this fails, zero the field out
+                ctx->wan_address[0] = 0;
+            }
+            ctx->use_permanent_lease = false;
+            ctx->wildcard_ext_port = false;
             ctx->type = NAT_TYPE_UPNP;
         } else {
             FreeUPNPUrls(&ctx->upnp_urls);
@@ -156,6 +219,12 @@ void nat_try_pmp(nat_ctx *ctx) {
     in_addr_t forcedgw = {0};
     if(initnatpmp(&ctx->natpmp, 0, forcedgw) == 0) {
         log_debug("discovered NAT-PMP server");
+        natpmpresp_t response;
+        sendpublicaddressrequest(&ctx->natpmp);
+        int r = readpmpresponse(ctx, &response);
+        if(r == 0) {
+            inet_ntop(AF_INET, (void *)&response.pnu.publicaddress.addr, ctx->wan_address, sizeof(ctx->wan_address));
+        }
         ctx->type = NAT_TYPE_PMP;
     }
 #else
@@ -183,25 +252,8 @@ void nat_release_upnp(nat_ctx *ctx) {
 void nat_release_pmp(nat_ctx *ctx) {
 #ifdef NATPMP_FOUND
     natpmpresp_t response;
-    int r;
     sendnewportmappingrequest(&ctx->natpmp, NATPMP_PROTOCOL_UDP, ctx->int_port, ctx->ext_port, 0);
-    do {
-        fd_set fds;
-        struct timeval timeout;
-        FD_ZERO(&fds);
-#ifdef _WIN32
-        log_debug("praying that winapi socket '%d' hasn't been truncated", ctx->natpmp.s);
-        // XXX : libnatpmp stores winapi SOCKETs as an `int`, which is terrible because SOCKET is pointer-sized.
-        // WinAPI seems to be kind to us, and is returning small values like 0x00000114.. but this is far from
-        // guaranteed! (using ptrdiff for sign-extension in case `s` is INVALID_SOCKET -1)
-        FD_SET((SOCKET)(ptrdiff_t)ctx->natpmp.s, &fds);
-#else
-        FD_SET(ctx->natpmp.s, &fds);
-#endif
-        getnatpmprequesttimeout(&ctx->natpmp, &timeout);
-        select(FD_SETSIZE, &fds, NULL, NULL, &timeout);
-        r = readnatpmpresponseorretry(&ctx->natpmp, &response);
-    } while(r == NATPMP_TRYAGAIN);
+    int r = readpmpresponse(ctx, &response);
     if(r == 0) {
         log_debug("released public port %hu to localport %hu", ctx->int_port, response.pnu.newportmapping.privateport);
     } else {

--- a/src/game/utils/nat.c
+++ b/src/game/utils/nat.c
@@ -50,9 +50,7 @@ bool nat_create_upnp_mapping(nat_ctx *ctx, uint16_t int_port, uint16_t ext_port)
     char ext_portstr[6];
     snprintf(ext_portstr, sizeof(ext_portstr), "%d", ctx->wildcard_ext_port ? 0 : ext_port);
 
-    bool use_permanent_lease = false;
-
-    char const *lease_duration = use_permanent_lease ? "0" : "86400";
+    char const *lease_duration = ctx->use_permanent_lease ? "0" : "86400";
 
     int error =
         UPNP_AddPortMapping(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype,
@@ -193,7 +191,7 @@ void nat_try_upnp(nat_ctx *ctx) {
 
         // look up possible "status" values, the number "1" indicates a valid IGD was found
         if(ctx->upnp_dev && status == 1) {
-            log_debug("discovered uPNP server %d");
+            log_debug("discovered uPNP server");
             // get the external (WAN) IP address
             if(UPNP_GetExternalIPAddress(ctx->upnp_urls.controlURL, ctx->upnp_data.first.servicetype, ctx->wan_address)) {
                 // if this fails, zero the field out

--- a/src/game/utils/nat.h
+++ b/src/game/utils/nat.h
@@ -5,6 +5,7 @@
 
 #ifdef MINIUPNPC_FOUND
 #include <miniupnpc/miniupnpc.h>
+#include <miniupnpc/portlistingparse.h>
 #include <miniupnpc/upnpcommands.h>
 #endif
 
@@ -19,8 +20,11 @@ typedef struct nat_ctx_t {
     nat_type_t type;
     uint16_t int_port;
     uint16_t ext_port;
+    char wan_address[64];
 #ifdef MINIUPNPC_FOUND
     char lan_address[64];
+    bool use_permanent_lease;
+    bool wildcard_ext_port;
     struct UPNPUrls upnp_urls;
     struct IGDdatas upnp_data;
     struct UPNPDev *upnp_dev;

--- a/src/game/utils/nat.h
+++ b/src/game/utils/nat.h
@@ -9,6 +9,10 @@
 #include <miniupnpc/upnpcommands.h>
 #endif
 
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#endif
+
 typedef enum
 {
     NAT_TYPE_NONE,


### PR DESCRIPTION
First commit makes our upnp work on my netgear router (which gives an err 725), second commit enables the miniupnpc and natpmp libraries by default in all builds, third commit adds the ability to enter a port on the connect screen.

I don't want to add a port setting to the "Start Server" dialog, because it mostly ignores it and likes to try random ports until it finds an available one. Players are expected to communicate their IP and port from server player to client player.