### PR TITLE
Avoid AI deadlock in avoid state

### DIFF
--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -2249,7 +2249,7 @@ bool handle_queued_tactic(controller *ctrl, ctrl_event **ev) {
             case MOVE_AVOID:
                 if(enemy_range == RANGE_FAR) {
                     tactic->move_timer = 0;
-                    acted = true;
+                    acted = false;
                 } else {
                     if(enemy_range == RANGE_CRAMPED || !roll_pref(a->pilot->pref_jump)) {
                         // take a step away


### PR DESCRIPTION
When the HAR is far enough away, release the avoid state.