### PR TITLE
Allow progressbars to animate when they're lowering

### DIFF
--- a/src/game/gui/progressbar.h
+++ b/src/game/gui/progressbar.h
@@ -26,6 +26,7 @@ extern const progressbar_theme _progressbar_theme_melee;
 #define PROGRESSBAR_RIGHT 1
 
 component *progressbar_create(progressbar_theme theme, int orientation, int percentage);
+// set progressbar value, progressbar will lower from current value to new value one % per tick if `animate` is true
 void progressbar_set_progress(component *bar, int percentage, bool animate);
 void progressbar_set_flashing(component *bar, int flashing, int rate);
 

--- a/src/game/gui/progressbar.h
+++ b/src/game/gui/progressbar.h
@@ -26,7 +26,7 @@ extern const progressbar_theme _progressbar_theme_melee;
 #define PROGRESSBAR_RIGHT 1
 
 component *progressbar_create(progressbar_theme theme, int orientation, int percentage);
-void progressbar_set_progress(component *bar, int percentage);
+void progressbar_set_progress(component *bar, int percentage, bool animate);
 void progressbar_set_flashing(component *bar, int flashing, int rate);
 
 #endif // PROGRESSBAR_H

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1030,8 +1030,8 @@ void arena_dynamic_tick(scene *scene, int paused) {
         for(int i = 0; i < 2; i++) {
             float hp = (float)hars[i]->health / (float)hars[i]->health_max;
             float en = (float)hars[i]->endurance / (float)hars[i]->endurance_max;
-            progressbar_set_progress(local->health_bars[i], hp * 100);
-            progressbar_set_progress(local->endurance_bars[i], en * 100);
+            progressbar_set_progress(local->health_bars[i], hp * 100, true);
+            progressbar_set_progress(local->endurance_bars[i], en * 100, true);
             progressbar_set_flashing(local->endurance_bars[i], (en * 100 < 50), 8);
             component_tick(local->health_bars[i]);
             component_tick(local->endurance_bars[i]);

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -216,12 +216,12 @@ void refresh_pilot_stats(melee_local *local) {
     pilot p_a, p_b;
     pilot_get_info(&p_a, CURSOR_INDEX(local, 0));
     pilot_get_info(&p_b, CURSOR_INDEX(local, 1));
-    progressbar_set_progress(local->bar_power[0], (p_a.power * 100) / MAX_STAT);
-    progressbar_set_progress(local->bar_agility[0], (p_a.agility * 100) / MAX_STAT);
-    progressbar_set_progress(local->bar_endurance[0], (p_a.endurance * 100) / MAX_STAT);
-    progressbar_set_progress(local->bar_power[1], (p_b.power * 100) / MAX_STAT);
-    progressbar_set_progress(local->bar_agility[1], (p_b.agility * 100) / MAX_STAT);
-    progressbar_set_progress(local->bar_endurance[1], (p_b.endurance * 100) / MAX_STAT);
+    progressbar_set_progress(local->bar_power[0], (p_a.power * 100) / MAX_STAT, false);
+    progressbar_set_progress(local->bar_agility[0], (p_a.agility * 100) / MAX_STAT, false);
+    progressbar_set_progress(local->bar_endurance[0], (p_a.endurance * 100) / MAX_STAT, false);
+    progressbar_set_progress(local->bar_power[1], (p_b.power * 100) / MAX_STAT, false);
+    progressbar_set_progress(local->bar_agility[1], (p_b.agility * 100) / MAX_STAT, false);
+    progressbar_set_progress(local->bar_endurance[1], (p_b.endurance * 100) / MAX_STAT, false);
 }
 
 void update_har(scene *scene, int player) {


### PR DESCRIPTION
This makes the health/endurance meters more like the original.