### PR TITLE
Restore REC support and make compatability much better

### DIFF
--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -148,7 +148,7 @@ enum
 
 int char_to_act(str *ch, int direction, int *position) {
     int action = 0;
-    switch((str_c(ch) + *position)[0]) {
+    switch(str_at(ch, *position)) {
         case '8':
             action = ACT_UP;
             break;
@@ -211,7 +211,9 @@ int char_to_act(str *ch, int direction, int *position) {
 
     // it's possible there's a kick/punch, or both, chained on here, so check the next 2 characters
     for(int i = 0; i < 2 && (*position) > 0; i++) {
-        switch((str_c(ch) + (*position) - 1)[0]) {
+        // this is a lookahead, so use - 1 to look at the previous character in the string (move strings are in reverse
+        // order)
+        switch(str_at(ch, (*position) - 1)) {
             case 'K':
                 log_debug("adding in extra kick to %d at string %s position %d", action, str_c(ch), *position - 1);
                 action |= ACT_KICK;
@@ -225,7 +227,8 @@ int char_to_act(str *ch, int direction, int *position) {
                 (*position)--;
                 break;
             default:
-                break;
+                // don't keep going
+                return action;
         }
     }
 

--- a/src/controller/ai_controller.c
+++ b/src/controller/ai_controller.c
@@ -1881,26 +1881,26 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
             // Jaguar Leap : D,F+P
-            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_PUNCH};
+            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_SHADOW: {
             // log_debug("Shadow move: Shadow Grab");
             // Shadow Grab       : D,D+P
-            int cmds[] = {ACT_DOWN, ACT_STOP, ACT_DOWN, ACT_PUNCH};
+            int cmds[] = {ACT_DOWN, ACT_STOP, ACT_DOWN | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_KATANA: {
             if(roll_chance(2) && roll_pref(a->pilot->ap_low)) {
                 // log_debug("Katana move: Trip-slide");
                 // Trip-Slide attack : D+B+K
-                int cmds[] = {DOWNBACK, ACT_KICK};
+                int cmds[] = {DOWNBACK | ACT_KICK};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             } else {
                 if(enemy_range >= RANGE_MID && roll_chance(2)) {
                     // log_debug("Katana move: Foward Razor Spin");
                     // Foward Razor Spin : D,F+K
-                    int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_KICK};
+                    int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_KICK};
                     chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
                 } else {
                     // log_debug("Katana move: Rising Blade ");
@@ -1910,7 +1910,7 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
                         chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
                     }
                     // Rising Blade : D,F+P
-                    int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_PUNCH};
+                    int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_PUNCH};
                     chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
                 }
             }
@@ -1919,18 +1919,18 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
             // log_debug("Flail move: Charging Punch");
             if(enemy_range > RANGE_MID && roll_pref(a->pilot->ap_special) && diff_scale(a)) {
                 // Shadow Punch : D,B,B,P
-                int cmds[] = {ACT_DOWN, DOWNBACK, BACK, ACT_STOP, BACK, ACT_PUNCH};
+                int cmds[] = {ACT_DOWN, DOWNBACK, BACK, ACT_STOP, BACK | ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             } else {
                 // Charging Punch : B,B,P
-                int cmds[] = {BACK, ACT_STOP, BACK, ACT_PUNCH};
+                int cmds[] = {BACK, ACT_STOP, BACK | ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
         } break;
         case HAR_THORN: {
             // log_debug("Thorn move: Spike-charge");
             // Spike-Charge : F,F+P
-            int cmds[] = {FORWARD, ACT_STOP, FORWARD, ACT_PUNCH};
+            int cmds[] = {FORWARD, ACT_STOP, FORWARD | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_PYROS: {
@@ -1941,7 +1941,7 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
             // Super Thrust : F,F+P
-            int cmds[] = {FORWARD, ACT_STOP, FORWARD, ACT_PUNCH};
+            int cmds[] = {FORWARD, ACT_STOP, FORWARD | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_ELECTRA: {
@@ -1952,14 +1952,14 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
             // Rolling Thunder : F,F+P
-            int cmds[] = {FORWARD, ACT_STOP, FORWARD, ACT_PUNCH};
+            int cmds[] = {FORWARD, ACT_STOP, FORWARD | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_CHRONOS: {
             if(enemy_range >= RANGE_MID && roll_pref(a->pilot->ap_special) && diff_scale(a)) {
                 // log_debug("Chronos move: Teleport");
                 // Teleportation : D,P
-                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_PUNCH};
+                int cmds[] = {ACT_DOWN, ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
                 // follow up with a close-range tactic
                 int tacs[] = {TACTIC_GRAB, TACTIC_PUSH, TACTIC_SHOOT, TACTIC_SPAM, TACTIC_TRIP};
@@ -1967,7 +1967,7 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
             } else {
                 // log_debug("Chronos move: Trip-slide");
                 // Trip-Slide attack : D,B+K
-                int cmds[] = {DOWNBACK, ACT_KICK};
+                int cmds[] = {DOWNBACK | ACT_KICK};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
         } break;
@@ -1975,7 +1975,7 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
             if(enemy_range > RANGE_MID && roll_pref(a->pilot->att_jump) && diff_scale(a)) {
                 // log_debug("Shredder move: Flip-kick");
                 // Flip Kick : D,D+K
-                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_DOWN, ACT_KICK};
+                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_DOWN | ACT_KICK};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             } else {
                 // log_debug("Shredder move: Head-butt");
@@ -1985,7 +1985,7 @@ bool attempt_charge_attack(controller *ctrl, ctrl_event **ev) {
                     chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
                 }
                 // Head-Butt : D,F+P
-                int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_PUNCH};
+                int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
         } break;
@@ -2047,7 +2047,7 @@ bool attempt_push_attack(controller *ctrl, ctrl_event **ev) {
         case HAR_JAGUAR: {
             // log_debug("Jaguar move: High Kick");
             // High Kick : B+K
-            int cmds[] = {BACK, ACT_KICK};
+            int cmds[] = {BACK | ACT_KICK};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_KATANA: {
@@ -2058,19 +2058,19 @@ bool attempt_push_attack(controller *ctrl, ctrl_event **ev) {
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
             // Rising Blade : D,F+P
-            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_PUNCH};
+            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_FLAIL: {
             if(roll_chance(3)) {
                 // log_debug("Flail move: Slow Swing Chains");
                 // Slow Swing Chain : D,K
-                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_KICK};
+                int cmds[] = {ACT_DOWN, ACT_KICK};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             } else {
                 // log_debug("Flail move: Swinging Chains");
                 // Swinging Chains : D,P
-                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_PUNCH};
+                int cmds[] = {ACT_DOWN, ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
         } break;
@@ -2082,31 +2082,31 @@ bool attempt_push_attack(controller *ctrl, ctrl_event **ev) {
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
             // Speed Kick : D,F+K
-            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_KICK};
+            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_KICK};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_PYROS: {
             // log_debug("Pyros move: Fire Spin");
-            // Fire Spin : D+P
-            int cmds[] = {ACT_DOWN, ACT_STOP, ACT_PUNCH};
+            // Fire Spin : D,P
+            int cmds[] = {ACT_DOWN, ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_ELECTRA: {
             // log_debug("Electra move: Electric Shards");
             // Electric Shards : D,F+P
-            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD, ACT_PUNCH};
+            int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
         } break;
         case HAR_NOVA: {
             if(diff_scale(a)) {
                 // log_debug("Nova move: Earthquake Slam");
-                // Earthquake Slam : D,D,P
-                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_DOWN, ACT_PUNCH};
+                // Earthquake Slam : D,D+P
+                int cmds[] = {ACT_DOWN, ACT_STOP, ACT_DOWN | ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             } else {
                 // log_debug("Nova move: Heavy Kick");
                 // Heavy Kick : B+K
-                int cmds[] = {BACK, ACT_KICK};
+                int cmds[] = {BACK | ACT_KICK};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
         } break;
@@ -2144,7 +2144,7 @@ bool attempt_trip_attack(controller *ctrl, ctrl_event **ev) {
 
     // log_debug("Har move: Trip");
     // Standard Trip : D+B+K
-    int cmds[] = {DOWNBACK, ACT_KICK};
+    int cmds[] = {DOWNBACK | ACT_KICK};
     chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
 
     return true;
@@ -2175,7 +2175,7 @@ bool attempt_projectile_attack(controller *ctrl, ctrl_event **ev) {
             if(h->id == HAR_SHREDDER && enemy_range > RANGE_MID) {
                 return false;
             }
-            int cmds[] = {ACT_DOWN, DOWNBACK, BACK, ACT_PUNCH};
+            int cmds[] = {ACT_DOWN, DOWNBACK, BACK | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             return true;
         } break;
@@ -2199,7 +2199,7 @@ bool attempt_projectile_attack(controller *ctrl, ctrl_event **ev) {
                 return false;
             }
             // Stasis : D, B, P
-            int cmds[] = {ACT_DOWN, DOWNBACK, BACK, ACT_PUNCH};
+            int cmds[] = {ACT_DOWN, DOWNBACK, BACK | ACT_PUNCH};
             chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             return true;
         } break;
@@ -2207,14 +2207,13 @@ bool attempt_projectile_attack(controller *ctrl, ctrl_event **ev) {
             controller_cmd(ctrl, ACT_DOWN, ev);
             if(roll_chance(3) && enemy_range >= RANGE_MID) {
                 // Mini-Grenade : D, B, P
-                int cmds[] = {ACT_DOWN, DOWNBACK, BACK};
+                int cmds[] = {ACT_DOWN, DOWNBACK, BACK | ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             } else {
                 // Missile : D, F, P
-                int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD};
+                int cmds[] = {ACT_DOWN, DOWNFORWARD, FORWARD | ACT_PUNCH};
                 chain_controller_cmd(ctrl, cmds, N_ELEMENTS(cmds), ev);
             }
-            controller_cmd(ctrl, ACT_PUNCH, ev);
             return true;
         } break;
     }

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -74,8 +74,8 @@ static inline void ctrl_action_push(ctrl_event **ev, int action) {
 
 void controller_cmd(controller *ctrl, int action, ctrl_event **ev) {
     ctrl->current |= action;
-    if((ctrl->last & action)) {
-        if(action & (ACT_KICK | ACT_PUNCH | ACT_ESC))
+    if(ctrl->last & action) {
+        if(ctrl->last & action & (ACT_KICK | ACT_PUNCH | ACT_ESC))
             // never keyrepeat these actions
             return;
         else if(ctrl->repeat)

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -17,42 +17,45 @@ int keyboard_poll(controller *ctrl, ctrl_event **ev) {
     keyboard *k = ctrl->data;
     ctrl->current = 0;
     const unsigned char *state = SDL_GetKeyboardState(NULL);
+    int action = 0;
     if(state[k->keys->jump_left]) {
-        keyboard_cmd(ctrl, ACT_UP | ACT_LEFT, ev);
+        action = ACT_UP | ACT_LEFT;
     } else if(state[k->keys->duck_back]) {
-        keyboard_cmd(ctrl, ACT_DOWN | ACT_LEFT, ev);
+        action = ACT_DOWN | ACT_LEFT;
     } else if(state[k->keys->jump_right]) {
-        keyboard_cmd(ctrl, ACT_UP | ACT_RIGHT, ev);
+        action = ACT_UP | ACT_RIGHT;
     } else if(state[k->keys->duck_forward]) {
-        keyboard_cmd(ctrl, ACT_DOWN | ACT_RIGHT, ev);
-    }
-
-    if(state[k->keys->walk_back] && state[k->keys->jump_up]) {
-        keyboard_cmd(ctrl, ACT_UP | ACT_LEFT, ev);
+        action = ACT_DOWN | ACT_RIGHT;
+    } else if(state[k->keys->walk_back] && state[k->keys->jump_up]) {
+        action = ACT_UP | ACT_LEFT;
     } else if(state[k->keys->walk_back] && state[k->keys->duck]) {
-        keyboard_cmd(ctrl, ACT_DOWN | ACT_LEFT, ev);
+        action = ACT_DOWN | ACT_LEFT;
     } else if(state[k->keys->walk_right] && state[k->keys->jump_up]) {
-        keyboard_cmd(ctrl, ACT_UP | ACT_RIGHT, ev);
+        action = ACT_UP | ACT_RIGHT;
     } else if(state[k->keys->walk_right] && state[k->keys->duck]) {
-        keyboard_cmd(ctrl, ACT_DOWN | ACT_RIGHT, ev);
+        action = ACT_DOWN | ACT_RIGHT;
     } else if(state[k->keys->walk_right]) {
-        keyboard_cmd(ctrl, ACT_RIGHT, ev);
+        action = ACT_RIGHT;
     } else if(state[k->keys->walk_back]) {
-        keyboard_cmd(ctrl, ACT_LEFT, ev);
+        action = ACT_LEFT;
     } else if(state[k->keys->jump_up]) {
-        keyboard_cmd(ctrl, ACT_UP, ev);
+        action = ACT_UP;
     } else if(state[k->keys->duck]) {
-        keyboard_cmd(ctrl, ACT_DOWN, ev);
+        action = ACT_DOWN;
     }
 
     if(state[k->keys->punch]) {
-        keyboard_cmd(ctrl, ACT_PUNCH, ev);
-    } else if(state[k->keys->kick]) {
-        keyboard_cmd(ctrl, ACT_KICK, ev);
+        action |= ACT_PUNCH;
     }
 
-    if(ctrl->current == 0) {
+    if(state[k->keys->kick]) {
+        action |= ACT_KICK;
+    }
+
+    if(action == 0) {
         keyboard_cmd(ctrl, ACT_STOP, ev);
+    } else {
+        keyboard_cmd(ctrl, action, ev);
     }
 
     ctrl->last = ctrl->current;

--- a/src/controller/rec_controller.c
+++ b/src/controller/rec_controller.c
@@ -7,7 +7,6 @@
 typedef struct {
     int id;
     uint32_t last_tick;
-    int last_action;
     uint32_t max_tick;
     hashmap tick_lookup;
 } wtf;
@@ -20,7 +19,8 @@ void rec_controller_free(controller *ctrl) {
     }
 }
 
-int rec_controller_tick(controller *ctrl, uint32_t ticks, ctrl_event **ev) {
+int rec_controller_poll(controller *ctrl, ctrl_event **ev) {
+    uint32_t ticks = ctrl->gs->int_tick;
     wtf *data = ctrl->data;
     sd_rec_move *move;
     unsigned int len;
@@ -34,14 +34,7 @@ int rec_controller_tick(controller *ctrl, uint32_t ticks, ctrl_event **ev) {
         if(hashmap_get_int(&data->tick_lookup, ticks, (void **)(&move), &len) == 0) {
             if(move->action == SD_ACT_NONE) {
                 controller_cmd(ctrl, ACT_STOP, ev);
-                data->last_action = ACT_STOP;
             } else {
-                if(move->action & SD_ACT_PUNCH) {
-                    controller_cmd(ctrl, ACT_PUNCH, ev);
-                } else if(move->action & SD_ACT_KICK) {
-                    controller_cmd(ctrl, ACT_KICK, ev);
-                }
-
                 int action = 0;
                 if(move->action & SD_ACT_UP) {
                     action |= ACT_UP;
@@ -58,15 +51,17 @@ int rec_controller_tick(controller *ctrl, uint32_t ticks, ctrl_event **ev) {
                 if(move->action & SD_ACT_RIGHT) {
                     action |= ACT_RIGHT;
                 }
+                if(move->action & SD_ACT_PUNCH) {
+                    action |= ACT_PUNCH;
+                }
+                if(move->action & SD_ACT_KICK) {
+                    action |= ACT_KICK;
+                }
+
                 if(action != 0) {
                     controller_cmd(ctrl, action, ev);
-                    data->last_action = action;
-                } else {
-                    data->last_action = ACT_STOP;
                 }
             }
-        } else {
-            controller_cmd(ctrl, data->last_action, ev);
         }
     }
     data->last_tick = ticks;
@@ -75,7 +70,6 @@ int rec_controller_tick(controller *ctrl, uint32_t ticks, ctrl_event **ev) {
 
 void rec_controller_create(controller *ctrl, int player, sd_rec_file *rec) {
     wtf *data = omf_calloc(1, sizeof(wtf));
-    data->last_action = ACT_STOP;
     data->last_tick = 0;
     hashmap_create(&data->tick_lookup);
     for(unsigned int i = 0; i < rec->move_count; i++) {
@@ -87,6 +81,6 @@ void rec_controller_create(controller *ctrl, int player, sd_rec_file *rec) {
     log_debug("max tick is %" PRIu32, data->last_tick);
     ctrl->data = data;
     ctrl->type = CTRL_TYPE_REC;
-    ctrl->dyntick_fun = &rec_controller_tick;
+    ctrl->poll_fun = &rec_controller_poll;
     ctrl->free_fun = &rec_controller_free;
 }

--- a/src/engine.c
+++ b/src/engine.c
@@ -3,6 +3,7 @@
 #include "console/console.h"
 #include "controller/controller.h"
 #include "formats/altpal.h"
+#include "formats/rec.h"
 #include "game/game_player.h"
 #include "game/game_state.h"
 #include "game/gui/text_render.h"
@@ -110,6 +111,17 @@ void save_palette_shot(void) {
     omf_free(time);
 }
 
+void save_rec(game_state *gs) {
+    char *time = format_time();
+    char *filename = omf_malloc(256);
+    snprintf(filename, 256, "%s.rec", time);
+    sd_rec_finish(gs->rec, gs->int_tick);
+    sd_rec_save(gs->rec, filename);
+    log_debug("REC saved: %s", filename);
+    omf_free(filename);
+    omf_free(time);
+}
+
 void engine_run(engine_init_flags *init_flags) {
     SDL_Event e;
     int visual_debugger = 0;
@@ -169,6 +181,11 @@ void engine_run(engine_init_flags *init_flags) {
                     }
                     if(e.key.keysym.sym == SDLK_F2) {
                         save_palette_shot();
+                    }
+                    if(e.key.keysym.sym == SDLK_F3) {
+                        if(init_flags->playback != 1) {
+                            save_rec(gs);
+                        }
                     }
                     if(e.key.keysym.sym == SDLK_F9) {
                         video_draw_atlas(true);

--- a/src/engine.h
+++ b/src/engine.h
@@ -7,6 +7,7 @@
 typedef struct engine_init_flags_t {
     unsigned int net_mode;
     unsigned int record;
+    unsigned int playback;
     char force_renderer[16];
     char force_audio_backend[16];
     char rec_file[255];

--- a/src/formats/rec.c
+++ b/src/formats/rec.c
@@ -328,3 +328,15 @@ int sd_rec_insert_action(sd_rec_file *rec, unsigned int number, const sd_rec_mov
     rec->move_count++;
     return SD_SUCCESS;
 }
+
+void sd_rec_finish(sd_rec_file *rec, unsigned int ticks) {
+    sd_rec_move move;
+
+    memset(&move, 0, sizeof(move));
+    move.tick = ticks;
+    move.lookup_id = 2;
+    move.player_id = 0;
+    move.action = 0;
+
+    sd_rec_insert_action(rec, rec->move_count, &move);
+}

--- a/src/formats/rec.c
+++ b/src/formats/rec.c
@@ -87,15 +87,15 @@ int sd_rec_load(sd_rec_file *rec, const char *file) {
     // Other flags
     rec->unknown_a = sd_read_byte(r);
     rec->unknown_b = sd_read_byte(r);
-    rec->unknown_c = sd_read_byte(r);
+    rec->game_mode = sd_read_byte(r);
     rec->throw_range = sd_read_word(r);
     rec->hit_pause = sd_read_word(r);
     rec->block_damage = sd_read_word(r);
     rec->vitality = sd_read_word(r);
     rec->jump_height = sd_read_word(r);
-    rec->unknown_i = sd_read_word(r);
-    rec->unknown_j = sd_read_word(r);
-    rec->unknown_k = sd_read_word(r);
+    rec->p1_controller = sd_read_word(r);
+    rec->p2_controller = sd_read_word(r);
+    rec->p2_controller_ = sd_read_word(r);
     uint32_t in = sd_read_udword(r);
     rec->knock_down = (in >> 0) & 0x03;  // 00000000 00000000 00000000 00000011 (2)
     rec->rehit_mode = (in >> 2) & 0x01;  // 00000000 00000000 00000000 00000100 (1)
@@ -213,15 +213,15 @@ int sd_rec_save(sd_rec_file *rec, const char *file) {
     // Other header data
     sd_write_byte(w, rec->unknown_a);
     sd_write_byte(w, rec->unknown_b);
-    sd_write_byte(w, rec->unknown_c);
+    sd_write_byte(w, rec->game_mode);
     sd_write_word(w, rec->throw_range);
     sd_write_word(w, rec->hit_pause);
     sd_write_word(w, rec->block_damage);
     sd_write_word(w, rec->vitality);
     sd_write_word(w, rec->jump_height);
-    sd_write_word(w, rec->unknown_i);
-    sd_write_word(w, rec->unknown_j);
-    sd_write_word(w, rec->unknown_k);
+    sd_write_word(w, rec->p1_controller);
+    sd_write_word(w, rec->p2_controller);
+    sd_write_word(w, rec->p2_controller_);
     uint32_t out = 0;
     out |= (rec->knock_down & 0x3) << 0;
     out |= (rec->rehit_mode & 0x1) << 2;

--- a/src/formats/rec.h
+++ b/src/formats/rec.h
@@ -164,4 +164,8 @@ int sd_rec_extra_len(int key);
  */
 int sd_rec_insert_action(sd_rec_file *rec, unsigned int number, const sd_rec_move *move);
 
+/*! \brief Insert a closing ACT_NONE on a rec at `ticks`
+ */
+void sd_rec_finish(sd_rec_file *rec, unsigned int ticks);
+
 #endif // SD_REC_H

--- a/src/formats/rec.h
+++ b/src/formats/rec.h
@@ -57,16 +57,18 @@ typedef struct {
     uint32_t scores[2];     ///< Score data at the start of the match
     int8_t unknown_a;       ///< Is Fire or ice ? 0 = no, 1 = fire, 2 = ice ?
     int8_t unknown_b;       ///< Unknown \todo: Find out
-    int8_t unknown_c;       ///< Unknown \todo: Find out
+    int8_t game_mode;       ///< 1 is tournament, 2 is 1/2 player
 
-    int16_t throw_range;  ///< Throw range (%)
-    int16_t hit_pause;    ///< Hit pause (ticks)
-    int16_t block_damage; ///< Block damage (%)
-    int16_t vitality;     ///< Vitality (%)
-    int16_t jump_height;  ///< Jump height (%)
-    int16_t unknown_i;    ///< Unknown \todo: Find out
-    int16_t unknown_j;    ///< Unknown \todo: Find out
-    int16_t unknown_k;    ///< Unknown \todo: Find out
+    int16_t throw_range;    ///< Throw range (%)
+    int16_t hit_pause;      ///< Hit pause (ticks)
+    int16_t block_damage;   ///< Block damage (%)
+    int16_t vitality;       ///< Vitality (%)
+    int16_t jump_height;    ///< Jump height (%)
+    int16_t p1_controller;  ///< 1-Custom 3-Joystick1 4-Joystick2 6-Network 7-Left Keyboard 8-Right Keyboard
+    int16_t p2_controller;  ///< 2-Custom 3-Joystick1 4-Joystick2 5-AI 6-Network 7-Left Keyboard 8-Right Keyboard 9-REC
+                            ///< Replay (can change at runtime)
+    int16_t p2_controller_; ///< 2-Custom 3-Joystick1 4-Joystick2 5-AI 6-Network 7-Left Keyboard 8-Right Keyboard 9-REC
+                            ///< Replay (static version)
 
     uint8_t knock_down; ///< Knock down (0 = None, 1 = Kicks, 2 = Punches, 3 = both)
     uint8_t rehit_mode; ///< Rehit mode (On/Off)

--- a/src/formats/setup.h
+++ b/src/formats/setup.h
@@ -54,9 +54,11 @@ static_assert(4 == sizeof(gflags3), "gflags3 should pack into 4 bytes");
 typedef struct {
     uint8_t game_speed;
     char unknown_a[211];
-    uint16_t unknown_b;
-    uint16_t unknown_c;
-    uint16_t unknown_d;
+    uint16_t p1_controller;  // 1-Custom 3-Joystick1 4-Joystick2 7-Left Keyboard 8-Right Keyboard
+    uint16_t p2_controller;  // 2-Custom 3-Joystick1 4-Joystick2 5-AI 7-Left Keyboard 8-Right Keyboard 9-REC Replay (can
+                             // change at runtime)
+    uint16_t p2_controller_; // 2-Custom 3-Joystick1 4-Joystick2 5-AI 7-Left Keyboard 8-Right Keyboard 9-REC Replay
+                             // (static version)
     char unknown_e[18];
     uint8_t difficulty;
     uint8_t unknown_g;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -6,7 +6,6 @@
 #include "controller/rec_controller.h"
 #include "formats/error.h"
 #include "formats/pilot.h"
-#include "formats/rec.h"
 #include "game/common_defines.h"
 #include "game/protos/object.h"
 #include "game/protos/scene.h"
@@ -112,16 +111,16 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
 
     reconfigure_controller(gs);
     int nscene;
-    if(strlen(init_flags->rec_file) > 0 && init_flags->record == 0) {
-        sd_rec_file rec;
-        sd_rec_create(&rec);
-        int ret = sd_rec_load(&rec, init_flags->rec_file);
+    if(strlen(init_flags->rec_file) > 0 && init_flags->playback == 1) {
+        gs->rec = omf_malloc(sizeof(sd_rec_file));
+        sd_rec_create(gs->rec);
+        int ret = sd_rec_load(gs->rec, init_flags->rec_file);
         if(ret != SD_SUCCESS) {
             log_error("Unable to load recording %s.", init_flags->rec_file);
             goto error_0;
         }
 
-        nscene = SCENE_ARENA0 + rec.arena_id;
+        nscene = SCENE_ARENA0 + gs->rec->arena_id;
         log_debug("playing recording file %s", init_flags->rec_file);
         gs->this_id = nscene;
         gs->next_id = nscene;
@@ -133,26 +132,26 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
 
         // set the HAR colors, pilot, har type and and pilot and HAR stats
         for(int i = 0; i < 2; i++) {
-            sd_pilot_set_player_color(gs->players[i]->pilot, PRIMARY, rec.pilots[i].info.color_3);
-            sd_pilot_set_player_color(gs->players[i]->pilot, SECONDARY, rec.pilots[i].info.color_2);
-            sd_pilot_set_player_color(gs->players[i]->pilot, TERTIARY, rec.pilots[i].info.color_1);
-            gs->players[i]->pilot->har_id = HAR_JAGUAR + rec.pilots[i].info.har_id;
-            gs->players[i]->pilot->pilot_id = rec.pilots[i].info.pilot_id;
-            gs->players[i]->pilot->agility = rec.pilots[i].info.agility;
-            gs->players[i]->pilot->power = rec.pilots[i].info.power;
-            gs->players[i]->pilot->endurance = rec.pilots[i].info.endurance;
-            gs->players[i]->pilot->leg_speed = rec.pilots[i].info.leg_speed;
-            gs->players[i]->pilot->arm_speed = rec.pilots[i].info.arm_speed;
-            gs->players[i]->pilot->leg_power = rec.pilots[i].info.leg_power;
-            gs->players[i]->pilot->arm_power = rec.pilots[i].info.arm_power;
-            gs->players[i]->pilot->armor = rec.pilots[i].info.armor;
-            gs->players[i]->pilot->stun_resistance = rec.pilots[i].info.stun_resistance;
+            sd_pilot_set_player_color(gs->players[i]->pilot, PRIMARY, gs->rec->pilots[i].info.color_3);
+            sd_pilot_set_player_color(gs->players[i]->pilot, SECONDARY, gs->rec->pilots[i].info.color_2);
+            sd_pilot_set_player_color(gs->players[i]->pilot, TERTIARY, gs->rec->pilots[i].info.color_1);
+            gs->players[i]->pilot->har_id = HAR_JAGUAR + gs->rec->pilots[i].info.har_id;
+            gs->players[i]->pilot->pilot_id = gs->rec->pilots[i].info.pilot_id;
+            gs->players[i]->pilot->agility = gs->rec->pilots[i].info.agility;
+            gs->players[i]->pilot->power = gs->rec->pilots[i].info.power;
+            gs->players[i]->pilot->endurance = gs->rec->pilots[i].info.endurance;
+            gs->players[i]->pilot->leg_speed = gs->rec->pilots[i].info.leg_speed;
+            gs->players[i]->pilot->arm_speed = gs->rec->pilots[i].info.arm_speed;
+            gs->players[i]->pilot->leg_power = gs->rec->pilots[i].info.leg_power;
+            gs->players[i]->pilot->arm_power = gs->rec->pilots[i].info.arm_power;
+            gs->players[i]->pilot->armor = gs->rec->pilots[i].info.armor;
+            gs->players[i]->pilot->stun_resistance = gs->rec->pilots[i].info.stun_resistance;
         }
 
         // XXX use playback controller once it exista
 
-        _setup_rec_controller(gs, 0, &rec);
-        _setup_rec_controller(gs, 1, &rec);
+        _setup_rec_controller(gs, 0, gs->rec);
+        _setup_rec_controller(gs, 1, gs->rec);
         if(arena_create(gs->sc)) {
             log_error("Error while creating arena scene.");
             goto error_1;
@@ -1096,6 +1095,11 @@ void game_state_free(game_state **_gs) {
     // Free scene
     scene_free(gs->sc);
     omf_free(gs->sc);
+
+    if(gs->rec) {
+        sd_rec_free(gs->rec);
+        omf_free(gs->rec);
+    }
 
     // Free players
     for(int i = 0; i < 2; i++) {

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -131,13 +131,22 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
             goto error_0;
         }
 
-        // set the HAR colors, pilot, har type
+        // set the HAR colors, pilot, har type and and pilot and HAR stats
         for(int i = 0; i < 2; i++) {
             sd_pilot_set_player_color(gs->players[i]->pilot, PRIMARY, rec.pilots[i].info.color_3);
             sd_pilot_set_player_color(gs->players[i]->pilot, SECONDARY, rec.pilots[i].info.color_2);
             sd_pilot_set_player_color(gs->players[i]->pilot, TERTIARY, rec.pilots[i].info.color_1);
             gs->players[i]->pilot->har_id = HAR_JAGUAR + rec.pilots[i].info.har_id;
             gs->players[i]->pilot->pilot_id = rec.pilots[i].info.pilot_id;
+            gs->players[i]->pilot->agility = rec.pilots[i].info.agility;
+            gs->players[i]->pilot->power = rec.pilots[i].info.power;
+            gs->players[i]->pilot->endurance = rec.pilots[i].info.endurance;
+            gs->players[i]->pilot->leg_speed = rec.pilots[i].info.leg_speed;
+            gs->players[i]->pilot->arm_speed = rec.pilots[i].info.arm_speed;
+            gs->players[i]->pilot->leg_power = rec.pilots[i].info.leg_power;
+            gs->players[i]->pilot->arm_power = rec.pilots[i].info.arm_power;
+            gs->players[i]->pilot->armor = rec.pilots[i].info.armor;
+            gs->players[i]->pilot->stun_resistance = rec.pilots[i].info.stun_resistance;
         }
 
         // XXX use playback controller once it exista

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "engine.h"
+#include "formats/rec.h"
 #include "game/protos/fight_stats.h"
 #include "utils/random.h"
 #include "utils/vector.h"
@@ -75,6 +76,8 @@ typedef struct game_state_t {
     bool clone;
     int delay;
     struct random_t rand;
+
+    sd_rec_file *rec;
 
     controller *menu_ctrl;
 } game_state;

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1589,10 +1589,16 @@ void add_input_to_buffer(char *buf, char c) {
 }
 
 void add_input(char *buf, int act_type, int direction) {
+
+    if(act_type == ACT_NONE) {
+        return;
+    }
     // for the reason behind the numbers, look at a numpad sometime
-    switch(act_type) {
+    switch(act_type & ~(ACT_PUNCH | ACT_KICK)) {
         case ACT_NONE:
-            return;
+            // make sure punches and kicks on their own frame are separated from previous input
+            add_input_to_buffer(buf, '5');
+            break;
         case ACT_UP:
             add_input_to_buffer(buf, '8');
             break;
@@ -1641,18 +1647,24 @@ void add_input(char *buf, int act_type, int direction) {
                 add_input_to_buffer(buf, '1');
             }
             break;
-        case ACT_KICK:
-            add_input_to_buffer(buf, 'K');
-            break;
-        case ACT_PUNCH:
-            add_input_to_buffer(buf, 'P');
-            break;
         case ACT_STOP:
-            add_input_to_buffer(buf, '5');
+            // might just be kick or punch, check below
             break;
         default:
             log_warn("Ignored input: buf %s, act_type 0x%x, direction %d", buf, act_type, direction);
             assert(false);
+    }
+
+    if(act_type & ACT_KICK) {
+        add_input_to_buffer(buf, 'K');
+    }
+
+    if(act_type & ACT_PUNCH) {
+        add_input_to_buffer(buf, 'P');
+    }
+
+    if(act_type == ACT_STOP) {
+        add_input_to_buffer(buf, '5');
     }
 }
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1711,12 +1711,40 @@ int arena_create(scene *scene) {
             log_debug("player %d using har %d", i, player->pilot->har_id);
             local->rec->pilots[i].info.har_id = (unsigned char)player->pilot->har_id;
             local->rec->pilots[i].info.pilot_id = player->pilot->pilot_id;
-            local->rec->pilots[i].info.color_1 = player->pilot->color_1;
+            local->rec->pilots[i].info.color_3 = player->pilot->color_1;
             local->rec->pilots[i].info.color_2 = player->pilot->color_2;
-            local->rec->pilots[i].info.color_3 = player->pilot->color_3;
-            memcpy(local->rec->pilots[i].info.name, lang_get(player->pilot->pilot_id + 20), 18);
+            local->rec->pilots[i].info.color_1 = player->pilot->color_3;
+            local->rec->pilots[i].info.agility = player->pilot->agility;
+            local->rec->pilots[i].info.power = player->pilot->power;
+            local->rec->pilots[i].info.endurance = player->pilot->endurance;
+            local->rec->pilots[i].info.arm_speed = player->pilot->arm_speed;
+            local->rec->pilots[i].info.leg_speed = player->pilot->leg_speed;
+            local->rec->pilots[i].info.arm_power = player->pilot->arm_power;
+            local->rec->pilots[i].info.leg_power = player->pilot->leg_power;
+            local->rec->pilots[i].info.armor = player->pilot->armor;
+            local->rec->pilots[i].info.stun_resistance = player->pilot->stun_resistance;
+            memset(local->rec->pilots[i].info.name, 0, 18);
+            strncpy(local->rec->pilots[i].info.name, lang_get(player->pilot->pilot_id + 20), 18);
+            char *nl;
+            if((nl = strchr(local->rec->pilots[i].info.name, '\n'))) {
+                *nl = 0;
+            }
         }
         local->rec->arena_id = scene->id - SCENE_ARENA0;
+
+        // TODO hardcode some values here
+        local->rec->unknown_c = 2;
+        local->rec->unknown_i = 1;
+        local->rec->unknown_j = 7;
+        local->rec->unknown_k = 7;
+
+        local->rec->throw_range = 100;
+        local->rec->hit_pause = 10;
+        local->rec->vitality = 100;
+        local->rec->jump_height = 100;
+
+        local->rec->power[0] = 7;
+        local->rec->power[1] = 2;
     } else {
         local->rec = NULL;
     }

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1746,12 +1746,46 @@ int arena_create(scene *scene) {
             }
         }
         local->rec->arena_id = scene->id - SCENE_ARENA0;
+        local->rec->game_mode = is_tournament(scene->gs) ? 1 : 2;
 
-        // hardcode some values here, we don't know what they do, but we copied them from a REC from the original engine
-        local->rec->unknown_c = 2;
-        local->rec->unknown_i = 1;
-        local->rec->unknown_j = 7;
-        local->rec->unknown_k = 7;
+        // player 1's controller
+        switch(game_state_get_player(scene->gs, 0)->ctrl->type) {
+            case CTRL_TYPE_KEYBOARD:
+                // TODO figure out the actual keyboard type custom vs left vs right
+                local->rec->p1_controller = 8; // right keyboard
+                break;
+            case CTRL_TYPE_GAMEPAD:
+                local->rec->p1_controller = 3; // joystick 1
+                break;
+            case CTRL_TYPE_AI:
+                local->rec->p1_controller = 5; // AI
+                break;
+            case CTRL_TYPE_NETWORK:
+                local->rec->p1_controller = 6; // network
+                break;
+            default:
+                assert(false);
+        }
+
+        // player 2's controller
+        switch(game_state_get_player(scene->gs, 0)->ctrl->type) {
+            case CTRL_TYPE_KEYBOARD:
+                // TODO figure out the actual keyboard type custom vs left vs right
+                local->rec->p1_controller = 7; // left keyboard
+                break;
+            case CTRL_TYPE_GAMEPAD:
+                local->rec->p1_controller = 4; // joystick 1
+                break;
+            case CTRL_TYPE_AI:
+                local->rec->p1_controller = 5; // AI
+                break;
+            case CTRL_TYPE_NETWORK:
+                local->rec->p1_controller = 6; // network
+                break;
+            default:
+                assert(false);
+        }
+        local->rec->p2_controller_ = local->rec->p2_controller;
 
         local->rec->throw_range = 100;
         local->rec->hit_pause = 10;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1771,21 +1771,32 @@ int arena_create(scene *scene) {
         switch(game_state_get_player(scene->gs, 0)->ctrl->type) {
             case CTRL_TYPE_KEYBOARD:
                 // TODO figure out the actual keyboard type custom vs left vs right
-                local->rec->p1_controller = 7; // left keyboard
+                local->rec->p2_controller = 7; // left keyboard
                 break;
             case CTRL_TYPE_GAMEPAD:
-                local->rec->p1_controller = 4; // joystick 1
+                local->rec->p2_controller = 4; // joystick 2
                 break;
             case CTRL_TYPE_AI:
-                local->rec->p1_controller = 5; // AI
+                local->rec->p2_controller = 5; // AI
                 break;
             case CTRL_TYPE_NETWORK:
-                local->rec->p1_controller = 6; // network
+                local->rec->p2_controller = 6; // network
                 break;
             default:
                 assert(false);
         }
-        local->rec->p2_controller_ = local->rec->p2_controller;
+
+        // this is how p2 is actually configured
+        switch(settings_get()->keys.ctrl_type1) {
+            case CTRL_TYPE_KEYBOARD:
+                local->rec->p2_controller_ = 7;
+                break;
+            case CTRL_TYPE_GAMEPAD:
+                local->rec->p2_controller_ = 4; // joystick 2
+                break;
+            default:
+                assert(false);
+        }
 
         local->rec->throw_range = 100;
         local->rec->hit_pause = 10;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -963,7 +963,11 @@ int arena_handle_events(scene *scene, game_player *player, ctrl_event *i) {
             if(i->type == EVENT_TYPE_ACTION) {
                 need_sync += object_act(game_state_find_object(scene->gs, game_player_get_har_obj_id(player)),
                                         i->event_data.action);
-                write_rec_move(scene, player, i->event_data.action);
+
+                if(!is_netplay(scene->gs)) {
+                    // netplay will manage its own REC events
+                    write_rec_move(scene, player, i->event_data.action);
+                }
             } else if(i->type == EVENT_TYPE_CLOSE) {
                 if(player->ctrl->type == CTRL_TYPE_REC) {
                     game_state_set_next(scene->gs, SCENE_NONE);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1747,7 +1747,7 @@ int arena_create(scene *scene) {
         }
         local->rec->arena_id = scene->id - SCENE_ARENA0;
 
-        // TODO hardcode some values here
+        // hardcode some values here, we don't know what they do, but we copied them from a REC from the original engine
         local->rec->unknown_c = 2;
         local->rec->unknown_i = 1;
         local->rec->unknown_j = 7;

--- a/src/main.c
+++ b/src/main.c
@@ -143,6 +143,7 @@ int main(int argc, char *argv[]) {
     } else if(lobby->count > 0) {
         init_flags.net_mode = NET_MODE_LOBBY;
     } else if(play->count > 0) {
+        init_flags.playback = 1;
         strncpy(init_flags.rec_file, play->filename[0], 254);
     } else if(rec->count > 0) {
         init_flags.record = 1;

--- a/tools/rectool/main.c
+++ b/tools/rectool/main.c
@@ -45,6 +45,11 @@ static const char *match_type[] = {"One match", "2 out of 3", "3 out of 5", "4 o
 
 static const char *knockdown_text[] = {"None", "Kicks", "Punches", "Both"};
 
+static const char *game_mode_text[] = {"?", "Tournament", "1/2 player"};
+
+static const char *controller_text[] = {"?",  "1P Custom", "2P Custom",     "Joystick 1",     "Joystick 2",
+                                        "AI", "Network",   "Left Keyboard", "Right Keyboard", "Replay"};
+
 void print_rec_root_info(sd_rec_file *rec) {
     if(rec != NULL) {
         // Print enemy data
@@ -60,15 +65,15 @@ void print_rec_root_info(sd_rec_file *rec) {
         printf("  - Score B:      %d\n", rec->scores[1]);
         printf("  - Unknown A:    %d\n", rec->unknown_a);
         printf("  - Unknown B:    %d\n", rec->unknown_b);
-        printf("  - Unknown C:    %d\n", rec->unknown_c);
+        printf("  - Game Mode:    %s\n", game_mode_text[rec->game_mode]);
         printf("  - Throw Range:  %d\n", rec->throw_range);
         printf("  - Hit Pause:    %d\n", rec->hit_pause);
         printf("  - Block Damage: %d\n", rec->block_damage);
         printf("  - Vitality:     %d\n", rec->vitality);
         printf("  - Jump Height:  %d\n", rec->jump_height);
-        printf("  - Unknown I:    %d\n", rec->unknown_i);
-        printf("  - Unknown J:    %d\n", rec->unknown_j);
-        printf("  - Unknown K:    %d\n", rec->unknown_k);
+        printf("  - P1 Control:   %s\n", controller_text[rec->p1_controller]);
+        printf("  - P2 Control:   %s\n", controller_text[rec->p2_controller]);
+        printf("  - P2 Control:   %s\n", controller_text[rec->p2_controller_]);
         printf("  - Knock down:   %s\n", knockdown_text[rec->knock_down]);
         printf("  - Rehit mode:   %s\n", onoff[rec->rehit_mode]);
         printf("  - Def. throws:  %s\n", onoff[rec->def_throws]);

--- a/tools/setuptool/main.c
+++ b/tools/setuptool/main.c
@@ -33,6 +33,9 @@ static const char *match_type[] = {"One match", "2 out of 3", "3 out of 5", "4 o
 
 static const char *knockdown_text[] = {"None", "Kicks", "Punches", "Kicks & Punches"};
 
+static const char *controller_text[] = {"1P Custom", "2P Custom",     "Joystick 1",     "Joystick 2", "AI",
+                                        "Network",   "Left Keyboard", "Right Keyboard", "Replay"};
+
 void print_setup_root_info(sd_setup_file *setup) {
     if(setup == NULL) {
         return;
@@ -42,9 +45,9 @@ void print_setup_root_info(sd_setup_file *setup) {
     printf(" - Unknown A:\n");
     print_bytes(setup->unknown_a, sizeof(setup->unknown_a), 32, 3);
     printf("\n");
-    printf(" - Unknown B:     %d\n", setup->unknown_b);
-    printf(" - Unknown C:     %d\n", setup->unknown_c);
-    printf(" - Unknown D:     %d\n", setup->unknown_d);
+    printf(" - P1 controller:  %s\n", controller_text[setup->p1_controller]);
+    printf(" - P2 controller:  %s\n", controller_text[setup->p2_controller]);
+    printf(" - P2 controller:  %s\n", controller_text[setup->p2_controller]);
     printf(" - Unknown E:\n");
     print_bytes(setup->unknown_e, sizeof(setup->unknown_e), 32, 3);
     printf("\n");

--- a/tools/setuptool/main.c
+++ b/tools/setuptool/main.c
@@ -33,8 +33,8 @@ static const char *match_type[] = {"One match", "2 out of 3", "3 out of 5", "4 o
 
 static const char *knockdown_text[] = {"None", "Kicks", "Punches", "Kicks & Punches"};
 
-static const char *controller_text[] = {"1P Custom", "2P Custom",     "Joystick 1",     "Joystick 2", "AI",
-                                        "Network",   "Left Keyboard", "Right Keyboard", "Replay"};
+static const char *controller_text[] = {"?",  "1P Custom", "2P Custom",     "Joystick 1",     "Joystick 2",
+                                        "AI", "Network",   "Left Keyboard", "Right Keyboard", "Replay"};
 
 void print_setup_root_info(sd_setup_file *setup) {
     if(setup == NULL) {


### PR DESCRIPTION
This patch makes REC loading/saving/playback work again, it makes REC files that the original engine can load and play and it fixes several inaccuracies in OpenOMF's input system discovered when trying to make RECs behave the same in both engines.