### PR TITLE
Store gameplay affecting settings in a game_state struct

### DIFF
--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -87,6 +87,22 @@ void game_state_match_settings_reset(game_state *gs) {
     gs->match_settings.fight_mode = settings_get()->gameplay.fight_mode;
 }
 
+void game_state_match_settings_defaults(game_state *gs) {
+    gs->match_settings.throw_range = 100;
+    gs->match_settings.hit_pause = 10;
+    gs->match_settings.block_damage = 0;
+    gs->match_settings.vitality = 100;
+    gs->match_settings.jump_height = 100;
+    gs->match_settings.knock_down = KNOCK_DOWN_NONE;
+    gs->match_settings.rehit = false;
+    gs->match_settings.defensive_throws = false;
+    gs->match_settings.power1 = 5;
+    gs->match_settings.power2 = 5;
+    gs->match_settings.hazards = true;
+    gs->match_settings.rounds = 1;
+    gs->match_settings.fight_mode = false;
+}
+
 int game_state_create(game_state *gs, engine_init_flags *init_flags) {
     gs->run = 1;
     gs->paused = 0;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -71,7 +71,7 @@ typedef struct {
 } playing_sound;
 
 // reset the match settings to use all the settings. This is essentially 1/2 player mode & demo mode
-void match_settings_reset(game_state *gs) {
+void game_state_match_settings_reset(game_state *gs) {
     gs->match_settings.throw_range = settings_get()->advanced.throw_range;
     gs->match_settings.hit_pause = settings_get()->advanced.hit_pause;
     gs->match_settings.block_damage = settings_get()->advanced.block_damage;
@@ -98,7 +98,7 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
     gs->init_flags = init_flags;
     gs->new_state = NULL;
     gs->clone = false;
-    match_settings_reset(gs);
+    game_state_match_settings_reset(gs);
     vector_create(&gs->objects, sizeof(render_obj));
     vector_create(&gs->sounds, sizeof(playing_sound));
 
@@ -166,17 +166,19 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
             gs->players[i]->pilot->stun_resistance = gs->rec->pilots[i].info.stun_resistance;
         }
 
-        gs->match_settings.throw_range = rec.throw_range;
-        gs->match_settings.hit_pause = rec.hit_pause;
-        gs->match_settings.block_damage = rec.block_damage;
-        gs->match_settings.vitality = rec.vitality;
-        gs->match_settings.jump_height = rec.jump_height;
-        gs->match_settings.knock_down = rec.knock_down;
-        gs->match_settings.rehit = rec.rehit_mode;
-        gs->match_settings.defensive_throws = rec.def_throws;
-        gs->match_settings.hazards = rec.hazards;
-        gs->match_settings.rounds = rec.round_type;
-        gs->match_settings.fight_mode = rec.hyper_mode;
+        gs->match_settings.throw_range = gs->rec->throw_range;
+        gs->match_settings.hit_pause = gs->rec->hit_pause;
+        gs->match_settings.block_damage = gs->rec->block_damage;
+        gs->match_settings.vitality = gs->rec->vitality;
+        gs->match_settings.jump_height = gs->rec->jump_height;
+        gs->match_settings.knock_down = gs->rec->knock_down;
+        gs->match_settings.rehit = gs->rec->rehit_mode;
+        gs->match_settings.defensive_throws = gs->rec->def_throws;
+        gs->match_settings.power1 = gs->rec->power[0];
+        gs->match_settings.power2 = gs->rec->power[1];
+        gs->match_settings.hazards = gs->rec->hazards;
+        gs->match_settings.rounds = gs->rec->round_type;
+        gs->match_settings.fight_mode = gs->rec->hyper_mode;
 
         _setup_rec_controller(gs, 0, gs->rec);
         _setup_rec_controller(gs, 1, gs->rec);

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -70,6 +70,23 @@ typedef struct {
     int playback_id;
 } playing_sound;
 
+// reset the match settings to use all the settings. This is essentially 1/2 player mode & demo mode
+void match_settings_reset(game_state *gs) {
+    gs->match_settings.throw_range = settings_get()->advanced.throw_range;
+    gs->match_settings.hit_pause = settings_get()->advanced.hit_pause;
+    gs->match_settings.block_damage = settings_get()->advanced.block_damage;
+    gs->match_settings.vitality = settings_get()->advanced.vitality;
+    gs->match_settings.jump_height = settings_get()->advanced.jump_height;
+    gs->match_settings.knock_down = settings_get()->advanced.knock_down;
+    gs->match_settings.rehit = settings_get()->advanced.rehit_mode;
+    gs->match_settings.defensive_throws = settings_get()->advanced.defensive_throws;
+    gs->match_settings.power1 = settings_get()->gameplay.power1;
+    gs->match_settings.power2 = settings_get()->gameplay.power2;
+    gs->match_settings.hazards = settings_get()->gameplay.hazards_on;
+    gs->match_settings.rounds = settings_get()->gameplay.rounds;
+    gs->match_settings.fight_mode = settings_get()->gameplay.fight_mode;
+}
+
 int game_state_create(game_state *gs, engine_init_flags *init_flags) {
     gs->run = 1;
     gs->paused = 0;
@@ -81,6 +98,7 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
     gs->init_flags = init_flags;
     gs->new_state = NULL;
     gs->clone = false;
+    match_settings_reset(gs);
     vector_create(&gs->objects, sizeof(render_obj));
     vector_create(&gs->sounds, sizeof(playing_sound));
 
@@ -148,7 +166,17 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
             gs->players[i]->pilot->stun_resistance = gs->rec->pilots[i].info.stun_resistance;
         }
 
-        // XXX use playback controller once it exista
+        gs->match_settings.throw_range = rec.throw_range;
+        gs->match_settings.hit_pause = rec.hit_pause;
+        gs->match_settings.block_damage = rec.block_damage;
+        gs->match_settings.vitality = rec.vitality;
+        gs->match_settings.jump_height = rec.jump_height;
+        gs->match_settings.knock_down = rec.knock_down;
+        gs->match_settings.rehit = rec.rehit_mode;
+        gs->match_settings.defensive_throws = rec.def_throws;
+        gs->match_settings.hazards = rec.hazards;
+        gs->match_settings.rounds = rec.round_type;
+        gs->match_settings.fight_mode = rec.hyper_mode;
 
         _setup_rec_controller(gs, 0, gs->rec);
         _setup_rec_controller(gs, 1, gs->rec);

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -14,6 +14,7 @@ typedef struct object_t object;
 typedef struct ctrl_event_t ctrl_event;
 
 void game_state_match_settings_reset(game_state *gs);
+void game_state_match_settings_defaults(game_state *gs);
 int game_state_create(game_state *gs, engine_init_flags *init_flags);
 void game_state_free(game_state **gs);
 int game_state_handle_event(game_state *gs, SDL_Event *event);

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -13,6 +13,7 @@ typedef struct game_player_t game_player;
 typedef struct object_t object;
 typedef struct ctrl_event_t ctrl_event;
 
+void game_state_match_settings_reset(game_state *gs);
 int game_state_create(game_state *gs, engine_init_flags *init_flags);
 void game_state_free(game_state **gs);
 int game_state_handle_event(game_state *gs, SDL_Event *event);

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -37,7 +37,7 @@ typedef struct ticktimer_t ticktimer;
 typedef struct controller_t controller;
 
 // roughly modeled after the configuration in REC files
-typedef struct match_settings_t {
+typedef struct {
     uint8_t throw_range;
     uint8_t hit_pause;
     uint8_t block_damage;

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -36,14 +36,6 @@ typedef struct game_player_t game_player;
 typedef struct ticktimer_t ticktimer;
 typedef struct controller_t controller;
 
-typedef enum
-{
-    KNOCKDOWN_NONE,
-    KNOCKDOWN_KICKS,
-    KNOCKDOWN_PUNCHES,
-    KNOCKDOWN_BOTH
-} knockdown_type;
-
 // roughly modeled after the configuration in REC files
 typedef struct match_settings_t {
     uint8_t throw_range;

--- a/src/game/game_state_type.h
+++ b/src/game/game_state_type.h
@@ -6,6 +6,7 @@
 #include "engine.h"
 #include "formats/rec.h"
 #include "game/protos/fight_stats.h"
+#include "game/utils/settings.h"
 #include "utils/random.h"
 #include "utils/vector.h"
 
@@ -35,6 +36,31 @@ typedef struct game_player_t game_player;
 typedef struct ticktimer_t ticktimer;
 typedef struct controller_t controller;
 
+typedef enum
+{
+    KNOCKDOWN_NONE,
+    KNOCKDOWN_KICKS,
+    KNOCKDOWN_PUNCHES,
+    KNOCKDOWN_BOTH
+} knockdown_type;
+
+// roughly modeled after the configuration in REC files
+typedef struct match_settings_t {
+    uint8_t throw_range;
+    uint8_t hit_pause;
+    uint8_t block_damage;
+    uint8_t vitality;
+    uint8_t jump_height;
+    knock_down_mode knock_down;
+    bool rehit;
+    bool defensive_throws;
+    uint8_t power1;
+    uint8_t power2;
+    bool hazards;
+    uint8_t rounds;
+    bool fight_mode;
+} match_settings;
+
 typedef struct game_state_t {
     unsigned int run;
     unsigned int paused;
@@ -46,6 +72,8 @@ typedef struct game_state_t {
     unsigned int role;
     unsigned int speed;
     engine_init_flags *init_flags;
+
+    match_settings match_settings;
 
     // For screen shaking
     int screen_shake_horizontal;

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -2353,18 +2353,18 @@ int har_create(object *obj, af *af_data, int dir, int har_id, int pilot_id, int 
                 // projectiles have hyper mode, but may have extra_string_selector of 0
                 if(move->ani.extra_string_count > 0 && move->extra_string_selector != 1 &&
                    move->extra_string_selector != 2) {
-                    str *str = vector_get(&move->ani.extra_strings, fight_mode);
+                    str *str = vector_get(&move->ani.extra_strings, fight_mode ? 1 : 0);
                     if(str && str_size(str) != 0 && !str_equal_c(str, "!")) {
                         // its not the empty string and its not the string '!'
                         // so we should use it
-                        str_set(&move->ani.animation_string, vector_get(&move->ani.extra_strings, fight_mode));
+                        str_set(&move->ani.animation_string, vector_get(&move->ani.extra_strings, fight_mode ? 1 : 0));
                         log_debug("using %s mode string '%s' for animation %d on har %d",
-                                  fight_mode == 1 ? "hyper" : "normal", str_c(str), i, har_id);
+                                  fight_mode ? "hyper" : "normal", str_c(str), i, har_id);
                     }
                 }
             } else {
                 // normal or hyper
-                extra_index = fight_mode;
+                extra_index = fight_mode ? 1 : 0;
                 // Tournament Mode
                 // Damage = (Base Damage * (25 + Power) / 35 + 1) * leg/arm power / armor
                 // Stun = ((Base Damage * (35 + Power) / 45) * 2 + 12) * 256
@@ -2394,7 +2394,7 @@ int har_create(object *obj, af *af_data, int dir, int har_id, int pilot_id, int 
                                       pilot->enhancements[har_id], str_c(str), i, har_id);
                         } else {
                             log_debug("using %s mode string '%s' for animation %d on har %d",
-                                      fight_mode == 1 ? "hyper" : "normal", str_c(str), i, har_id);
+                                      fight_mode ? "hyper" : "normal", str_c(str), i, har_id);
                         }
                     }
                 }

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -15,7 +15,6 @@
 #include "game/protos/intersect.h"
 #include "game/scenes/arena.h"
 #include "game/utils/serial.h"
-#include "game/utils/settings.h"
 #include "resources/af_loader.h"
 #include "resources/animation.h"
 #include "resources/pilots.h"
@@ -2214,10 +2213,10 @@ int har_create(object *obj, af *af_data, int dir, int har_id, int pilot_id, int 
     sd_pilot *pilot = gp->pilot;
 
     // power 2 applies to player 1's health
-    int power = settings_get()->gameplay.power2;
+    int power = obj->gs->match_settings.power2;
     if(player_id == 1) {
         // power 1 applies to player 2's health
-        power = settings_get()->gameplay.power1;
+        power = obj->gs->match_settings.power1;
     }
 
     // see https://www.omf2097.com/wiki/doku.php?id=omf2097:stats
@@ -2338,7 +2337,7 @@ int har_create(object *obj, af *af_data, int dir, int har_id, int pilot_id, int 
 
     af_move *move;
     int extra_index;
-    int fight_mode = settings_get()->gameplay.fight_mode;
+    int fight_mode = obj->gs->match_settings.fight_mode;
     // apply pilot stats and HAR upgrades/enhancements/hyper mode to the HAR
     for(int i = 0; i < MAX_AF_MOVES; i++) {
         move = af_get_move(af_data, i);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1743,6 +1743,9 @@ int arena_create(scene *scene) {
             if((nl = strchr(local->rec->pilots[i].info.name, '\n'))) {
                 *nl = 0;
             }
+
+            // this is the score when the REC started
+            local->rec->scores[i] = game_player_get_score(player)->score;
         }
         local->rec->arena_id = scene->id - SCENE_ARENA0;
 
@@ -1752,13 +1755,21 @@ int arena_create(scene *scene) {
         local->rec->unknown_j = 7;
         local->rec->unknown_k = 7;
 
-        local->rec->throw_range = 100;
-        local->rec->hit_pause = 10;
-        local->rec->vitality = 100;
-        local->rec->jump_height = 100;
+        // capture the match settings
+        local->rec->throw_range = scene->gs->match_settings.throw_range;
+        local->rec->hit_pause = scene->gs->match_settings.hit_pause;
+        local->rec->block_damage = scene->gs->match_settings.block_damage;
+        local->rec->vitality = scene->gs->match_settings.vitality;
+        local->rec->jump_height = scene->gs->match_settings.jump_height;
+        local->rec->knock_down = scene->gs->match_settings.knock_down;
+        local->rec->rehit_mode = scene->gs->match_settings.rehit;
+        local->rec->def_throws = scene->gs->match_settings.defensive_throws;
+        local->rec->power[0] = scene->gs->match_settings.power1;
+        local->rec->power[1] = scene->gs->match_settings.power2;
+        local->rec->hazards = scene->gs->match_settings.hazards;
+        local->rec->round_type = scene->gs->match_settings.rounds;
+        local->rec->hyper_mode = scene->gs->match_settings.fight_mode;
 
-        local->rec->power[0] = 7;
-        local->rec->power[1] = 2;
     } else {
         local->rec = NULL;
     }

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1087,8 +1087,7 @@ void arena_dynamic_tick(scene *scene, int paused) {
 
         // Endings and beginnings
         if(local->state != ARENA_STATE_ENDING && local->state != ARENA_STATE_STARTING) {
-            settings *setting = settings_get();
-            if(setting->gameplay.hazards_on) {
+            if(scene->gs->match_settings.hazards) {
                 arena_spawn_hazard(scene);
             }
         }
@@ -1424,7 +1423,7 @@ int arena_create(scene *scene) {
     local->rein_enabled = 0;
 
     local->round = 0;
-    switch(setting->gameplay.rounds) {
+    switch(scene->gs->match_settings.rounds) {
         case 0:
             local->rounds = 1;
             break;

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -1430,8 +1430,8 @@ int lobby_create(scene *scene) {
 
     lobby_local *local;
 
-    // Load up settings
-    // setting = settings_get();
+    // force the match to use reasonable defaults
+    game_state_match_settings_defaults(scene->gs);
 
     fight_stats *fight_stats = &scene->gs->fight_stats;
     memset(fight_stats, 0, sizeof(*fight_stats));

--- a/src/game/scenes/mainmenu.c
+++ b/src/game/scenes/mainmenu.c
@@ -78,6 +78,9 @@ int mainmenu_create(scene *scene) {
     mainmenu_local *local = omf_calloc(1, sizeof(mainmenu_local));
     scene_set_userdata(scene, local);
 
+    // every time we enter the menu, reset the match settings to 1/2 player/demo mode
+    game_state_match_settings_reset(scene->gs);
+
     // fix up any jank from tournament mode
     game_player *player1 = game_state_get_player(scene->gs, 0);
     game_player *player2 = game_state_get_player(scene->gs, 1);

--- a/src/game/scenes/mainmenu/menu_connect.c
+++ b/src/game/scenes/mainmenu/menu_connect.c
@@ -190,6 +190,10 @@ void menu_connect_tick(component *c) {
         if(c1->type == CTRL_TYPE_NETWORK && net_controller_ready(c1)) {
             log_debug("network peer is ready, tick offset is %d and rtt is %d", net_controller_tick_offset(c1),
                       c1->rtt);
+
+            // force the match to use reasonable defaults
+            game_state_match_settings_defaults(gs);
+
             game_state_set_next(gs, SCENE_MELEE);
         }
     }

--- a/src/game/scenes/mainmenu/menu_listen.c
+++ b/src/game/scenes/mainmenu/menu_listen.c
@@ -100,6 +100,10 @@ void menu_listen_tick(component *c) {
                       c2->rtt);
             local->host = NULL;
             local->controllers_created = 0;
+
+            // force the match to use reasonable defaults
+            game_state_match_settings_defaults(gs);
+
             game_state_set_next(gs, SCENE_MELEE);
         }
     }

--- a/src/game/scenes/mechlab.c
+++ b/src/game/scenes/mechlab.c
@@ -485,6 +485,13 @@ int mechlab_create(scene *scene) {
     mechlab_local *local = omf_calloc(1, sizeof(mechlab_local));
     local->selling = false;
 
+    // reset the match settings and override the settings that don't apply in tournament mode
+    game_state_match_settings_reset(scene->gs);
+    scene->gs->match_settings.power1 = 5;
+    scene->gs->match_settings.power2 = 5;
+    scene->gs->match_settings.vitality = 100;
+    // TODO what others are there?
+
     animation *bg_ani[3];
 
     // Init the background

--- a/src/game/scenes/mechlab.c
+++ b/src/game/scenes/mechlab.c
@@ -490,7 +490,7 @@ int mechlab_create(scene *scene) {
     scene->gs->match_settings.power1 = 5;
     scene->gs->match_settings.power2 = 5;
     scene->gs->match_settings.vitality = 100;
-    // TODO what others are there?
+    scene->gs->match_settings.rounds = 0;
 
     animation *bg_ani[3];
 


### PR DESCRIPTION
This struct avoids direct access to the global settings. This is because in some cases (tournament mode, netplay, REC playback) we don't want to use the global settings blindly. For example some options are ignored in netplay mode (eg player 1/2 power), agreeing on the options for netplay should be handled differently, and REC files contain their own set of all the gameplay settings.