### PR TITLE
Fix Q tag implementation

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1118,7 +1118,7 @@ int har_collide_with_har(object *obj_a, object *obj_b, int loop) {
        (intersect_sprite_hitpoint(obj_a, obj_b, level, &hit_coord) || move->category == CAT_CLOSE ||
         (player_frame_isset(obj_a, "ue") && b->state != STATE_JUMPING))) {
 
-        obj_a->q_counter = player_frame_isset(obj_a, "q") ? player_frame_get(obj_ta, "q") : obj_a->q_counter;
+        obj_a->q_counter = player_frame_isset(obj_a, "q") ? player_frame_get(obj_a, "q") : obj_a->q_counter;
 
         if(har_is_blocking(b, move) &&
            // earthquake smash is unblockable

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1118,7 +1118,7 @@ int har_collide_with_har(object *obj_a, object *obj_b, int loop) {
        (intersect_sprite_hitpoint(obj_a, obj_b, level, &hit_coord) || move->category == CAT_CLOSE ||
         (player_frame_isset(obj_a, "ue") && b->state != STATE_JUMPING))) {
 
-        obj_a->q_counter++;
+        obj_a->q_counter = player_frame_isset(obj_a, "q") ? player_frame_get(obj_ta, "q") : obj_a->q_counter;
 
         if(har_is_blocking(b, move) &&
            // earthquake smash is unblockable

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1118,7 +1118,7 @@ int har_collide_with_har(object *obj_a, object *obj_b, int loop) {
        (intersect_sprite_hitpoint(obj_a, obj_b, level, &hit_coord) || move->category == CAT_CLOSE ||
         (player_frame_isset(obj_a, "ue") && b->state != STATE_JUMPING))) {
 
-        obj_a->q_counter = player_frame_isset(obj_a, "q") ? player_frame_get(obj_a, "q") : obj_a->q_counter;
+        obj_a->q_counter = obj_a->q_val;
 
         if(har_is_blocking(b, move) &&
            // earthquake smash is unblockable

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1113,11 +1113,12 @@ int har_collide_with_har(object *obj_a, object *obj_b, int loop) {
     if(obj_a->can_hit) {
         a->damage_done = 0;
         obj_a->can_hit = 0;
-        obj_a->hit_frames = 0;
     }
     if(a->damage_done == 0 &&
        (intersect_sprite_hitpoint(obj_a, obj_b, level, &hit_coord) || move->category == CAT_CLOSE ||
         (player_frame_isset(obj_a, "ue") && b->state != STATE_JUMPING))) {
+
+        obj_a->q_counter++;
 
         if(har_is_blocking(b, move) &&
            // earthquake smash is unblockable

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -74,8 +74,8 @@ void object_create(object *obj, game_state *gs, vec2i pos, vec2f vel) {
 
     random_seed(&obj->rand_state, rand_intmax());
 
-    // For enabling hit on the current and the next n-1 frames
-    obj->hit_frames = 0;
+    // For enabling multiple hits per move
+    obj->q_counter = 0;
     obj->can_hit = 0;
 
     // Callbacks & userdata

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -76,6 +76,7 @@ void object_create(object *obj, game_state *gs, vec2i pos, vec2f vel) {
 
     // For enabling multiple hits per move
     obj->q_counter = 0;
+    obj->q_val = 0;
     obj->can_hit = 0;
 
     // Callbacks & userdata

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -83,7 +83,7 @@ struct object_t {
     int8_t group;
 
     // Set by q tag
-    int8_t hit_frames;
+    int8_t q_counter;
     int8_t can_hit;
 
     int8_t orbit;

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -84,6 +84,7 @@ struct object_t {
 
     // Set by q tag
     int8_t q_counter;
+    int8_t q_val;
     int8_t can_hit;
 
     int8_t orbit;

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -627,8 +627,9 @@ void player_run(object *obj) {
             obj->orbit = 0;
         }
         if(sd_script_isset(frame, "q")) {
+            obj->q_val = sd_script_get(frame, "q");
             // Enable hit if the q value is higher than the hit count for this animation
-            if(sd_script_get(frame, "q") > obj->q_counter) {
+            if(obj->q_val > obj->q_counter) {
                 obj->can_hit = 1;
             }
         }

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -62,6 +62,7 @@ void player_reload_with_str(object *obj, const char *custom_str) {
     obj->enemy_slide_state.dest = vec2i_create(0, 0);
     obj->enemy_slide_state.duration = 0;
     obj->q_counter = 0;
+    obj->q_val = 0;
     obj->can_hit = 0;
 }
 

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -61,7 +61,7 @@ void player_reload_with_str(object *obj, const char *custom_str) {
     obj->enemy_slide_state.timer = 0;
     obj->enemy_slide_state.dest = vec2i_create(0, 0);
     obj->enemy_slide_state.duration = 0;
-    obj->hit_frames = 0;
+    obj->q_counter = 0;
     obj->can_hit = 0;
 }
 
@@ -627,12 +627,10 @@ void player_run(object *obj) {
             obj->orbit = 0;
         }
         if(sd_script_isset(frame, "q")) {
-            // Enable hit on the current and the next n-1 frames.
-            obj->hit_frames = sd_script_get(frame, "q");
-        }
-        if(obj->hit_frames > 0) {
-            obj->can_hit = 1;
-            obj->hit_frames--;
+            // Enable hit if the q value is higher than the hit count for this animation
+            if(sd_script_get(frame, "q") > obj->q_counter) {
+                obj->can_hit = 1;
+            }
         }
 
         // Set video effects now.


### PR DESCRIPTION
The Q tag should allow subsequent hits if the # of hits this move has made already is less than the value of Q. For example a move like A1-q2B1-q2C1 should only hit twice, the second hit coming either on the B or C frame, but A1-q2B1-q3C1 can hit 3 times.