### PR TITLE
Fix controller_cmd action debouncing

### DIFF
--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -89,7 +89,7 @@ void controller_cmd(controller *ctrl, int action, ctrl_event **ev) {
 
     if(action == ACT_NONE) {
         // above debouncing probably ate our action
-        return;
+        action = ACT_STOP;
     }
 
     // fire any installed hooks


### PR DESCRIPTION
this recently regressed with commit a80be6c4dde6efc6d7dcd027411577c85aa8aade, because the debouncing logic I wrote assumed actions would never be combined into one action bitmask (e.g. `ACT_PUNCH | ACT_RIGHT`)