### PR TITLE
Use fixed size string in video settings

### DIFF
--- a/src/game/scenes/mainmenu/menu_video.c
+++ b/src/game/scenes/mainmenu/menu_video.c
@@ -87,8 +87,7 @@ void renderer_toggled(component *c, void *userdata, int pos) {
     settings_video *v = &settings_get()->video;
     const char *renderer;
     video_get_renderer_info(pos, &renderer, NULL);
-    omf_free(v->renderer);
-    v->renderer = omf_strdup(renderer);
+    strncpy_or_abort(v->renderer, renderer, sizeof(v->renderer));
 }
 
 void menu_video_done(component *c, void *u) {
@@ -128,7 +127,6 @@ component *menu_video_create(scene *s) {
     // Menu userdata
     video_menu_data *local = omf_calloc(1, sizeof(video_menu_data));
     local->old_video_settings = settings_get()->video;
-    local->old_video_settings.renderer = omf_strdup(local->old_video_settings.renderer);
 
     // Load settings etc.
     const char *offon_opts[] = {"OFF", "ON"};

--- a/src/game/scenes/mainmenu/menu_video_confirm.c
+++ b/src/game/scenes/mainmenu/menu_video_confirm.c
@@ -20,7 +20,6 @@ void video_confirm_ok_clicked(component *c, void *userdata) {
     m->finished = 1;
 
     video_menu_confirm_data *local = userdata;
-    omf_free(local->old_video_settings->renderer);
     *local->old_video_settings = settings_get()->video;
 }
 
@@ -28,7 +27,6 @@ void video_confirm_cancel_clicked(component *c, void *userdata) {
     video_menu_confirm_data *local = userdata;
     settings_video *v = &settings_get()->video;
     bool render_plugin_changed = strcmp(v->renderer, local->old_video_settings->renderer) != 0;
-    omf_free(v->renderer);
     *v = *local->old_video_settings;
     if(render_plugin_changed) {
         video_close();

--- a/src/game/utils/settings.h
+++ b/src/game/utils/settings.h
@@ -40,7 +40,7 @@ typedef struct {
 } settings_language;
 
 typedef struct {
-    char *renderer;
+    char renderer[16];
     int screen_w;
     int screen_h;
     int vsync;

--- a/src/utils/c_string_util.c
+++ b/src/utils/c_string_util.c
@@ -12,8 +12,7 @@ char *strncpy_or_truncate(char *dest, const char *src, size_t n) {
 }
 
 char *strncpy_or_abort(char *dest, const char *src, size_t n) {
-    size_t len = strnlen(src, n);
-    assert(len < n);
+    size_t len = omf_strnlen_s(src, n);
     if(len >= n)
         abort();
     memcpy(dest, src, len + 1);

--- a/src/utils/c_string_util.c
+++ b/src/utils/c_string_util.c
@@ -11,6 +11,15 @@ char *strncpy_or_truncate(char *dest, const char *src, size_t n) {
     return ret;
 }
 
+char *strncpy_or_abort(char *dest, const char *src, size_t n) {
+    size_t len = strnlen(src, n);
+    assert(len < n);
+    if(len >= n)
+        abort();
+    memcpy(dest, src, len + 1);
+    return dest;
+}
+
 char *omf_strdup_real(char const *s, char const *file, int line) {
     assert(s != NULL);
     size_t valid_range = strlen(s) + 1;

--- a/src/utils/c_string_util.h
+++ b/src/utils/c_string_util.h
@@ -3,8 +3,11 @@
 
 #include <stddef.h>
 
-// strncpy() that guarantees null-termination.
+// strncpy() that guarantees null-termination by truncating the excess
 char *strncpy_or_truncate(char *dest, const char *src, size_t n);
+
+// strncpy() that guarantees null-termination by aborting on overflow
+char *strncpy_or_abort(char *dest, const char *src, size_t n);
 
 // strdup() that uses our allocator
 char *omf_strdup_real(char const *s, char const *file, int line);


### PR DESCRIPTION
While testing https://github.com/omf2097/openomf/pull/898, the video settings' "renderer" string was some version of wild free (could have been a bug from master? wasn't able to repro with openomf_0.7.2-524-g071faf17_windows.zip release)

ASan didn't feel like giving me any more info (no alloc site, first free site, or anything), and it occured to me that the settings library would probably support fixed sized strings (which, it does!).

So, no more dynamically allocated `renderer` and associated bugs.