### PR TITLE
Tournament REC fixes

### DIFF
--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -23,7 +23,10 @@ void sd_pilot_clone(sd_pilot *dest, const sd_pilot *src) {
             dest->quotes[m] = omf_strdup(src->quotes[m]);
         }
     }
-    sd_sprite_copy(dest->photo, src->photo);
+    if(src->photo) {
+        dest->photo = omf_calloc(1, sizeof(sd_sprite));
+        sd_sprite_copy(dest->photo, src->photo);
+    }
 }
 
 void sd_pilot_copy_shallow(sd_pilot *dest, const sd_pilot *src) {

--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -331,7 +331,7 @@ void sd_pilot_set_player_color(sd_pilot *pilot, player_color index, uint8_t colo
             pilot->color_1 = color;
             break;
     }
-    if(color != 255) {
+    if(color != 255 && color != 16) {
         palette_load_altpal_player_color(&pilot->palette, 0, color, index);
     }
 }

--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -26,6 +26,13 @@ void sd_pilot_clone(sd_pilot *dest, const sd_pilot *src) {
     }
 }
 
+void sd_pilot_copy_shallow(sd_pilot *dest, const sd_pilot *src) {
+    sd_pilot_free(dest);
+    *dest = *src;
+    dest->photo = NULL;
+    memset(dest->quotes, 0, sizeof dest->quotes);
+}
+
 void sd_pilot_free(sd_pilot *pilot) {
     if(pilot == NULL)
         return;

--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -17,13 +17,13 @@ int sd_pilot_create(sd_pilot *pilot) {
 }
 
 void sd_pilot_clone(sd_pilot *dest, const sd_pilot *src) {
-    sd_pilot_free(dest);
-    memcpy(dest, src, sizeof(sd_pilot));
+    sd_pilot_copy_shallow(dest, src);
     for(int m = 0; m < 10; m++) {
         if(src->quotes[m] != NULL) {
             dest->quotes[m] = omf_strdup(src->quotes[m]);
         }
     }
+    sd_sprite_copy(dest->photo, src->photo);
 }
 
 void sd_pilot_copy_shallow(sd_pilot *dest, const sd_pilot *src) {

--- a/src/formats/pilot.h
+++ b/src/formats/pilot.h
@@ -41,9 +41,9 @@ typedef struct {
     uint16_t offense;        ///< Offense preference value (100 high, should be under 200).
     uint16_t defense;        ///< Defense preference value (100 high, should be under 200).
     int32_t money;           ///< Amount of money the pilot currently has
-    uint8_t color_1;         ///< Color 1 field for the HAR (0-15). 255 means random.
-    uint8_t color_2;         ///< Color 2 field for the HAR (0-15). 255 means random.
-    uint8_t color_3;         ///< Color 3 field for the HAR (0-15). 255 means random.
+    uint8_t color_1;         ///< HAR Color 1. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
+    uint8_t color_2;         ///< HAR Color 2. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
+    uint8_t color_3;         ///< HAR Color 3. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
     char trn_name[13];       ///< Tournament file
     char trn_desc[31];       ///< Tournament description
     char trn_image[13];      ///< Tournament image file
@@ -102,7 +102,7 @@ typedef struct {
     uint32_t total_value; ///< Total value for the pilot
     float unk_f_a;        ///< Unknown
     float unk_f_b;        ///< Unknown
-    vga_palette palette;  ///< Palette for photo ?
+    vga_palette palette;  ///< Photo palette, used as HAR colors when not using altpals.
     uint16_t unk_block_i; ///< Unknown
     uint16_t photo_id;    ///< Which face photo this pilot uses
 

--- a/src/formats/pilot.h
+++ b/src/formats/pilot.h
@@ -132,6 +132,9 @@ typedef enum
 int sd_pilot_create(sd_pilot *pilot);
 
 void sd_pilot_clone(sd_pilot *dest, const sd_pilot *src);
+/*! \brief Copies an sd_pilot, but not any child allocations (quotes, photo surface, etc..)
+ */
+void sd_pilot_copy_shallow(sd_pilot *dest, const sd_pilot *src);
 
 /*! \brief Free pilot structure
  *

--- a/src/formats/rec.h
+++ b/src/formats/rec.h
@@ -55,6 +55,14 @@ enum
     REC_CONTROLLER_REPLAY
 };
 
+enum
+{
+    // TOURNAMENT
+    REC_GAMEMODE_TOURNAMENT = 1,
+    // 1 PLAYER, 2 PLAYER, DEMO, and NETPLAY.
+    REC_GAMEMODE_ARCADE = 2,
+};
+
 /*! \brief REC recording
  *
  * Contains a record of a single OMF:2097 match. This may be

--- a/src/formats/sprite.c
+++ b/src/formats/sprite.c
@@ -289,6 +289,9 @@ int sd_sprite_vga_decode(sd_vga_image *dst, const sd_sprite *src) {
         return SD_SUCCESS;
     }
 
+    // the number of bytes that can be written to `dst`.
+    unsigned int dst_size = dst->w * dst->h;
+
     // Walk through raw sprite data
     while(i < src->len) {
         // read a word
@@ -308,7 +311,13 @@ int sd_sprite_vga_decode(sd_vga_image *dst, const sd_sprite *src) {
             case 1:
                 while(data > 0) {
                     uint8_t b = src->data[i];
-                    int pos = ((y * src->width) + x);
+                    unsigned int pos = ((y * src->width) + x);
+                    // if we're about to overflow the `dst` buffer, don't.
+                    if(pos >= dst_size) {
+                        // it's not pretty, but this bounds check is necessary & used.
+                        // without it, tournament rec files can't load their pilot pics
+                        return SD_SUCCESS;
+                    }
                     dst->data[pos] = b;
                     i++; // we read 1 byte
                     x++;

--- a/src/formats/sprite.c
+++ b/src/formats/sprite.c
@@ -5,6 +5,7 @@
 #include "formats/palette.h"
 #include "formats/sprite.h"
 #include "utils/allocator.h"
+#include "utils/log.h"
 
 int sd_sprite_create(sd_sprite *sprite) {
     if(sprite == NULL) {
@@ -314,8 +315,10 @@ int sd_sprite_vga_decode(sd_vga_image *dst, const sd_sprite *src) {
                     unsigned int pos = ((y * src->width) + x);
                     // if we're about to overflow the `dst` buffer, don't.
                     if(pos >= dst_size) {
-                        // it's not pretty, but this bounds check is necessary & used.
-                        // without it, tournament rec files can't load their pilot pics
+                        log_warn("Truncating sd_sprite vga data");
+                        // This code path is taken when loading tournament REC files (incl. ones from DOS)
+                        // TODO: Figure out what's going on with sprite width/height, and
+                        // clean up (centralize?) those width/height++/-- adjustments.
                         return SD_SUCCESS;
                     }
                     dst->data[pos] = b;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1579,9 +1579,7 @@ int arena_create(scene *scene) {
         game_player_set_har(player, obj);
         game_player_get_ctrl(player)->har_obj_id = obj->id;
 
-        // TODO change this to simply check if the pilot has a photo but currently this causes REC playback from
-        // tournament mode to crash decoding the sprite for some reason
-        if(local->tournament) {
+        if(player->pilot->photo) {
             // render pilot portraits
             object *portrait = omf_calloc(1, sizeof(object));
             if(i == 0) {
@@ -1804,7 +1802,7 @@ int arena_create(scene *scene) {
         for(int i = 0; i < 2; i++) {
             // Declare some vars
             game_player *player = game_state_get_player(scene->gs, i);
-            sd_pilot_copy_shallow(&scene->gs->rec->pilots[i].info, player->pilot);
+            sd_pilot_clone(&scene->gs->rec->pilots[i].info, player->pilot);
 
             // this is the score when the REC started
             scene->gs->rec->scores[i] = game_player_get_score(player)->score;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1803,27 +1803,7 @@ int arena_create(scene *scene) {
         for(int i = 0; i < 2; i++) {
             // Declare some vars
             game_player *player = game_state_get_player(scene->gs, i);
-            log_debug("player %d using har %d", i, player->pilot->har_id);
-            scene->gs->rec->pilots[i].info.har_id = (unsigned char)player->pilot->har_id;
-            scene->gs->rec->pilots[i].info.pilot_id = player->pilot->pilot_id;
-            scene->gs->rec->pilots[i].info.color_3 = player->pilot->color_1;
-            scene->gs->rec->pilots[i].info.color_2 = player->pilot->color_2;
-            scene->gs->rec->pilots[i].info.color_1 = player->pilot->color_3;
-            scene->gs->rec->pilots[i].info.agility = player->pilot->agility;
-            scene->gs->rec->pilots[i].info.power = player->pilot->power;
-            scene->gs->rec->pilots[i].info.endurance = player->pilot->endurance;
-            scene->gs->rec->pilots[i].info.arm_speed = player->pilot->arm_speed;
-            scene->gs->rec->pilots[i].info.leg_speed = player->pilot->leg_speed;
-            scene->gs->rec->pilots[i].info.arm_power = player->pilot->arm_power;
-            scene->gs->rec->pilots[i].info.leg_power = player->pilot->leg_power;
-            scene->gs->rec->pilots[i].info.armor = player->pilot->armor;
-            scene->gs->rec->pilots[i].info.stun_resistance = player->pilot->stun_resistance;
-            memset(scene->gs->rec->pilots[i].info.name, 0, 18);
-            strncpy(scene->gs->rec->pilots[i].info.name, lang_get(player->pilot->pilot_id + 20), 18);
-            char *nl;
-            if((nl = strchr(scene->gs->rec->pilots[i].info.name, '\n'))) {
-                *nl = 0;
-            }
+            sd_pilot_copy_shallow(&scene->gs->rec->pilots[i].info, player->pilot);
 
             // this is the score when the REC started
             scene->gs->rec->scores[i] = game_player_get_score(player)->score;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1809,7 +1809,7 @@ int arena_create(scene *scene) {
             scene->gs->rec->scores[i] = game_player_get_score(player)->score;
         }
         scene->gs->rec->arena_id = scene->id - SCENE_ARENA0;
-        scene->gs->rec->game_mode = is_tournament(scene->gs) ? 1 : 2;
+        scene->gs->rec->game_mode = is_tournament(scene->gs) ? REC_GAMEMODE_TOURNAMENT : REC_GAMEMODE_ARCADE;
 
         // player 1's controller
         switch(game_state_get_player(scene->gs, 0)->ctrl->type) {

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -596,17 +596,18 @@ void arena_har_defeat_hook(int loser_player_id, scene *scene) {
                     fight_stats->winnings =
                         (player_loser->pilot->money + player_loser->pilot->winnings) * winnings_multiplier;
                     fight_stats->winnings += (int)(400 * hp_percentage);
-                }
-                // secret players have no rank, and don't increase your own ranking
-                if(!gs->match_settings.sim && player_loser->pilot->rank > 0) {
-                    player_winner->pilot->rank--;
-                    if(player_winner->pilot->rank < 1) {
-                        player_winner->pilot->rank = 1;
-                    }
-                    for(int i = 0; i < player_winner->chr->pilot.enemies_inc_unranked; i++) {
-                        if(player_winner->chr->enemies[i]->pilot.rank == player_winner->pilot->rank) {
-                            player_winner->chr->enemies[i]->pilot.rank += 1;
-                            break;
+
+                    // secret players have no rank, and don't increase your own ranking
+                    if(!gs->match_settings.sim && player_loser->pilot->rank > 0) {
+                        player_winner->pilot->rank--;
+                        if(player_winner->pilot->rank < 1) {
+                            player_winner->pilot->rank = 1;
+                        }
+                        for(int i = 0; i < player_winner->chr->pilot.enemies_inc_unranked; i++) {
+                            if(player_winner->chr->enemies[i]->pilot.rank == player_winner->pilot->rank) {
+                                player_winner->chr->enemies[i]->pilot.rank += 1;
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- Tournament pilots names no longer get saved as "Crystal"
- Tournament pilots colors are now saved, and are loaded correctly (without being overwritten by colors from ALTPALs.)
- Watching player 1 win a tournament match in a REC no longer crashes the game trying to rank them up.
- Tournament pilots photos are now saved and loaded to REC, visible in replays.

Also: tested working with .RECs from DOS, ~~although the tournament rec caused some unrelated pointer problems regarding the round-end tournament score calculations.~~ fixed that crash.