### PR TITLE
Correct color order, and fix tournament colors save-compatibility

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -184,7 +184,7 @@ void engine_run(engine_init_flags *init_flags) {
                         save_palette_shot();
                     }
                     if(e.key.keysym.sym == SDLK_F3) {
-                        if(init_flags->playback != 1) {
+                        if(init_flags->playback != 1 && gs->rec) {
                             save_rec(gs);
                         }
                     }

--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -74,9 +74,9 @@ void sd_pilot_load_player_from_mem(memreader *mr, sd_pilot *pilot) {
     pilot->offense = memread_uword(mr);
     pilot->defense = memread_uword(mr);
     pilot->money = memread_dword(mr);
-    sd_pilot_set_player_color(pilot, PRIMARY, memread_ubyte(mr));
-    sd_pilot_set_player_color(pilot, SECONDARY, memread_ubyte(mr));
     sd_pilot_set_player_color(pilot, TERTIARY, memread_ubyte(mr));
+    sd_pilot_set_player_color(pilot, SECONDARY, memread_ubyte(mr));
+    sd_pilot_set_player_color(pilot, PRIMARY, memread_ubyte(mr));
 }
 
 void sd_pilot_load_from_mem(memreader *mr, sd_pilot *pilot) {
@@ -207,9 +207,9 @@ void sd_pilot_save_player_to_mem(memwriter *w, const sd_pilot *pilot) {
     memwrite_uword(w, pilot->offense);
     memwrite_uword(w, pilot->defense);
     memwrite_dword(w, pilot->money);
-    memwrite_ubyte(w, pilot->color_1);
-    memwrite_ubyte(w, pilot->color_2);
     memwrite_ubyte(w, pilot->color_3);
+    memwrite_ubyte(w, pilot->color_2);
+    memwrite_ubyte(w, pilot->color_1);
 }
 
 void sd_pilot_save_to_mem(memwriter *w, const sd_pilot *pilot) {
@@ -321,14 +321,14 @@ int sd_pilot_save(sd_writer *fw, const sd_pilot *pilot) {
 
 void sd_pilot_set_player_color(sd_pilot *pilot, player_color index, uint8_t color) {
     switch(index) {
-        case PRIMARY:
-            pilot->color_1 = color;
+        case TERTIARY:
+            pilot->color_3 = color;
             break;
         case SECONDARY:
             pilot->color_2 = color;
             break;
-        case TERTIARY:
-            pilot->color_3 = color;
+        case PRIMARY:
+            pilot->color_1 = color;
             break;
     }
     if(color != 255 && color != 16) {

--- a/src/formats/pilot.c
+++ b/src/formats/pilot.c
@@ -322,13 +322,13 @@ int sd_pilot_save(sd_writer *fw, const sd_pilot *pilot) {
 void sd_pilot_set_player_color(sd_pilot *pilot, player_color index, uint8_t color) {
     switch(index) {
         case PRIMARY:
-            pilot->color_3 = color;
+            pilot->color_1 = color;
             break;
         case SECONDARY:
             pilot->color_2 = color;
             break;
         case TERTIARY:
-            pilot->color_1 = color;
+            pilot->color_3 = color;
             break;
     }
     if(color != 255 && color != 16) {

--- a/src/formats/pilot.h
+++ b/src/formats/pilot.h
@@ -41,9 +41,9 @@ typedef struct {
     uint16_t offense;        ///< Offense preference value (100 high, should be under 200).
     uint16_t defense;        ///< Defense preference value (100 high, should be under 200).
     int32_t money;           ///< Amount of money the pilot currently has
-    uint8_t color_1;         ///< HAR Color 1. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
-    uint8_t color_2;         ///< HAR Color 2. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
-    uint8_t color_3;         ///< HAR Color 3. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
+    uint8_t color_3;         ///< HAR Tertiary Color.  0-15 are altpals, 16 means use 'palette' field, 255 means random.
+    uint8_t color_2;         ///< HAR Secondary Color. 0-15 are altpals, 16 means use 'palette' field, 255 means random.
+    uint8_t color_1;         ///< HAR Primary Color.   0-15 are altpals, 16 means use 'palette' field, 255 means random.
     char trn_name[13];       ///< Tournament file
     char trn_desc[31];       ///< Tournament description
     char trn_image[13];      ///< Tournament image file
@@ -115,9 +115,9 @@ typedef struct {
 
 typedef enum
 {
-    PRIMARY,
+    TERTIARY,
     SECONDARY,
-    TERTIARY
+    PRIMARY,
 } player_color;
 
 /*! \brief Initialize pilot struct

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -180,9 +180,9 @@ int game_state_create(game_state *gs, engine_init_flags *init_flags) {
             omf_free(gs->players[i]->pilot);
             gs->players[i]->pilot = &gs->rec->pilots[i].info;
             // this function alters the palette
-            sd_pilot_set_player_color(gs->players[i]->pilot, PRIMARY, gs->rec->pilots[i].info.color_3);
+            sd_pilot_set_player_color(gs->players[i]->pilot, PRIMARY, gs->rec->pilots[i].info.color_1);
             sd_pilot_set_player_color(gs->players[i]->pilot, SECONDARY, gs->rec->pilots[i].info.color_2);
-            sd_pilot_set_player_color(gs->players[i]->pilot, TERTIARY, gs->rec->pilots[i].info.color_1);
+            sd_pilot_set_player_color(gs->players[i]->pilot, TERTIARY, gs->rec->pilots[i].info.color_3);
         }
 
         gs->match_settings.throw_range = gs->rec->throw_range;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -1096,9 +1096,9 @@ void game_state_init_demo(game_state *gs) {
         // set proper color
         pilot pilot_info;
         pilot_get_info(&pilot_info, player->pilot->pilot_id);
-        sd_pilot_set_player_color(player->pilot, PRIMARY, pilot_info.colors[2]);
+        sd_pilot_set_player_color(player->pilot, PRIMARY, pilot_info.colors[0]);
         sd_pilot_set_player_color(player->pilot, SECONDARY, pilot_info.colors[1]);
-        sd_pilot_set_player_color(player->pilot, TERTIARY, pilot_info.colors[0]);
+        sd_pilot_set_player_color(player->pilot, TERTIARY, pilot_info.colors[2]);
 
         strncpy_or_truncate(player->pilot->name, lang_get(player->pilot->pilot_id + 20), sizeof(player->pilot->name));
         // TODO: lang: remove (the need for) newline stripping

--- a/src/game/scenes/mechlab.c
+++ b/src/game/scenes/mechlab.c
@@ -392,6 +392,10 @@ void mechlab_select_dashboard(scene *scene, dashboard_type type) {
             player1->pilot->money = 2000;
             // and a jaguar
             player1->pilot->har_id = 0;
+            // with no altpals yet
+            player1->pilot->color_1 = 16;
+            player1->pilot->color_2 = 16;
+            player1->pilot->color_3 = 16;
             object_free(local->mech);
             omf_free(local->mech);
             local->mech = omf_calloc(1, sizeof(object));

--- a/src/game/scenes/mechlab/lab_dash_main.c
+++ b/src/game/scenes/mechlab/lab_dash_main.c
@@ -375,6 +375,7 @@ component *lab_dash_main_create(scene *s, dashboard_widgets *dw) {
         dw->pilot->photo_id = portrait_selected(dw->photo[0]);
         portrait_load(dw->pilot->photo, &dw->pilot->palette, PIC_PLAYERS, 0);
     }
+
     palette_load_player_colors(&dw->pilot->palette, 0);
 
     xysizer_attach(xy, dw->photo[0], 12, -1, -1, -1);

--- a/src/game/scenes/mechlab/lab_menu_customize.c
+++ b/src/game/scenes/mechlab/lab_menu_customize.c
@@ -75,21 +75,21 @@ void lab_menu_customize_done(component *c, void *userdata) {
 void lab_menu_customize_color_main(component *c, void *userdata) {
     scene *s = userdata;
     game_player *p1 = game_state_get_player(s->gs, 0);
-    sd_pilot_set_player_color(&p1->chr->pilot, SECONDARY, (p1->chr->pilot.color_2 + 1) % 16);
+    sd_pilot_set_player_color(&p1->chr->pilot, PRIMARY, (p1->chr->pilot.color_1 + 1) % 16);
     mechlab_update(s);
 }
 
 void lab_menu_customize_color_secondary(component *c, void *userdata) {
     scene *s = userdata;
     game_player *p1 = game_state_get_player(s->gs, 0);
-    sd_pilot_set_player_color(&p1->chr->pilot, TERTIARY, (p1->chr->pilot.color_1 + 1) % 16);
+    sd_pilot_set_player_color(&p1->chr->pilot, SECONDARY, (p1->chr->pilot.color_2 + 1) % 16);
     mechlab_update(s);
 }
 
 void lab_menu_customize_color_third(component *c, void *userdata) {
     scene *s = userdata;
     game_player *p1 = game_state_get_player(s->gs, 0);
-    sd_pilot_set_player_color(&p1->chr->pilot, PRIMARY, (p1->chr->pilot.color_3 + 1) % 16);
+    sd_pilot_set_player_color(&p1->chr->pilot, TERTIARY, (p1->chr->pilot.color_3 + 1) % 16);
     mechlab_update(s);
 }
 

--- a/src/game/scenes/mechlab/lab_menu_customize.c
+++ b/src/game/scenes/mechlab/lab_menu_customize.c
@@ -75,21 +75,21 @@ void lab_menu_customize_done(component *c, void *userdata) {
 void lab_menu_customize_color_main(component *c, void *userdata) {
     scene *s = userdata;
     game_player *p1 = game_state_get_player(s->gs, 0);
-    sd_pilot_set_player_color(&p1->chr->pilot, PRIMARY, (p1->chr->pilot.color_1 + 1) % 16);
+    sd_pilot_set_player_color(&p1->chr->pilot, PRIMARY, (p1->chr->pilot.color_1 + 1) % 17);
     mechlab_update(s);
 }
 
 void lab_menu_customize_color_secondary(component *c, void *userdata) {
     scene *s = userdata;
     game_player *p1 = game_state_get_player(s->gs, 0);
-    sd_pilot_set_player_color(&p1->chr->pilot, SECONDARY, (p1->chr->pilot.color_2 + 1) % 16);
+    sd_pilot_set_player_color(&p1->chr->pilot, SECONDARY, (p1->chr->pilot.color_2 + 1) % 17);
     mechlab_update(s);
 }
 
 void lab_menu_customize_color_third(component *c, void *userdata) {
     scene *s = userdata;
     game_player *p1 = game_state_get_player(s->gs, 0);
-    sd_pilot_set_player_color(&p1->chr->pilot, TERTIARY, (p1->chr->pilot.color_3 + 1) % 16);
+    sd_pilot_set_player_color(&p1->chr->pilot, TERTIARY, (p1->chr->pilot.color_3 + 1) % 17);
     mechlab_update(s);
 }
 

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -334,9 +334,9 @@ void handle_action(scene *scene, int player, int action) {
                     player1->pilot->power = p_a.power;
                     player1->pilot->agility = p_a.agility;
                     player1->pilot->sex = p_a.sex;
-                    sd_pilot_set_player_color(player1->pilot, TERTIARY, p_a.colors[0]);
+                    sd_pilot_set_player_color(player1->pilot, PRIMARY, p_a.colors[0]);
                     sd_pilot_set_player_color(player1->pilot, SECONDARY, p_a.colors[1]);
-                    sd_pilot_set_player_color(player1->pilot, PRIMARY, p_a.colors[2]);
+                    sd_pilot_set_player_color(player1->pilot, TERTIARY, p_a.colors[2]);
                     palette_load_player_colors(&player1->pilot->palette, 0);
 
                     if(player2->selectable) {
@@ -347,9 +347,9 @@ void handle_action(scene *scene, int player, int action) {
                         player2->pilot->power = p_a.power;
                         player2->pilot->agility = p_a.agility;
                         player2->pilot->sex = p_a.sex;
-                        sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.colors[0]);
+                        sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.colors[0]);
                         sd_pilot_set_player_color(player2->pilot, SECONDARY, p_a.colors[1]);
-                        sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.colors[2]);
+                        sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.colors[2]);
                         palette_load_player_colors(&player2->pilot->palette, 1);
                     }
                 } else {
@@ -402,9 +402,9 @@ void handle_action(scene *scene, int player, int action) {
                         player2->pilot->power = p_a.power;
                         player2->pilot->agility = p_a.agility;
                         player2->pilot->sex = p_a.sex;
-                        sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.colors[0]);
+                        sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.colors[0]);
                         sd_pilot_set_player_color(player2->pilot, SECONDARY, p_a.colors[1]);
-                        sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.colors[2]);
+                        sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.colors[2]);
                     }
                     // TODO in netplay, use the lobby names
                     strncpy_or_truncate(player1->pilot->name, lang_get(player1->pilot->pilot_id + 20),

--- a/src/resources/sgmanager.c
+++ b/src/resources/sgmanager.c
@@ -134,6 +134,11 @@ int sg_load(sd_chr_file *chr, const char *pilotname) {
         return ret;
     }
 
+    // Load colors from other files
+    sd_pilot_set_player_color(&chr->pilot, PRIMARY, chr->pilot.color_1);
+    sd_pilot_set_player_color(&chr->pilot, SECONDARY, chr->pilot.color_2);
+    sd_pilot_set_player_color(&chr->pilot, TERTIARY, chr->pilot.color_3);
+
     return SD_SUCCESS;
 }
 


### PR DESCRIPTION
I tested these changes by copy-pasting CHR's and RECs between OMF and openomf.

- Colors are now ordered correctly: TERTIARY, followed by SECONDARY, and finally PRIMARY.
- Tournament save-games from DOS now load fully: Previously, the HAR colors would be all-black.
- The mechlab now lets you select the PIC colors (color number 16) in the customization screen.
- A crash was fixed, where by mashing F3 and ALT-F4 the game would try to save a recording after the recording was already freed and nulled.