### PR TITLE
Use 'sed' instead of 'xargs' to trim whitespace in run_rectests.sh

### DIFF
--- a/run_rectests.sh
+++ b/run_rectests.sh
@@ -51,8 +51,8 @@ i=0
 for test in "${tests[@]}"; do
     IFS=':' read -r desc filename <<< "$test"
     # Trim whitespace from description and filename
-    desc=$(echo "$desc" | xargs)
-    filename=$(echo "$filename" | xargs)
+    desc=$(echo "$desc" | sed -re 's/^[[:blank:]]+|[[:blank:]]+$//g')
+    filename=$(echo "$filename" | sed -re 's/^[[:blank:]]+|[[:blank:]]+$//g')
     output_file="$temp_dir/output_$i.log"
 
     echo -n "${desc} :"


### PR DESCRIPTION
This permits quote marks in rectest descriptions.