### PR TITLE
github: Extract rec_and_menu_tests from unittest job

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -55,23 +55,6 @@ jobs:
         cd build-test
         ctest --verbose --output-on-failure
 
-    - name: Get OMF2097 assets
-      uses: ./.github/actions/assets
-
-    - name: Extract omf 2097 assets
-      run: unzip -j omf2097-assets.zip -d build-test/resources
-
-    - name: Install pytest requirements
-      run: |
-        pipx install poetry
-        poetry install
-
-    - name: Run pytest tests
-      run: ./run_pytest.sh build-test
-
-    - name: Run rec tests
-      run: ./run_rectests.sh build-test
-
   # Build windows release artifacts with MSVC
   # -----------------------------------------------------------------------------------------------
   build_msvc:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,0 +1,60 @@
+name: Functional CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+
+  # Run rec tests and menu tests
+  # -----------------------------------------------------------------------------------------------
+  rec_and_menu_tests:
+    name: Run rec tests and menu tests
+    runs-on: ubuntu-24.04
+    env:
+      clang-version: '18'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+
+    - name: Install dependencies
+      uses: Eeems-Org/apt-cache-action@v1.3
+      with:
+        packages: cmake cmake-data ninja-build libargtable2-dev libcunit1-dev
+          libsdl2-mixer-dev libconfuse-dev libenet-dev libsdl2-dev libxmp-dev
+          libpng-dev libopusfile-dev libepoxy-dev
+          clang-${{ env.clang-version }}
+
+    - name: Build tests
+      run: |
+        cmake -DCMAKE_C_COMPILER=clang-${{ env.clang-version }} \
+              -DUSE_SANITIZERS=On \
+              -DUSE_FATAL_SANITIZERS=On \
+              -DUSE_MINIUPNPC=Off \
+              -DUSE_NATPMP=Off \
+              -G "Ninja Multi-Config" \
+              -S . -B build-test
+        cmake --build build-test -j $(getconf _NPROCESSORS_ONLN)
+
+    - name: Get OMF2097 assets
+      uses: ./.github/actions/assets
+
+    - name: Extract omf 2097 assets
+      run: unzip -j omf2097-assets.zip -d build-test/resources
+
+    - name: Run rec tests
+      run: ./run_rectests.sh build-test
+
+    - name: Install pytest requirements
+      run: |
+        pipx install poetry
+        poetry install
+
+    - name: Run menu tests
+      run: ./run_pytest.sh build-test

--- a/lsan.supp
+++ b/lsan.supp
@@ -3,3 +3,6 @@ leak:libconfuse
 
 # SDL leak
 leak:has_gl_available
+
+# dbus
+leak:dbus_pending_call_block

--- a/run_rectests.sh
+++ b/run_rectests.sh
@@ -49,7 +49,7 @@ RUNDIR=$(pwd)
 
 cd $BUILD_DIR
 
-export ASAN_OPTIONS=detect_leaks=0
+export LSAN_OPTIONS="suppressions=../lsan.supp"
 i=0
 for test in "${tests[@]}"; do
     IFS=':' read -r desc filename <<< "$test"


### PR DESCRIPTION
This is to speed up the CI run.