### PR TITLE
gl3: Implement Electra & Pyros palette quirks

### DIFF
--- a/shaders/palette.frag
+++ b/shaders/palette.frag
@@ -19,6 +19,7 @@ in vec4 gl_FragCoord;
 bool REMAP_SPRITE = (options & 1u) != 0u;
 bool SPRITE_MASK = (options & 2u) != 0u;
 bool SPRITE_INDEX_ADD = (options & 4u) != 0u;
+bool USE_HAR_QUIRKS = (options & 8u) != 0u;
 
 
 float PHI = 1.61803398874989484820459;
@@ -65,8 +66,10 @@ void main() {
 
     vec4 remap = texture(remaps, vec2(texel.r, remap_offset / 18.0));
 
+    bool NO_REMAP = USE_HAR_QUIRKS && index > 0x30;
+
     // If remapping is on, do it now.
-    if (REMAP_SPRITE) {
+    if (REMAP_SPRITE && !NO_REMAP) {
         texel = remap;
     }
 

--- a/shaders/palette.frag
+++ b/shaders/palette.frag
@@ -16,9 +16,9 @@ uniform sampler2D remaps;
 
 in vec4 gl_FragCoord;
 
-uint use_sprite_remap = options & 1u;
-uint use_sprite_mask = options & 2u;
-uint use_index_add = options & 4u;
+bool REMAP_SPRITE = (options & 1u) != 0u;
+bool SPRITE_MASK = (options & 2u) != 0u;
+bool SPRITE_INDEX_ADD = (options & 4u) != 0u;
 
 
 float PHI = 1.61803398874989484820459;
@@ -33,7 +33,7 @@ vec4 handle(float index, float remap) {
         float r_rounds = remap_rounds / 255.0;
         return vec4(0.0, r_index, r_rounds, 0.0);
     }
-    if (use_index_add > 0u) {
+    if (SPRITE_INDEX_ADD) {
         float add = (index * 255.0 * 60) / 255.0;
         return vec4(0.0, 0.0, 0.0, add);
     }
@@ -66,12 +66,12 @@ void main() {
     vec4 remap = texture(remaps, vec2(texel.r, remap_offset / 18.0));
 
     // If remapping is on, do it now.
-    if (use_sprite_remap > 0u) {
+    if (REMAP_SPRITE) {
         texel = remap;
     }
 
     // If masking is on, set our color to always be index 1.
-    if (use_sprite_mask > 0u) {
+    if (SPRITE_MASK) {
         texel.r = 1.0 / 255.0;
     }
 

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -2613,6 +2613,9 @@ int har_create(object *obj, af *af_data, int dir, int har_id, int pilot_id, int 
 
 #endif
 
+    // Enable Electra Electricity & Pyros Fire palette tricks
+    object_add_animation_effects(obj, EFFECT_HAR_QUIRKS);
+
     // fixup a bunch of stuff based on player stats
 
     bool is_tournament = false;

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -418,6 +418,10 @@ void object_render(object *obj) {
         options |= SPRITE_INDEX_ADD;
     }
 
+    if((options & REMAP_SPRITE) != 0 && object_has_effect(obj, EFFECT_HAR_QUIRKS)) {
+        options |= USE_HAR_QUIRKS;
+    }
+
     video_draw_full(obj->cur_surface, x, y, w, h, remap_offset, remap_rounds, obj->pal_offset, obj->pal_limit, opacity,
                     flip_mode, options);
 }

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -55,6 +55,8 @@ enum
     EFFECT_GLOW = 0x20,
     EFFECT_TRAIL = 0x40,
     EFFECT_ADD = 0x80,
+    // palette quirks for electra electricity and pyros fire
+    EFFECT_HAR_QUIRKS = 0x100,
 };
 
 typedef struct object_t object;

--- a/src/video/enums.h
+++ b/src/video/enums.h
@@ -10,6 +10,8 @@ typedef enum
     SPRITE_MASK = 0x02,
     // This implements the "bg" tag feature. Add indexes together in the postprocess.
     SPRITE_INDEX_ADD = 0x04,
+    // palette quirks for electra electricity and pyros fire
+    USE_HAR_QUIRKS = 0x08,
 } renderer_options;
 
 typedef enum


### PR DESCRIPTION
Electra electricity and Pyros Fire use palette indexes from outside the HAR range (first 48 colors), and should skip remapping to ensure they remain bright and colorful.

Part of issue #649

<details><summary>Visual Comparison, on Stadium (positional lighting remap is in effect)</summary>

Before:
![image](https://github.com/user-attachments/assets/0f8851d7-2ece-4951-9840-9408674b2003)
After:
![image](https://github.com/user-attachments/assets/646a38d6-9d2a-4aca-a765-d2315a07c5b6)

</details>