### PR TITLE
Recalculate last held inputs when rewinding rec controller

### DIFF
--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -156,7 +156,6 @@ int controller_rumble(controller *ctrl, float magnitude, int duration) {
 
 void controller_rewind(controller *ctrl) {
     ctrl->current = 0;
-    ctrl->last = 0;
     if(ctrl->rewind_fun != NULL) {
         ctrl->rewind_fun(ctrl);
     }

--- a/src/formats/actions.h
+++ b/src/formats/actions.h
@@ -23,5 +23,6 @@ typedef enum
 } sd_action;
 
 #define SD_MOVE_MASK (SD_ACT_UP | SD_ACT_DOWN | SD_ACT_LEFT | SD_ACT_RIGHT) ///< Mask of all movement keys
+#define SD_ACT_VALID_BITS 0x3Fu                                             ///< Mask of all valid bits of an sd_action
 
 #endif // SD_ACTIONS_H


### PR DESCRIPTION
This fixes a desync where rec_controllers would let go of buttons after rewinding.