### PR TITLE
Implement soft shadows in GLSL

### DIFF
--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -442,12 +442,8 @@ void object_render_shadow(object *obj) {
         return;
     }
 
-    // Scale of the sprite on Y axis should be less than the
-    // height of the sprite because of light position
-    float scale_y = 0.25f;
     int w = cur_sprite->data->w;
     int h = cur_sprite->data->h;
-    int scaled_h = h * scale_y;
 
     // Determine X
     int flip_mode = obj->sprite_state.flipmode;
@@ -465,15 +461,11 @@ void object_render_shadow(object *obj) {
         opacity = clamp(state->blend_start + d, 0, 255);
     }
 
-    // Determine Y
-    int y = 190 - scaled_h;
+    // Draw at ARENA_FLOOR
+    int y = ARENA_FLOOR;
 
-    // Render shadow object twice with different offsets, so that
-    // the shadows seem a bit blobbier and shadow-y
-    for(int i = 0; i < 2; i++) {
-        video_draw_full(cur_sprite->data, x + i, y + i, w, scaled_h, 2, 1, obj->pal_offset, obj->pal_limit, opacity,
-                        flip_mode, SPRITE_MASK);
-    }
+    // Draw the shadow, using the texture data to determine which remap to use (uses the first four remaps)
+    video_draw_full(cur_sprite->data, x, y, w, h, -1, 1, 0, 0, opacity, flip_mode, SPRITE_SHADOW);
 }
 
 void object_palette_transform(object *obj) {

--- a/src/resources/sprite.h
+++ b/src/resources/sprite.h
@@ -8,7 +8,7 @@ typedef struct sprite_t {
     int id;
     vec2i pos;
     surface *data;
-    bool owned; // if we own the surface data
+    bool owned; // if we own the `data` surface
 } sprite;
 
 void sprite_create(sprite *sp, void *src, int id);

--- a/src/video/enums.h
+++ b/src/video/enums.h
@@ -6,8 +6,8 @@ typedef enum
     // If this is on, then we remap sprite using the selected index and blit.
     // Otherwise we use sprite palette indexes as remap selection indexes and modify existing image.
     REMAP_SPRITE = 0x01,
-    // Use sprite as a mask of 1's instead of color indexes.
-    SPRITE_MASK = 0x02,
+    // Render sprite at 1/4th height, and use four samples of its mask to generate a coverage
+    SPRITE_SHADOW = 0x02,
     // This implements the "bg" tag feature. Add indexes together in the postprocess.
     SPRITE_INDEX_ADD = 0x04,
     // palette quirks for electra electricity and pyros fire

--- a/src/video/renderers/opengl3/helpers/object_array.c
+++ b/src/video/renderers/opengl3/helpers/object_array.c
@@ -146,7 +146,7 @@ void object_array_draw(const object_array *array, object_array_batch *state) {
     ptr.opacity = opacity;                                                                                             \
     ptr.options = options;
 
-static void add_item(object_array *array, float dx, float dy, int x, int y, int w, int h, int tx, int ty, int tw,
+static void add_item(object_array *array, float dx, float dy, int x, int y_, int w, int h_, int tx, int ty, int tw,
                      int th, int flags, int transparency, int remap_offset, int remap_rounds, int pal_offset,
                      int pal_limit, int opacity, unsigned int options) {
     float tx0, tx1;
@@ -165,6 +165,13 @@ static void add_item(object_array *array, float dx, float dy, int x, int y, int 
     } else {
         ty0 = ty * dy;
         ty1 = (ty + th) * dy;
+    }
+
+    float y = y_;
+    float h = h_;
+    if(options & SPRITE_SHADOW) {
+        h /= 4.0f;
+        y -= h;
     }
 
     object_data *data = (object_data *)array->mapping;


### PR DESCRIPTION
There's a [soft-shadows](https://github.com/omf2097/openomf/tree/soft-shadows) branch which implements this by creating a copy of the surface on the CPU, but I think we'd prefer to do it in shader.

To make the OMF soft shadow effect, we make not one but four samples of the texture as a mask and add them up-- this coverage determines which of the four first remaps we use to make the shadow.

![image](https://github.com/user-attachments/assets/d6aa567f-21c0-4032-a820-96c8dbb62abc)