### PR TITLE
Implement pilot stats cheat from the original

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,11 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Wl,-s")
 endif()
 
+# Configure GCC to accept `// [[fallthrough]]` as a fallthrough comment.
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wimplicit-fallthrough=2")
+endif()
+
 set(COREINCS
     src
     ${CMAKE_CURRENT_BINARY_DIR}/src/

--- a/src/game/gui/progressbar.c
+++ b/src/game/gui/progressbar.c
@@ -51,6 +51,7 @@ typedef struct progressbar {
     int state;
     int tick;
     int refresh;
+    bool highlight;
 } progressbar;
 
 void progressbar_set_progress(component *c, int percentage, bool animate) {
@@ -73,6 +74,11 @@ void progressbar_set_flashing(component *c, int flashing, int rate) {
     }
     bar->flashing = clamp(flashing, 0, 1);
     bar->rate = (rate < 0) ? 0 : rate;
+}
+
+void progressbar_set_highlight(component *c, bool highlight) {
+    progressbar *bar = widget_get_obj(c);
+    bar->highlight = highlight;
 }
 
 static void progressbar_render(component *c) {
@@ -120,7 +126,8 @@ static void progressbar_render(component *c) {
 
     // Render block
     if(bar->block != NULL) {
-        video_draw(bar->block, c->x + (bar->orientation == PROGRESSBAR_LEFT ? 0 : c->w - bar->block->w), c->y);
+        video_draw_offset(bar->block, c->x + (bar->orientation == PROGRESSBAR_LEFT ? 0 : c->w - bar->block->w), c->y,
+                          bar->highlight ? 1 : 0, 255);
     }
 }
 

--- a/src/game/gui/progressbar.c
+++ b/src/game/gui/progressbar.c
@@ -163,6 +163,7 @@ static void progressbar_layout(component *c, int x, int y, int w, int h) {
     image_rect_bevel(&tmp, 0, 0, w - 1, h - 1, bar->theme.border_topleft_color, bar->theme.border_bottomright_color,
                      bar->theme.border_bottomright_color, bar->theme.border_topleft_color);
     surface_create_from_image(bar->background, &tmp);
+    surface_set_transparency(bar->background, 0);
     image_free(&tmp);
 
     image_create(&tmp, w, h);
@@ -170,6 +171,7 @@ static void progressbar_layout(component *c, int x, int y, int w, int h) {
     image_rect_bevel(&tmp, 0, 0, w - 1, h - 1, bar->theme.border_topleft_color, bar->theme.border_bottomright_color,
                      bar->theme.border_bottomright_color, bar->theme.border_topleft_color);
     surface_create_from_image(bar->background_alt, &tmp);
+    surface_set_transparency(bar->background_alt, 0);
     image_free(&tmp);
 }
 

--- a/src/game/gui/progressbar.h
+++ b/src/game/gui/progressbar.h
@@ -29,5 +29,6 @@ component *progressbar_create(progressbar_theme theme, int orientation, int perc
 // set progressbar value, progressbar will lower from current value to new value one % per tick if `animate` is true
 void progressbar_set_progress(component *bar, int percentage, bool animate);
 void progressbar_set_flashing(component *bar, int flashing, int rate);
+void progressbar_set_highlight(component *bar, bool highlight);
 
 #endif // PROGRESSBAR_H

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -96,7 +96,7 @@ typedef struct {
     text *player_bio[2];
 
     // nova selection cheat
-    unsigned char har_selected[2][10];
+    unsigned char cheat_selected[2][10];
     unsigned char katana_down_count[2];
 } melee_local;
 
@@ -348,9 +348,10 @@ void handle_action(scene *scene, int player, int action) {
                     local->pilot_id_a = CURSOR_INDEX(local, 0);
                     local->pilot_id_b = CURSOR_INDEX(local, 1);
 
-                    // nova selection cheat
-                    local->har_selected[0][local->pilot_id_a] = 1;
-                    local->har_selected[1][local->pilot_id_b] = 1;
+                    // prepare for nova selection cheat
+                    memset(local->cheat_selected, 0, sizeof(local->cheat_selected));
+                    local->cheat_selected[0][local->pilot_id_a] = 1;
+                    local->cheat_selected[1][local->pilot_id_b] = 1;
 
                     load_pilot(scene, 0);
 
@@ -360,15 +361,8 @@ void handle_action(scene *scene, int player, int action) {
                 } else {
                     int nova_activated[2] = {1, 1};
                     for(int i = 0; i < 2; i++) {
-                        for(int j = 0; j < 10; j++) {
-                            if(local->har_selected[i][j] == 0) {
-                                nova_activated[i] = 0;
-                                break;
-                            }
-                        }
-                        if(local->katana_down_count[i] < 11) {
-                            nova_activated[i] = 0;
-                        }
+                        nova_activated[i] = local->katana_down_count[i] >= 11 &&
+                                            !memchr(local->cheat_selected[i], 0, sizeof(local->cheat_selected[i]));
                     }
                     if(nova_activated[0] && CURSOR_NOVA_SELECT(local, 0)) {
                         player1->pilot->har_id = HAR_NOVA;
@@ -442,7 +436,7 @@ void handle_action(scene *scene, int player, int action) {
 
     // nova selection cheat
     if(local->page == HAR_SELECT) {
-        local->har_selected[player][5 * (*row) + *column] = 1;
+        local->cheat_selected[player][5 * (*row) + *column] = 1;
     }
 
     refresh_pilot_stats(local);
@@ -856,7 +850,7 @@ int melee_create(scene *scene) {
     set_cursor_colors(0, 0, false, false);
 
     // initialize nova selection cheat
-    memset(local->har_selected, 0, sizeof(local->har_selected));
+    memset(local->cheat_selected, 0, sizeof(local->cheat_selected));
     memset(local->katana_down_count, 0, sizeof(local->katana_down_count));
 
     // Set callbacks

--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -259,6 +259,32 @@ static void reset_cursor_blinky(melee_local *local, int player) {
     }
 }
 
+static void load_pilot(scene *scene, int player_id) {
+    game_player *player = game_state_get_player(scene->gs, player_id);
+    melee_local *local = scene_get_userdata(scene);
+
+    int pilot_id = player_id == 0 ? local->pilot_id_a : local->pilot_id_b;
+
+    if(player->selectable) {
+        object *big_portrait = player_id == 0 ? &local->big_portrait_1 : &local->big_portrait_2;
+        object_select_sprite(big_portrait, pilot_id);
+    }
+
+    pilot p_a;
+    pilot_get_info(&p_a, pilot_id);
+
+    // update the player palette
+    pilot_get_info(&p_a, pilot_id);
+    player->pilot->endurance = p_a.endurance;
+    player->pilot->power = p_a.power;
+    player->pilot->agility = p_a.agility;
+    player->pilot->sex = p_a.sex;
+    sd_pilot_set_player_color(player->pilot, PRIMARY, p_a.color_1);
+    sd_pilot_set_player_color(player->pilot, SECONDARY, p_a.color_2);
+    sd_pilot_set_player_color(player->pilot, TERTIARY, p_a.color_3);
+    palette_load_player_colors(&player->pilot->palette, player_id);
+}
+
 void handle_action(scene *scene, int player, int action) {
     game_player *player1 = game_state_get_player(scene->gs, 0);
     game_player *player2 = game_state_get_player(scene->gs, 1);
@@ -326,31 +352,10 @@ void handle_action(scene *scene, int player, int action) {
                     local->har_selected[0][local->pilot_id_a] = 1;
                     local->har_selected[1][local->pilot_id_b] = 1;
 
-                    object_select_sprite(&local->big_portrait_1, local->pilot_id_a);
-                    // update the player palette
-                    pilot p_a;
-                    pilot_get_info(&p_a, local->pilot_id_a);
-                    player1->pilot->endurance = p_a.endurance;
-                    player1->pilot->power = p_a.power;
-                    player1->pilot->agility = p_a.agility;
-                    player1->pilot->sex = p_a.sex;
-                    sd_pilot_set_player_color(player1->pilot, PRIMARY, p_a.color_1);
-                    sd_pilot_set_player_color(player1->pilot, SECONDARY, p_a.color_2);
-                    sd_pilot_set_player_color(player1->pilot, TERTIARY, p_a.color_3);
-                    palette_load_player_colors(&player1->pilot->palette, 0);
+                    load_pilot(scene, 0);
 
                     if(player2->selectable) {
-                        object_select_sprite(&local->big_portrait_2, local->pilot_id_b);
-                        // update the player palette
-                        pilot_get_info(&p_a, local->pilot_id_b);
-                        player2->pilot->endurance = p_a.endurance;
-                        player2->pilot->power = p_a.power;
-                        player2->pilot->agility = p_a.agility;
-                        player2->pilot->sex = p_a.sex;
-                        sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.color_1);
-                        sd_pilot_set_player_color(player2->pilot, SECONDARY, p_a.color_2);
-                        sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.color_3);
-                        palette_load_player_colors(&player2->pilot->palette, 1);
+                        load_pilot(scene, 1);
                     }
                 } else {
                     int nova_activated[2] = {1, 1};
@@ -396,15 +401,8 @@ void handle_action(scene *scene, int player, int action) {
                             }
                         }
 
-                        pilot p_a;
-                        pilot_get_info(&p_a, player2->pilot->pilot_id);
-                        player2->pilot->endurance = p_a.endurance;
-                        player2->pilot->power = p_a.power;
-                        player2->pilot->agility = p_a.agility;
-                        player2->pilot->sex = p_a.sex;
-                        sd_pilot_set_player_color(player2->pilot, PRIMARY, p_a.color_1);
-                        sd_pilot_set_player_color(player2->pilot, SECONDARY, p_a.color_2);
-                        sd_pilot_set_player_color(player2->pilot, TERTIARY, p_a.color_3);
+                        local->pilot_id_b = player2->pilot->pilot_id;
+                        load_pilot(scene, 1);
                     }
                     // TODO in netplay, use the lobby names
                     strncpy_or_truncate(player1->pilot->name, lang_get(player1->pilot->pilot_id + 20),


### PR DESCRIPTION
Players can enable the pilot stats cheat by moving their cursor across all pilots and wrapping on both rows, then pressing KICK.
While holding KICK, the stats can be reallocated with the directional input.