### PR TITLE
Properly load Shirro for second player in 2-player scene

### DIFF
--- a/src/game/scenes/melee.c
+++ b/src/game/scenes/melee.c
@@ -874,6 +874,7 @@ int melee_create(scene *scene) {
 
     local->cursor[1].row = 0;
     local->cursor[1].column = 4;
+    local->pilot_id_b = CURSOR_INDEX(local, 1);
 
     game_player *player1 = game_state_get_player(scene->gs, 0);
     game_player *player2 = game_state_get_player(scene->gs, 1);


### PR DESCRIPTION
Regressed in my recent pr, #1067.
Was accidentally loading a bunch of Crystal's data instead of Shirro when creating the melee scene.