### PR TITLE
Language loader fixes

### DIFF
--- a/src/console/console.c
+++ b/src/console/console.c
@@ -17,6 +17,7 @@
 #define HISTORY_MAX 100
 #define BUFFER_INC(b) (((b) + 1) % sizeof(con->output))
 #define BUFFER_DEC(b) (((b) + sizeof(con->output) - 1) % sizeof(con->output))
+#define CONSOLE_TEXT_COLOR 0xFE
 
 // Console State
 console *con = NULL;
@@ -223,7 +224,7 @@ bool console_init(void) {
     con->output_overflowing = 0;
     con->hist_pos = -1;
     con->text = text_create_with_font_and_size(FONT_SMALL, 320, 100);
-    text_set_color(con->text, TEXT_MEDIUM_GREEN);
+    text_set_color(con->text, CONSOLE_TEXT_COLOR);
     text_set_line_spacing(con->text, 0);
     list_create(&con->history);
     hashmap_create(&con->cmds);

--- a/src/game/gui/text/text.c
+++ b/src/game/gui/text/text.c
@@ -239,6 +239,10 @@ void text_get_str(const text *t, str *dst) {
     str_from(dst, &t->buf);
 }
 
+const char *text_c(const text *t) {
+    return str_c(&t->buf);
+}
+
 font_size text_get_font(const text *t) {
     return t->font;
 }

--- a/src/game/gui/text/text.h
+++ b/src/game/gui/text/text.h
@@ -14,6 +14,15 @@ typedef struct text_document text_document;
 
 #define TEXT_BBOX_MAX UINT16_MAX
 
+// For compatibility
+#ifndef TEXT_MEDIUM_GREEN
+#define TEXT_DARK_GREEN 0xFE
+#define TEXT_MEDIUM_GREEN 0xFE
+#define TEXT_BLINKY_GREEN 0xFF
+#define TEXT_BRIGHT_GREEN 0xFD
+#define TEXT_TRN_BLUE 0xAB
+#endif
+
 #define TEXT_YELLOW 0xF8
 // EDIT: for shadows, the palette *one after* cshadow is used.
 // so we set TEXT_SHADOW_YELLOW to 0xC0 and it renders in 0xC1.

--- a/src/game/gui/text/text.h
+++ b/src/game/gui/text/text.h
@@ -53,6 +53,7 @@ void text_set_glyph_margin(text *t, uint8_t glyph_margin);
 void text_set_word_wrap(text *t, bool enable);
 
 void text_get_str(const text *t, str *dst);
+const char *text_c(const text *t);
 font_size text_get_font(const text *t);
 void text_get_bounding_box(const text *t, uint16_t *w, uint16_t *h);
 vga_index text_get_color(const text *t);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1508,6 +1508,7 @@ static text *create_text_object(const char *str) {
     text_set_shadow_style(obj, GLYPH_SHADOW_RIGHT | GLYPH_SHADOW_BOTTOM);
     text_set_word_wrap(obj, false);
     text_set_from_c(obj, str);
+    text_generate_layout(obj);
     return obj;
 }
 
@@ -1785,8 +1786,7 @@ int arena_create(scene *scene) {
 
     // Score positioning
     chr_score_set_pos(game_player_get_score(_player[0]), 5, 33, OBJECT_FACE_RIGHT);
-    chr_score_set_pos(game_player_get_score(_player[1]), 315, 33,
-                      OBJECT_FACE_LEFT); // TODO: Set better coordinates for this
+    chr_score_set_pos(game_player_get_score(_player[1]), 315, 33, OBJECT_FACE_LEFT);
 
     // Possibly use tournament mode scoring
     chr_score_set_tournament_mode(game_player_get_score(_player[0]), local->tournament);

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -39,7 +39,7 @@
 
 // the pilot name, HAR, and score
 #define TEXT_HUD_COLOR 0xE7
-#define TEXT_HUD_SHADOW 0xF7
+#define TEXT_HUD_SHADOW 0xF8
 
 #define HAR1_START_POS 110
 #define HAR2_START_POS 210
@@ -63,7 +63,7 @@ typedef enum
     DONE
 } win_state;
 
-typedef struct arena_local_t {
+typedef struct arena_local {
     gui_frame *game_menu;
 
     int menu_visible;
@@ -72,6 +72,10 @@ typedef struct arena_local_t {
 
     component *health_bars[2];
     component *endurance_bars[2];
+
+    text *player_name[2];
+    text *player_har[2];
+    text *player_ping[2];
 
     int round;
     int rounds;
@@ -946,6 +950,13 @@ void arena_free(scene *scene) {
         component_free(local->endurance_bars[i]);
     }
 
+    // Free player texts
+    for(int i = 0; i < 2; i++) {
+        text_free(&local->player_name[i]);
+        text_free(&local->player_har[i]);
+        text_free(&local->player_ping[i]);
+    }
+
     settings_save();
 
     omf_free(local);
@@ -1303,14 +1314,6 @@ void arena_render_overlay(scene *scene) {
 
     char buf[40];
 
-    text_settings tconf_players;
-    text_defaults(&tconf_players);
-    tconf_players.font = FONT_SMALL;
-    tconf_players.cforeground = TEXT_HUD_COLOR;
-    tconf_players.cshadow = TEXT_HUD_SHADOW;
-    tconf_players.shadow = TEXT_SHADOW_RIGHT | TEXT_SHADOW_BOTTOM;
-    const font *fnt = fonts_get_font(tconf_players.font);
-
     for(int i = 0; i < 2; i++) {
         player[i] = game_state_get_player(scene->gs, i);
         obj[i] = game_state_find_object(scene->gs, game_player_get_har_obj_id(player[i]));
@@ -1323,24 +1326,11 @@ void arena_render_overlay(scene *scene) {
         }
 
         // Render HAR and pilot names
-        const char *player1_name = NULL;
-        const char *player2_name = NULL;
-        player1_name = player[0]->pilot->name;
+        text_draw(local->player_name[0], 5, 19);
+        text_draw(local->player_har[0], 5, 26);
         if(player[1]->pilot) {
-            // when quitting this can go null
-            player2_name = player[1]->pilot->name;
-        }
-
-        text_render_mode(&tconf_players, TEXT_DEFAULT, 5, 19, 250, 6, player1_name);
-        text_render_mode(&tconf_players, TEXT_DEFAULT, 5, 26, 250, 6, lang_get((player[0]->pilot->har_id) + 31));
-
-        // when quitting, pilot can go null
-        if(player[1]->pilot) {
-            char const *player2_har = lang_get((player[1]->pilot->har_id) + 31);
-            int p2len = strlen(player2_name) * fnt->w;
-            int h2len = (strlen(player2_har) - 1) * fnt->w; // TODO: FIXME(lang): -1 because of errant newline
-            text_render_mode(&tconf_players, TEXT_DEFAULT, 315 - p2len, 19, 100, 6, player2_name);
-            text_render_mode(&tconf_players, TEXT_DEFAULT, 315 - h2len, 26, 100, 6, player2_har);
+            text_draw(local->player_name[1], 160, 19);
+            text_draw(local->player_har[1], 160, 26);
         }
 
         // Render score stuff
@@ -1350,12 +1340,13 @@ void arena_render_overlay(scene *scene) {
         // render ping, if player is networked
         if(player[0]->ctrl->type == CTRL_TYPE_NETWORK) {
             snprintf(buf, 40, "ping %d", player[0]->ctrl->rtt / 2);
-            text_render_mode(&tconf_players, TEXT_DEFAULT, 5, 40, 250, 6, buf);
+            text_set_from_c(local->player_ping[0], buf);
+            text_draw(local->player_ping[0], 5, 40);
         }
-
         if(player[1]->ctrl->type == CTRL_TYPE_NETWORK) {
             snprintf(buf, 40, "ping %d", player[1]->ctrl->rtt / 2);
-            text_render_mode(&tconf_players, TEXT_DEFAULT, 315 - (strlen(buf) * fnt->w), 40, 250, 6, buf);
+            text_set_from_c(local->player_ping[1], buf);
+            text_draw(local->player_ping[1], 160, 40);
         }
     }
 
@@ -1504,6 +1495,20 @@ void arena_startup(scene *scene, int id, int *m_load, int *m_repeat) {
                 return;
         }
     }
+}
+
+/**
+ * Creates text objects for har + player names and pings.
+ */
+static text *create_text_object(const char *str) {
+    // Width is screen size divided by two, minus left or right padding of 5 pixels.
+    text *obj = text_create_with_font_and_size(FONT_SMALL, 155, 6);
+    text_set_color(obj, TEXT_HUD_COLOR);
+    text_set_shadow_color(obj, TEXT_HUD_SHADOW);
+    text_set_shadow_style(obj, GLYPH_SHADOW_RIGHT | GLYPH_SHADOW_BOTTOM);
+    text_set_word_wrap(obj, false);
+    text_set_from_c(obj, str);
+    return obj;
 }
 
 int arena_create(scene *scene) {
@@ -1696,6 +1701,18 @@ int arena_create(scene *scene) {
         game_player_get_har_obj_id(_player[0]);
 
     maybe_install_har_hooks(scene);
+
+    // Set the name and HAR here, as they will remain static during the match. Ping will be dynamically set.
+    for(int i = 0; i < 2; i++) {
+        local->player_name[i] = create_text_object(_player[i]->pilot->name);
+        local->player_har[i] = create_text_object(lang_get(_player[i]->pilot->har_id + 31));
+        local->player_ping[i] = create_text_object("0");
+    }
+
+    // HAR 2 texts should be aligned to the right side of the screen.
+    text_set_horizontal_align(local->player_name[1], TEXT_ALIGN_RIGHT);
+    text_set_horizontal_align(local->player_har[1], TEXT_ALIGN_RIGHT);
+    text_set_horizontal_align(local->player_ping[1], TEXT_ALIGN_RIGHT);
 
     // Arena menu theme
     gui_theme theme;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -48,6 +48,7 @@
 #define GAME_MENU_QUIT_ID 101
 
 // Colors specific to palette used by arena
+#define DIALOG_BORDER_COLOR 0xFE
 #define TEXT_PRIMARY_COLOR 0xFE
 #define TEXT_SECONDARY_COLOR 0xFD
 #define TEXT_DISABLED_COLOR 0xC0
@@ -1718,7 +1719,7 @@ int arena_create(scene *scene) {
     // Arena menu theme
     gui_theme theme;
     gui_theme_defaults(&theme);
-    theme.dialog.border_color = TEXT_MEDIUM_GREEN;
+    theme.dialog.border_color = DIALOG_BORDER_COLOR;
     theme.text.primary_color = TEXT_PRIMARY_COLOR;
     theme.text.secondary_color = TEXT_SECONDARY_COLOR;
     theme.text.disabled_color = TEXT_DISABLED_COLOR;

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -17,8 +17,6 @@
 #include <stdio.h>
 
 // FIXME: No idea what these should be
-#define TEXT_COLOR 0xFE
-#define BLUE_TEXT_COLOR 0xFE
 #define TEXT_BLACK 1
 
 #define YELL_COLOR 3
@@ -30,6 +28,15 @@
 #define VERSION_BUF_SIZE 30
 // increment this when the protocol with the lobby server changes
 #define PROTOCOL_VERSION 0
+
+// GUI colors specific to palette used by lobby
+#define TEXT_PRIMARY_COLOR 6
+#define TEXT_SECONDARY_COLOR 6
+#define TEXT_DISABLED_COLOR 4
+#define TEXT_ACTIVE_COLOR 5
+#define TEXT_INACTIVE_COLOR 3
+#define TEXT_SHADOW_COLOR 6
+#define DIALOG_BORDER_COLOR 0xFE
 
 enum
 {
@@ -1385,14 +1392,14 @@ int lobby_create(scene *scene) {
     // Create lobby theme
     gui_theme theme;
     gui_theme_defaults(&theme);
-    theme.dialog.border_color = TEXT_MEDIUM_GREEN;
     theme.text.font = FONT_NET1;
-    theme.text.primary_color = 6;
-    theme.text.secondary_color = 6;
-    theme.text.disabled_color = 4;
-    theme.text.active_color = 5;
-    theme.text.inactive_color = 3;
-    theme.text.shadow_color = 6;
+    theme.dialog.border_color = DIALOG_BORDER_COLOR;
+    theme.text.primary_color = TEXT_PRIMARY_COLOR;
+    theme.text.secondary_color = TEXT_SECONDARY_COLOR;
+    theme.text.disabled_color = TEXT_DISABLED_COLOR;
+    theme.text.active_color = TEXT_ACTIVE_COLOR;
+    theme.text.inactive_color = TEXT_INACTIVE_COLOR;
+    theme.text.shadow_color = TEXT_SHADOW_COLOR;
 
     component *menu = menu_create();
     menu_set_horizontal(menu, true);

--- a/src/game/scenes/mainmenu.c
+++ b/src/game/scenes/mainmenu.c
@@ -18,6 +18,7 @@
 #define TEXT_ACTIVE_COLOR 0xFF
 #define TEXT_INACTIVE_COLOR 0xFE
 #define TEXT_SHADOW_COLOR 0xC0
+#define DIALOG_BORDER_COLOR 0xFE
 
 typedef struct mainmenu_local_t {
     gui_frame *frame;
@@ -110,7 +111,7 @@ int mainmenu_create(scene *scene) {
     // Create main menu
     gui_theme theme;
     gui_theme_defaults(&theme);
-    theme.dialog.border_color = TEXT_MEDIUM_GREEN;
+    theme.dialog.border_color = DIALOG_BORDER_COLOR;
     theme.text.font = FONT_BIG;
     theme.text.primary_color = TEXT_PRIMARY_COLOR;
     theme.text.secondary_color = TEXT_SECONDARY_COLOR;

--- a/src/game/scenes/scoreboard.c
+++ b/src/game/scenes/scoreboard.c
@@ -21,6 +21,7 @@
 
 static const char *SCORE_ROW_FMT = "%-18.16s%-9s%-9s%11s";
 
+#define DIALOG_BORDER_COLOR 0xFE
 #define TEXT_PRIMARY_COLOR 0xFD
 #define TEXT_SECONDARY_COLOR 0xFE
 #define TEXT_DISABLED_COLOR 0xC0
@@ -241,7 +242,7 @@ int scoreboard_create(scene *scene) {
     // Arena menu theme
     gui_theme theme;
     gui_theme_defaults(&theme);
-    theme.dialog.border_color = TEXT_MEDIUM_GREEN;
+    theme.dialog.border_color = DIALOG_BORDER_COLOR;
     theme.text.primary_color = TEXT_PRIMARY_COLOR;
     theme.text.secondary_color = TEXT_SECONDARY_COLOR;
     theme.text.disabled_color = TEXT_DISABLED_COLOR;

--- a/src/game/utils/score.h
+++ b/src/game/utils/score.h
@@ -1,7 +1,7 @@
 #ifndef SCORE_H
 #define SCORE_H
 
-#include "game/gui/text_render.h"
+#include "game/gui/text/text.h"
 #include "game/protos/object.h"
 #include "utils/list.h"
 #include "video/surface.h"
@@ -26,6 +26,7 @@ typedef struct chr_score_t {
     int direction;
     int difficulty;
     list texts;
+    text *total;
 
     int consecutive_hits;
     int consecutive_hit_score;

--- a/src/resources/languages.c
+++ b/src/resources/languages.c
@@ -32,6 +32,14 @@ bool lang_init(void) {
         goto error_0;
     }
 
+    // Trim off the last linebreak from the translation texts. We don't need it.
+    for(unsigned int i = 0; i < language->count; i++) {
+        size_t len = strlen(language->strings[i].data);
+        if(len > 0 && language->strings[i].data[len - 1] == '\n') {
+            language->strings[i].data[len - 1] = '\0';
+        }
+    }
+
     // OMF GERMAN.DAT and old versions of ENGLISH.DAT have only 990 strings
     unsigned int const old_language_count = 990;
 


### PR DESCRIPTION
Done:
- Remove trailing newline in language strings
- Make arena use the new text renderer (bacause arena texts broke due to the newline removal)
- Some color define fixes