### PR TITLE
Allow _setup_keyboard to specify the user and which config to user

### DIFF
--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -1100,7 +1100,7 @@ int game_state_num_players(game_state *gs) {
     return N_ELEMENTS(gs->players);
 }
 
-void _setup_keyboard(game_state *gs, int player_id) {
+void _setup_keyboard(game_state *gs, int player_id, int control_id) {
     settings_keyboard *k = &settings_get()->keys;
     // Set up controller
     controller *ctrl = omf_calloc(1, sizeof(controller));
@@ -1109,7 +1109,7 @@ void _setup_keyboard(game_state *gs, int player_id) {
 
     // Set up keyboards
     keyboard_keys *keys = omf_calloc(1, sizeof(keyboard_keys));
-    if(player_id == 0) {
+    if(control_id == 0) {
         keys->jump_up = SDL_GetScancodeFromName(k->key1_jump_up);
         keys->jump_right = SDL_GetScancodeFromName(k->key1_jump_right);
         keys->walk_right = SDL_GetScancodeFromName(k->key1_walk_right);
@@ -1175,7 +1175,7 @@ static void _setup_rec_controller(game_state *gs, int player_id, sd_rec_file *re
 void reconfigure_controller(game_state *gs) {
     settings_keyboard *k = &settings_get()->keys;
     if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-        _setup_keyboard(gs, 0);
+        _setup_keyboard(gs, 0, 0);
     } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
         if(!_setup_joystick(gs, 0, k->joy_name1, k->joy_offset1)) {
             // fallback on the good old keyboard
@@ -1185,7 +1185,7 @@ void reconfigure_controller(game_state *gs) {
     }
 
     // Set up second player keyboard to be available in menu
-    _setup_keyboard(gs, 1);
+    _setup_keyboard(gs, 1, 1);
 }
 
 void game_state_init_demo(game_state *gs) {

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -49,7 +49,7 @@ void game_state_play_sound(game_state *gs, int id, float volume, float panning, 
 int game_state_clone(game_state *src, game_state *dst);
 void game_state_clone_free(game_state *gs);
 
-void _setup_keyboard(game_state *gs, int player_id);
+void _setup_keyboard(game_state *gs, int player_id, int control_id);
 void _setup_ai(game_state *gs, int player_id);
 int _setup_joystick(game_state *gs, int player_id, const char *joyname, int offset);
 void reconfigure_controller(game_state *gs);

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -913,7 +913,7 @@ void lobby_tick(scene *scene, int paused) {
                     // Challengee -- local
                     settings_keyboard *k = &settings_get()->keys;
                     if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-                        _setup_keyboard(scene->gs, player_id);
+                        _setup_keyboard(scene->gs, player_id, 0);
                     } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                         _setup_joystick(scene->gs, player_id, k->joy_name1, k->joy_offset1);
                     }
@@ -1076,7 +1076,7 @@ void lobby_tick(scene *scene, int paused) {
                             // Challenger -- local
                             settings_keyboard *k = &settings_get()->keys;
                             if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-                                _setup_keyboard(scene->gs, player_id);
+                                _setup_keyboard(scene->gs, player_id, 0);
                             } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                                 _setup_joystick(scene->gs, player_id, k->joy_name1, k->joy_offset1);
                             }
@@ -1173,7 +1173,7 @@ void lobby_tick(scene *scene, int paused) {
                         // Challengee -- local
                         settings_keyboard *k = &settings_get()->keys;
                         if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-                            _setup_keyboard(scene->gs, player_id);
+                            _setup_keyboard(scene->gs, player_id, 0);
                         } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                             _setup_joystick(scene->gs, player_id, k->joy_name1, k->joy_offset1);
                         }

--- a/src/game/scenes/mainmenu/menu_connect.c
+++ b/src/game/scenes/mainmenu/menu_connect.c
@@ -160,7 +160,7 @@ void menu_connect_tick(component *c) {
             // Player 2 controller -- Local
             settings_keyboard *k = &settings_get()->keys;
             if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-                _setup_keyboard(gs, 1);
+                _setup_keyboard(gs, 1, 0);
             } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                 _setup_joystick(gs, 1, k->joy_name1, k->joy_offset1);
             }

--- a/src/game/scenes/mainmenu/menu_listen.c
+++ b/src/game/scenes/mainmenu/menu_listen.c
@@ -70,9 +70,9 @@ void menu_listen_tick(component *c) {
             // Player 1 controller -- Local
             settings_keyboard *k = &settings_get()->keys;
             if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-                _setup_keyboard(gs, 1);
+                _setup_keyboard(gs, 0, 0);
             } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
-                _setup_joystick(gs, 1, k->joy_name1, k->joy_offset1);
+                _setup_joystick(gs, 0, k->joy_name1, k->joy_offset1);
             }
 
             // Player 2 controller -- Network

--- a/src/game/scenes/mainmenu/menu_main.c
+++ b/src/game/scenes/mainmenu/menu_main.c
@@ -20,7 +20,7 @@ void mainmenu_1v1(component *c, void *userdata) {
     // Set up controllers
     settings_keyboard *k = &settings_get()->keys;
     if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-        _setup_keyboard(s->gs, 0);
+        _setup_keyboard(s->gs, 0, 0);
     } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
         _setup_joystick(s->gs, 0, k->joy_name1, k->joy_offset1);
     }
@@ -47,13 +47,13 @@ void mainmenu_1v2(component *c, void *userdata) {
 
     settings_keyboard *k = &settings_get()->keys;
     if(k->ctrl_type1 == CTRL_TYPE_KEYBOARD) {
-        _setup_keyboard(s->gs, 0);
+        _setup_keyboard(s->gs, 0, 0);
     } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
         _setup_joystick(s->gs, 0, k->joy_name1, k->joy_offset1);
     }
 
     if(k->ctrl_type2 == CTRL_TYPE_KEYBOARD) {
-        _setup_keyboard(s->gs, 1);
+        _setup_keyboard(s->gs, 1, 1);
     } else if(k->ctrl_type2 == CTRL_TYPE_GAMEPAD) {
         _setup_joystick(s->gs, 1, k->joy_name2, k->joy_offset2);
     }


### PR DESCRIPTION
In netplay, we sometimes want to use the player 1 keyboard controls for player 2 (the challengee). This change allows the game to apply the player 1 controls to the player 2 player for this situation.