### PR TITLE
Rewrite dissolve effects noise function

### DIFF
--- a/shaders/palette.frag
+++ b/shaders/palette.frag
@@ -29,7 +29,10 @@ float ATLAS_H = 2048.0;
 vec2 NATIVE_SIZE = vec2(320.0, 200.0);
 
 float noise(in vec2 v) {
-    return fract(tan(distance(v * PHI, v)) * v.x);
+    // OMF had a fairly random offset for each row, because
+    // they applied their noise row by row.
+    // they then changed the threshold by 0x6b for each subsequent X.
+    return fract(tan(10 * PHI * v.y) + (float(0x6b) * v.x) / 256.0);
 }
 
 vec4 handle(float index) {


### PR DESCRIPTION
after some poking around in ghidra, I found OMF's dissolve effect code.
Magic number 0x6B comes directly from that.

`tan(10*PHI*v.y)` is to offset each row, simulating how OMF's draw_sprite_row_dissolve would shift the pattern depending on where the row started.

<details>
<summary>Visual Comparison. OMF, OpenOMF (this PR), OpenOMF (master)</summary>

![image](https://github.com/user-attachments/assets/30c4fda3-d08e-4844-98fb-e995e6a1fc54)
![image](https://github.com/user-attachments/assets/565ae47d-5dc7-49c9-9611-860b3d87dc32)
![image](https://github.com/user-attachments/assets/96464723-fd30-4405-a9df-3bf79ccea33e)


</details>