### PR TITLE
Fix some bugs with unranked challengers:

### DIFF
--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -392,7 +392,8 @@ int newsroom_create(scene *scene) {
             local->challenger = fight_stats->challenger;
             p2->pilot = local->challenger;
             fight_stats->challenger = NULL;
-        } else if(p1->chr) {
+        } else if(p1->chr && p2->pilot && p2->pilot->rank != 0) {
+            // we didn't just beat an unranked challenger
             int health = game_player_get_score(p1)->health;
             // see if we have meet any unranked challenger criteria
             for(int k = p1->chr->pilot.enemies_ex_unranked - 1; k < p1->chr->pilot.enemies_inc_unranked; k++) {
@@ -421,7 +422,8 @@ int newsroom_create(scene *scene) {
                 }
             }
         }
-        if(!local->challenger && p1->chr && p1->chr->pilot.rank == 1) {
+        if(!local->challenger && p1->chr && p1->chr->pilot.rank == 1 && p2->pilot && p2->pilot->rank == 2) {
+            // we beat the champion, not an unranked challenger
             local->champion = true;
         }
         health = game_player_get_score(p1)->health;

--- a/src/game/scenes/newsroom.c
+++ b/src/game/scenes/newsroom.c
@@ -392,8 +392,7 @@ int newsroom_create(scene *scene) {
             local->challenger = fight_stats->challenger;
             p2->pilot = local->challenger;
             fight_stats->challenger = NULL;
-        } else if(p1->chr && p2->pilot && p2->pilot->rank != 0) {
-            // we didn't just beat an unranked challenger
+        } else if(p1->chr) {
             int health = game_player_get_score(p1)->health;
             // see if we have meet any unranked challenger criteria
             for(int k = p1->chr->pilot.enemies_ex_unranked - 1; k < p1->chr->pilot.enemies_inc_unranked; k++) {
@@ -414,8 +413,13 @@ int newsroom_create(scene *scene) {
                        (!p->req_fighter || p->req_fighter == p1->pilot->har_id) &&
                        (!p->req_scrap || (p->req_scrap && fight_stats->finish >= FINISH_SCRAP)) &&
                        (!p->req_destroy || (p->req_destroy && fight_stats->finish == FINISH_DESTRUCTION))) {
-                        fight_stats->challenger = p;
-                        log_debug("found challenger!");
+                        // check if we just beat an unranked challenger, and if this new unranked is directly tied to
+                        // that (eg. Jazz Jackrabbit and Eva Earlong) otherwise don't allow another unranked to chain
+                        if(p2->pilot && (p2->pilot->rank != 0 ||
+                                         (p->req_enemy && &p1->chr->enemies[p->req_enemy - 1]->pilot == p2->pilot))) {
+                            fight_stats->challenger = p;
+                            log_debug("found challenger!");
+                        }
                         // XXX we are going to assume the first match, from the lowest in the file, is the one to choose
                         break;
                     }


### PR DESCRIPTION
* Only play ending cutscene after beating the real tournament champion, not any unranked challengers that trigger thereafter
* Prevent beating an unranked challenger from triggering another unranked challenger