### PR TITLE
Don't free recs when --rec is passed on cli, fix double-free in sd_rec_free

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -409,6 +409,7 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
             data->last_traced_tick = ev->tick;
 
             for(int j = 0; j < 2; j++) {
+                memset(&move, 0, sizeof(move))
                 move.tick = ev->tick;
                 move.lookup_id = 2;
                 move.player_id = j;

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -409,7 +409,7 @@ int rewind_and_replay(wtf *data, game_state *gs_current) {
             data->last_traced_tick = ev->tick;
 
             for(int j = 0; j < 2; j++) {
-                memset(&move, 0, sizeof(move))
+                memset(&move, 0, sizeof(move));
                 move.tick = ev->tick;
                 move.lookup_id = 2;
                 move.player_id = j;

--- a/src/formats/rec.c
+++ b/src/formats/rec.c
@@ -45,6 +45,8 @@ void sd_rec_free(sd_rec_file *rec) {
     for(int i = 0; i < 2; i++) {
         sd_pilot_free(&rec->pilots[i].info);
     }
+    // zero it out so we can pass this so sd_rec_create can be used again
+    memset(rec, 0, sizeof(sd_rec_file));
 }
 
 int sd_rec_load(sd_rec_file *rec, const char *file) {
@@ -174,7 +176,7 @@ int sd_rec_load(sd_rec_file *rec, const char *file) {
         }
     }
 
-    // Okay, not reduce the allocated memory to match what we actually need
+    // Okay, now reduce the allocated memory to match what we actually need
     // Realloc should keep our old data intact
     rec->moves = omf_realloc(rec->moves, rec->move_count * sizeof(sd_rec_move));
 

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1546,9 +1546,6 @@ static void arena_free(scene *scene) {
         if(scene->gs->init_flags->record == 1) {
             // we're supposed to save it
             sd_rec_save(scene->gs->rec, scene->gs->init_flags->rec_file);
-            sd_rec_free(scene->gs->rec);
-            omf_free(scene->gs->rec);
-            scene->gs->rec = NULL;
         }
     }
 


### PR DESCRIPTION
This should help the netplay crash. #1153 