### PR TITLE
Fix versioncmake

### DIFF
--- a/cmake-scripts/version.cmake
+++ b/cmake-scripts/version.cmake
@@ -60,6 +60,8 @@ endmacro()
 if(DEFINED CMAKE_SCRIPT_MODE_FILE)
     # suppress find_package's status message in script mode
     set(GIT_FIND_QUIETLY QUIET)
+    # treat version errors as fatal
+    set(VERSION_REQUIRED ON)
 endif()
 
 find_package(Git ${GIT_FIND_QUIETLY})

--- a/cmake-scripts/version.cmake
+++ b/cmake-scripts/version.cmake
@@ -89,6 +89,7 @@ execute_process(
 execute_process(
     COMMAND "${GIT_EXECUTABLE}" cat-file -e "0.4"
     OUTPUT_QUIET ERROR_QUIET
+    RESULT_VARIABLE "GIT_ERRORCODE"
 )
 if(GIT_ERRORCODE)
     # tag 0.4 wasn't found, so fetch all tags


### PR DESCRIPTION
i broke it, working to fix it in this pr.

![image](https://github.com/user-attachments/assets/2ed57f7d-23a0-4ee4-840c-2052bb862362)

i thought i had VERSION_REQUIRED on in CI, but didn't-- hence why this failed silently.

I'm guessing that it's failing to fetch the tags?
EDIT: Yes, failing to fetch the tags.. by thinking it already had them! the third commit is the actual fix.