### PR TITLE
Restore Interpolator Logic

### DIFF
--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -128,6 +128,7 @@ struct object_t {
 
     player_sprite_state sprite_state;
     player_animation_state animation_state;
+    player_slide_state slide_state;
 
     // state ringbuffer
     uint32_t age;

--- a/src/game/protos/player.h
+++ b/src/game/protos/player.h
@@ -37,6 +37,11 @@ typedef struct player_sprite_state_t {
     bool bd_flag;        // bd
 } player_sprite_state;
 
+typedef struct player_slide_op_t {
+    vec2f vel;
+    int timer;
+} player_slide_state;
+
 typedef struct player_animation_state_t {
     uint32_t previous_tick;
     uint32_t current_tick;


### PR DESCRIPTION
Undo some changes from #1183
Realized that x= is an entirely different tag from x- or x+
enemy_slide_state is still totally unused and still deleted.