### PR TITLE
Implement input delay for smoother feeling netplay

### DIFF
--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -201,7 +201,7 @@ void controller_set_repeat(controller *ctrl, int repeat) {
 }
 
 bool controller_set_delay(controller *ctrl, uint8_t delay) {
-    if(ctrl->supports_delay && delay <= 10) {
+    if(ctrl->supports_delay && delay > 0 && delay <= 10) {
         if(!ctrl->buffer) {
             ctrl->buffer = omf_calloc(sizeof(vector), 1);
             vector_create_with_size(ctrl->buffer, sizeof(struct event_buffer_element), 11);

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -205,6 +205,7 @@ bool controller_set_delay(controller *ctrl, uint8_t delay) {
         ctrl->delay = delay;
         return true;
     }
+    ctrl->delay = 0;
     return false;
 }
 

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -6,6 +6,7 @@
 #include "game/protos/object.h"
 #include "game/utils/serial.h"
 #include "utils/list.h"
+#include "utils/vector.h"
 
 enum
 {
@@ -31,6 +32,8 @@ enum
     CTRL_TYPE_REC
 };
 
+// TODO this should be reduced to only ACTION and CLOSE
+// the rest are netplay specific and should not live here
 enum
 {
     EVENT_TYPE_ACTION,
@@ -45,6 +48,7 @@ typedef struct ctrl_event_t ctrl_event;
 
 struct ctrl_event_t {
     int type;
+    // TODO the 'ser' component is no longer used, remove it and this union
     union {
         int action;
         serial *ser;
@@ -56,8 +60,11 @@ typedef struct controller_t controller;
 
 struct controller_t {
     game_state *gs;
+    uint8_t delay;
+    bool supports_delay;
     uint32_t har_obj_id;
     list hooks;
+    vector *buffer;
     ctrl_event *extra_events;
     int (*tick_fun)(controller *ctrl, uint32_t ticks, ctrl_event **ev);
     int (*dyntick_fun)(controller *ctrl, uint32_t ticks, ctrl_event **ev);
@@ -89,6 +96,7 @@ void controller_clear_hooks(controller *ctrl);
 void controller_free_chain(ctrl_event *ev);
 void controller_free(controller *ctrl);
 void controller_set_repeat(controller *ctrl, int repeat);
+bool controller_set_delay(controller *ctrl, uint8_t delay);
 int controller_rumble(controller *ctrl, float magnitude, int duration);
 void controller_rewind(controller *ctrl);
 

--- a/src/controller/joystick.c
+++ b/src/controller/joystick.c
@@ -191,6 +191,7 @@ int joystick_create(controller *ctrl, int joystick_id) {
     ctrl->type = CTRL_TYPE_GAMEPAD;
     ctrl->poll_fun = &joystick_poll;
     ctrl->free_fun = &joystick_free;
+    ctrl->supports_delay = true;
 
     k->joy = SDL_GameControllerOpen(joystick_id);
     if(k->joy) {

--- a/src/controller/keyboard.c
+++ b/src/controller/keyboard.c
@@ -80,6 +80,7 @@ void keyboard_create(controller *ctrl, keyboard_keys *keys, int delay) {
     ctrl->type = CTRL_TYPE_KEYBOARD;
     ctrl->poll_fun = &keyboard_poll;
     ctrl->free_fun = &keyboard_free;
+    ctrl->supports_delay = true;
 }
 
 void keyboard_menu_poll(controller *ctrl, ctrl_event **ev) {

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -1137,6 +1137,12 @@ void _setup_keyboard(game_state *gs, int player_id, int control_id) {
 
     keyboard_create(ctrl, keys, 0);
 
+    if(control_id == 0) {
+        controller_set_delay(ctrl, k->input1_delay);
+    } else {
+        controller_set_delay(ctrl, k->input2_delay);
+    }
+
     // Set up player controller
     game_player_set_ctrl(player, ctrl);
     game_player_set_selectable(player, 1);
@@ -1160,6 +1166,11 @@ int _setup_joystick(game_state *gs, int player_id, const char *joyname, int offs
     controller_init(ctrl, gs);
 
     int res = joystick_create(ctrl, joystick_name_to_id(joyname, offset));
+    if(player_id == 0) {
+        controller_set_delay(ctrl, settings_get()->keys.input1_delay);
+    } else {
+        controller_set_delay(ctrl, settings_get()->keys.input1_delay);
+    }
     game_player_set_ctrl(player, ctrl);
     game_player_set_selectable(player, 1);
     return res;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -1169,7 +1169,7 @@ int _setup_joystick(game_state *gs, int player_id, const char *joyname, int offs
     if(player_id == 0) {
         controller_set_delay(ctrl, settings_get()->keys.input1_delay);
     } else {
-        controller_set_delay(ctrl, settings_get()->keys.input1_delay);
+        controller_set_delay(ctrl, settings_get()->keys.input2_delay);
     }
     game_player_set_ctrl(player, ctrl);
     game_player_set_selectable(player, 1);

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -939,16 +939,18 @@ void lobby_tick(scene *scene, int paused) {
                     net_ctrl = omf_calloc(1, sizeof(controller));
                     controller_init(net_ctrl, gs);
 
-                    game_player *challengee;
+                    game_player *challengee, *challenger;
 
                     int player_id = 0;
                     if(local->role == ROLE_CHALLENGER) {
                         // we did the connecting and we're the challenger
                         // so we are player 1
+                        challenger = p1;
                         challengee = p2;
                     } else {
                         player_id = 1;
                         challengee = p1;
+                        challenger = p2;
                     }
 
                     net_ctrl->har_obj_id = challengee->har_obj_id;
@@ -965,6 +967,7 @@ void lobby_tick(scene *scene, int paused) {
                     } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                         _setup_joystick(scene->gs, player_id, k->joy_name1, k->joy_offset1);
                     }
+                    controller_set_delay(challenger->ctrl, settings_get()->net.net_input_delay);
 
                     game_player_set_selectable(challengee, 1);
 
@@ -1104,16 +1107,18 @@ void lobby_tick(scene *scene, int paused) {
                             net_ctrl = omf_calloc(1, sizeof(controller));
                             controller_init(net_ctrl, gs);
 
-                            game_player *challengee;
+                            game_player *challengee, *challenger;
 
                             int player_id = 0;
                             if(local->role == ROLE_CHALLENGER) {
                                 // we were connected TO but we are the challenger
                                 // so we are player 1
+                                challenger = p1;
                                 challengee = p2;
                             } else {
                                 player_id = 1;
                                 challengee = p1;
+                                challenger = p2;
                             }
 
                             net_ctrl->har_obj_id = challengee->har_obj_id;
@@ -1130,6 +1135,7 @@ void lobby_tick(scene *scene, int paused) {
                             } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                                 _setup_joystick(scene->gs, player_id, k->joy_name1, k->joy_offset1);
                             }
+                            controller_set_delay(challenger->ctrl, settings_get()->net.net_input_delay);
 
                             game_player_set_selectable(challengee, 1);
 
@@ -1201,16 +1207,18 @@ void lobby_tick(scene *scene, int paused) {
                         net_ctrl = omf_calloc(1, sizeof(controller));
                         controller_init(net_ctrl, gs);
 
-                        game_player *challengee;
+                        game_player *challengee, *challenger;
 
                         int player_id = 0;
                         if(local->role == ROLE_CHALLENGER) {
                             // we did the connecting and we're the challenger
                             // so we are player 1
+                            challenger = p1;
                             challengee = p2;
                         } else {
                             player_id = 1;
                             challengee = p1;
+                            challenger = p2;
                         }
 
                         net_ctrl->har_obj_id = challengee->har_obj_id;
@@ -1227,6 +1235,7 @@ void lobby_tick(scene *scene, int paused) {
                         } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                             _setup_joystick(scene->gs, player_id, k->joy_name1, k->joy_offset1);
                         }
+                        controller_set_delay(challenger->ctrl, settings_get()->net.net_input_delay);
 
                         game_player_set_selectable(challengee, 1);
 

--- a/src/game/scenes/mainmenu/menu_connect.c
+++ b/src/game/scenes/mainmenu/menu_connect.c
@@ -164,6 +164,7 @@ void menu_connect_tick(component *c) {
             } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                 _setup_joystick(gs, 1, k->joy_name1, k->joy_offset1);
             }
+            controller_set_delay(player2_ctrl, settings_get()->net.net_input_delay);
             game_player_set_selectable(p2, 1);
 
             chr_score_set_difficulty(game_player_get_score(game_state_get_player(gs, 0)), AI_DIFFICULTY_CHAMPION);

--- a/src/game/scenes/mainmenu/menu_input.c
+++ b/src/game/scenes/mainmenu/menu_input.c
@@ -178,6 +178,7 @@ void menu_input_free(component *c) {
 
 component *menu_input_create(scene *s, int player_id) {
     menu_input_local *local = omf_calloc(1, sizeof(menu_input_local));
+    const char *input_delays[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
     local->selected_player = player_id;
 
     component *menu = menu_create();
@@ -210,6 +211,16 @@ component *menu_input_create(scene *s, int player_id) {
     }
     menu_attach(menu, joy1);
     menu_attach(menu, joy2);
+
+    int *bind_var = &settings_get()->keys.input1_delay;
+
+    if(player_id == 1) {
+        bind_var = &settings_get()->keys.input2_delay;
+    }
+    menu_attach(menu, textselector_create_bind_opts("INPUT DELAY",
+                                                    "Set input delay, useful for local netplay practice, default is 0",
+                                                    NULL, NULL, bind_var, input_delays, 11));
+
     menu_attach(menu, button_create("DONE", "Leave without changing anything.", false, false, menu_input_done, NULL));
 
     menu_set_userdata(menu, local);

--- a/src/game/scenes/mainmenu/menu_input.c
+++ b/src/game/scenes/mainmenu/menu_input.c
@@ -214,7 +214,7 @@ component *menu_input_create(scene *s, int player_id) {
 
     int *bind_var = &settings_get()->keys.input1_delay;
 
-    if(player_id == 1) {
+    if(player_id == 2) {
         bind_var = &settings_get()->keys.input2_delay;
     }
     menu_attach(menu, textselector_create_bind_opts("INPUT DELAY",

--- a/src/game/scenes/mainmenu/menu_listen.c
+++ b/src/game/scenes/mainmenu/menu_listen.c
@@ -74,6 +74,7 @@ void menu_listen_tick(component *c) {
             } else if(k->ctrl_type1 == CTRL_TYPE_GAMEPAD) {
                 _setup_joystick(gs, 0, k->joy_name1, k->joy_offset1);
             }
+            controller_set_delay(player1_ctrl, settings_get()->net.net_input_delay);
 
             // Player 2 controller -- Network
             net_controller_create(player2_ctrl, local->host, event.peer, NULL, ROLE_SERVER);

--- a/src/game/scenes/mainmenu/menu_netconfig.c
+++ b/src/game/scenes/mainmenu/menu_netconfig.c
@@ -13,6 +13,7 @@ void menu_netconfig_done(component *c, void *u) {
 component *menu_netconfig_create(scene *s) {
     const char *bool_opts[] = {"OFF", "ON"};
 
+    const char *input_delays[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
     component *menu = menu_create();
     menu_attach(menu, label_create_title("NETWORK CONFIG"));
     menu_attach(menu, filler_create());
@@ -22,6 +23,9 @@ component *menu_netconfig_create(scene *s) {
     menu_attach(menu, textselector_create_bind_opts("ENABLE UPnP",
                                                     "Enable this if your router has working UPnP, disable otherwise.",
                                                     NULL, NULL, &settings_get()->net.net_use_upnp, bool_opts, 2));
+    menu_attach(menu, textselector_create_bind_opts(
+                          "INPUT DELAY", "Set input delay, in game ticks, for smoother rollback, default is 0", NULL,
+                          NULL, &settings_get()->net.net_input_delay, input_delays, 11));
 
     menu_attach(menu, button_create("DONE", "Go back to the main menu.", false, false, menu_netconfig_done, NULL));
     return menu;

--- a/src/game/utils/settings.c
+++ b/src/game/utils/settings.c
@@ -128,6 +128,7 @@ const field f_keyboard[] = {
     F_STRING(settings_keyboard, key1_jump_left, "Home"),
     F_STRING(settings_keyboard, key1_kick, "Right Shift"),
     F_STRING(settings_keyboard, key1_punch, "Return"),
+    F_INT(settings_keyboard, input1_delay, 0),
 
     // Player two
     F_INT(settings_keyboard, ctrl_type2, CTRL_TYPE_KEYBOARD),
@@ -143,6 +144,7 @@ const field f_keyboard[] = {
     F_STRING(settings_keyboard, key2_jump_left, "Q"),
     F_STRING(settings_keyboard, key2_kick, "Left Shift"),
     F_STRING(settings_keyboard, key2_punch, "Left Ctrl"),
+    F_INT(settings_keyboard, input2_delay, 0),
 };
 
 const field f_net[] = {
@@ -156,7 +158,8 @@ const field f_net[] = {
     F_INT(settings_network, net_ext_port_start, 0),
     F_INT(settings_network, net_ext_port_end, 0),
     F_BOOL(settings_network, net_use_pmp, 1),
-    F_BOOL(settings_network, net_use_upnp, 1)
+    F_BOOL(settings_network, net_use_upnp, 1),
+    F_INT(settings_network, net_input_delay, 0),
 };
 
 // Map struct to field

--- a/src/game/utils/settings.h
+++ b/src/game/utils/settings.h
@@ -92,6 +92,7 @@ typedef struct {
     char *key1_jump_left;
     char *key1_kick;
     char *key1_punch;
+    int input1_delay;
 
     // Player two
     int ctrl_type2;
@@ -107,6 +108,7 @@ typedef struct {
     char *key2_jump_left;
     char *key2_kick;
     char *key2_punch;
+    int input2_delay;
 } settings_keyboard;
 
 typedef struct {
@@ -121,6 +123,7 @@ typedef struct {
     int net_ext_port_end;
     int net_use_upnp;
     int net_use_pmp;
+    int net_input_delay;
 } settings_network;
 
 typedef struct {


### PR DESCRIPTION
Allow delay of up to 10 frames on local input. This helps reduce the jittery feel that can happen with laggy netplay. Additionally allow delay to be set in local play as well so that people can develop muscle memory for a given input delay.