### PR TITLE
Fix version.cmake non-prerelease tag matching

### DIFF
--- a/cmake-scripts/version.cmake
+++ b/cmake-scripts/version.cmake
@@ -160,7 +160,7 @@ while(1) # loop until we found a release that is not newer than HEAD
     endif()
 
     # use regex to extract the first release tag from the list
-    string(REGEX MATCH "(^|\n)([0-9]+[.][0-9]+[.][0-9]+(-)[A-Za-z0-9.]*)(\n.*|$)" outvar_dontcare "${VERSION_TAGS}")
+    string(REGEX MATCH "(^|\n)([0-9]+[.][0-9]+[.][0-9]+(-[A-Za-z0-9.]*)?)(\n.*|$)" outvar_dontcare "${VERSION_TAGS}")
     set(LATEST_RELEASE_TAG "${CMAKE_MATCH_2}")
     set(VERSION_TAGS "${CMAKE_MATCH_4}") # set VERSION_TAGS to the older ones we haven't look at yet.
 


### PR DESCRIPTION
As Vagabond wrote in Discord:
>  I think the regexp on line 154 of version,cmake is ignoring tags without a label

Now it successfully matches `0.8.1` (and thus labels `master` as a 0.8.2 prerelease)