### PR TITLE
Create a cache for the 'shadow trail' animation effects

### DIFF
--- a/src/game/objects/har.h
+++ b/src/game/objects/har.h
@@ -188,7 +188,7 @@ typedef struct har_t {
 
     vector child_objects;
     hashmap disabled_animations;
-    hashmap trail_cache;
+    hashmap *trail_cache;
 
 #ifdef DEBUGMODE
     surface hit_pixel;

--- a/src/game/objects/har.h
+++ b/src/game/objects/har.h
@@ -188,6 +188,7 @@ typedef struct har_t {
 
     vector child_objects;
     hashmap disabled_animations;
+    hashmap trail_cache;
 
 #ifdef DEBUGMODE
     surface hit_pixel;


### PR DESCRIPTION
Currently we are creating a new animation and sprite for every single frame that needs a trail effect. Netcode rollbacks can cause this to overflow the atlas. This patch changes things so that each potential sprite that needs the trail effect only creates one animation, that is cached and reused (along with the associated sprite).