### PR TITLE
Implemented AG and UG tags

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -1030,13 +1030,11 @@ void har_spawn_scrap(object *obj, vec2i pos, int amount) {
 
 void har_block(object *obj, vec2i hit_coord, uint8_t block_stun) {
     har *h = obj->userdata;
-    if(h->state == STATE_WALKFROM) {
-        object_set_animation(obj, &af_get_move(h->af_data, ANIM_STANDING_BLOCK)->ani);
-    } else if(h->state == STATE_BLOCKSTUN) {
-        // restart the block animation
-        object_set_animation(obj, obj->cur_animation);
-    } else {
+    char last_input = get_last_input(h);
+    if(last_input == '1' || last_input == '3') {
         object_set_animation(obj, &af_get_move(h->af_data, ANIM_CROUCHING_BLOCK)->ani);
+    } else {
+        object_set_animation(obj, &af_get_move(h->af_data, ANIM_STANDING_BLOCK)->ani);
     }
     // the HARs have a lame blank frame in their animation string, so use a custom one
 

--- a/src/game/objects/har.h
+++ b/src/game/objects/har.h
@@ -206,7 +206,7 @@ void har_walk_to(object *obj, int destination);
 int har_is_active(object *obj);
 int har_is_crouching(har *h);
 int har_is_walking(har *h);
-int har_is_blocking(har *h, af_move *move);
+int har_is_blocking(object *obj, af_move *move);
 void har_copy_actions(object *new, object *old);
 void har_reset(object *obj);
 

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -816,7 +816,7 @@ void object_set_disable_cb(object *obj, object_state_disable_cb cbf, void *userd
 }
 
 int object_is_airborne(const object *obj) {
-    return obj->pos.y < ARENA_FLOOR || obj->vel.y < 0;
+    return obj->pos.y < ARENA_FLOOR || obj->vel.y < 0 || player_frame_isset(obj, "ug");
 }
 
 /* Attaches one object to another. Positions are synced to this from the attached. */

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -87,6 +87,7 @@ struct object_t {
     // Set when moving against the wall either by continuous velocity or by instantaneous position changes.
     bool wall_collision;
     bool hit_pixels_disabled;
+    bool crossup_protection;
 
     // Set by q tag
     int8_t q_counter;

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -336,7 +336,7 @@ void player_run(object *obj) {
             }
         }
 
-        if(sd_script_isset(frame, "bm")) {
+        if(sd_script_isset(frame, "bm") && enemy) {
             int destination = 160;
             if(sd_script_isset(frame, "am") && sd_script_isset(frame, "e")) {
                 // destination is the enemy's position

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -230,11 +230,7 @@ void player_run(object *obj) {
     }
 
     if(enemy) {
-        if(sd_script_isset(frame, "ag")) {
-            enemy->crossup_protection = true;
-        } else {
-            enemy->crossup_protection = false;
-        }
+        enemy->crossup_protection = sd_script_isset(frame, "ag");
     }
 
     if(sd_script_isset(frame, "ar")) {

--- a/src/game/protos/player.c
+++ b/src/game/protos/player.c
@@ -229,6 +229,14 @@ void player_run(object *obj) {
         // log_debug("E: pos.x = %f, pos.y = %f", obj->pos.x, obj->pos.y);
     }
 
+    if(enemy) {
+        if(sd_script_isset(frame, "ag")) {
+            enemy->crossup_protection = true;
+        } else {
+            enemy->crossup_protection = false;
+        }
+    }
+
     if(sd_script_isset(frame, "ar")) {
         object_set_direction(obj, object_get_direction(obj) * -1);
     }


### PR DESCRIPTION
fixes #329 

- UG moves are treated as airborne (Electra rolling thunder, Shredder headbutt)
- AG allows blocking from both sides (Jaguar overhead throw, Katana wallspin)

Reworked blocking so that a player must hold the direction to continue blocking