### PR TITLE
Fix Scrap Before Match End

### DIFF
--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -2106,6 +2106,12 @@ bool is_move_chain_allowed(object *obj, af_move *move) {
                 break;
         }
     }
+
+    bool is_over = arena_is_over(obj->gs->sc) != -1;
+    if(move->category == CAT_SCRAP && !is_over) {
+        allowed = false;
+    }
+
     return allowed;
 }
 


### PR DESCRIPTION
Thorn's scrap uses a different tag than other scrap moves, so another check needs to be done to disable it