### PR TITLE
Fix fire orb random to not desync netplay

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -394,7 +394,7 @@ int rewind_and_replay(wtf *data, controller *ctrl) {
                 do {
                     object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ev->events[j][k]);
                     k++;
-                } while(ev->events[j][k]);
+                } while(ev->events[j][k] && k < 11);
             }
 
             // update arena hash now inputs have been done
@@ -414,7 +414,7 @@ int rewind_and_replay(wtf *data, controller *ctrl) {
                     move.action = 0;
 
                     int k = 0;
-                    while(ev->events[j][k]) {
+                    while(ev->events[j][k] && k < 11) {
                         if(ev->events[j][k] & ACT_PUNCH) {
                             move.action |= SD_ACT_PUNCH;
                         }
@@ -1240,7 +1240,7 @@ int net_controller_poll(controller *ctrl, ctrl_event **ev) {
             return 0;
         } else if(e->events[id][0] != 0 && e->tick < current_tick) {
             int i = 0;
-            while(e->events[id][i]) {
+            while(e->events[id][i] && i < 11) {
                 last = e->events[id][i];
                 i++;
             }

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -71,9 +71,11 @@ typedef struct {
     int winner;
 } wtf;
 
+#define MAX_EVENTS_PER_TICK 11
+
 typedef struct {
     uint32_t tick;
-    uint8_t events[2][11];
+    uint8_t events[2][MAX_EVENTS_PER_TICK];
 } tick_events;
 
 // simple standard deviation calculation
@@ -124,8 +126,8 @@ void insert_event(wtf *data, uint32_t tick, uint16_t action, int id) {
     tick_events *nev = NULL;
     tick_events event;
     event.tick = tick;
-    memset(event.events[id], 0, 11);
-    memset(event.events[abs(id - 1)], 0, 11);
+    memset(event.events[id], 0, MAX_EVENTS_PER_TICK);
+    memset(event.events[abs(id - 1)], 0, MAX_EVENTS_PER_TICK);
     event.events[id][0] = action;
     int i = 0;
 
@@ -149,7 +151,7 @@ void insert_event(wtf *data, uint32_t tick, uint16_t action, int id) {
             list_prepend(transcript, &event, sizeof(tick_events));
             goto done;
         } else if(ev->tick == tick) {
-            for(int j = 0; j < 11; j++) {
+            for(int j = 0; j < MAX_EVENTS_PER_TICK; j++) {
                 if(ev->events[id][j] == 0) {
                     if(j > 0 && ev->events[id][j - 1] == action) {
                         // dedup
@@ -195,7 +197,7 @@ bool has_event(wtf *data, int delay) {
 
 void event_names(char *buf, uint8_t *actions) {
 
-    for(int i = 0; i < 11; i++) {
+    for(int i = 0; i < MAX_EVENTS_PER_TICK; i++) {
         uint8_t action = actions[i];
         if(action == ACT_STOP) {
             buf[0] = '5';
@@ -394,7 +396,7 @@ int rewind_and_replay(wtf *data, controller *ctrl) {
                 do {
                     object_act(game_state_find_object(gs, game_player_get_har_obj_id(player)), ev->events[j][k]);
                     k++;
-                } while(ev->events[j][k] && k < 11);
+                } while(ev->events[j][k] && k < MAX_EVENTS_PER_TICK);
             }
 
             // update arena hash now inputs have been done
@@ -414,7 +416,7 @@ int rewind_and_replay(wtf *data, controller *ctrl) {
                     move.action = 0;
 
                     int k = 0;
-                    while(ev->events[j][k] && k < 11) {
+                    while(ev->events[j][k] && k < MAX_EVENTS_PER_TICK) {
                         if(ev->events[j][k] & ACT_PUNCH) {
                             move.action |= SD_ACT_PUNCH;
                         }
@@ -1240,7 +1242,7 @@ int net_controller_poll(controller *ctrl, ctrl_event **ev) {
             return 0;
         } else if(e->events[id][0] != 0 && e->tick < current_tick) {
             int i = 0;
-            while(e->events[id][i] && i < 11) {
+            while(e->events[id][i] && i < MAX_EVENTS_PER_TICK) {
                 last = e->events[id][i];
                 i++;
             }

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -1011,10 +1011,6 @@ void game_state_static_tick(game_state *gs, bool replay) {
 // This function is called when the game speed requires it
 void game_state_dynamic_tick(game_state *gs, bool replay) {
 
-    if(gs->hit_pause > 0) {
-        gs->hit_pause--;
-        return;
-    }
     // Change the screen shake value downwards
     if(gs->screen_shake_horizontal > 0 && !gs->paused) {
         gs->screen_shake_horizontal--;
@@ -1049,8 +1045,12 @@ void game_state_dynamic_tick(game_state *gs, bool replay) {
         game_state_dyntick_controllers(gs);
     }
 
-    // Tick scene
-    scene_dynamic_tick(gs->sc, game_state_is_paused(gs));
+    if(gs->hit_pause > 0) {
+        gs->hit_pause--;
+    } else {
+        // Tick scene
+        scene_dynamic_tick(gs->sc, game_state_is_paused(gs));
+    }
 
     // Poll input. If console is opened, do not poll the controllers.
     if((!console_window_is_open() || gs->init_flags->playback) && !replay) {

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -787,7 +787,6 @@ void apply_stun_damage(object *obj, int stun_amount) {
     stun_amount = (stun_amount * 2 + 12) * 256;
     log_debug("applying %d endurance damage to %d", stun_amount, h->endurance);
     h->endurance += stun_amount;
-    log_debug("endurance is now %d", h->endurance);
 
     if(h->endurance < 1) {
         if(h->state == STATE_STUNNED) {
@@ -1759,8 +1758,6 @@ static void har_palette_transform(damage_tracker *damage, vga_palette *pal, void
 void har_handle_stun(object *obj) {
     har *h = object_get_userdata(obj);
 
-    uint32_t old_endurance = h->endurance;
-
     if(h->health <= 0) { // Lock the stun meter to near-empty when KO'd
         h->endurance = h->endurance_max - 2;
     } else {
@@ -1807,8 +1804,6 @@ void har_handle_stun(object *obj) {
             har_stunned_done(obj);
         }
     }
-
-    log_debug("har endurance went from %d to %d on tick %d", old_endurance, h->endurance, obj->gs->int_tick);
 }
 
 void har_tick(object *obj) {

--- a/src/game/objects/har.c
+++ b/src/game/objects/har.c
@@ -785,8 +785,9 @@ void apply_stun_damage(object *obj, int stun_amount) {
         stun_amount /= 2;
     }
     stun_amount = (stun_amount * 2 + 12) * 256;
-    log_debug("applying %f stun damage to %f", stun_amount, h->endurance);
+    log_debug("applying %d endurance damage to %d", stun_amount, h->endurance);
     h->endurance += stun_amount;
+    log_debug("endurance is now %d", h->endurance);
 
     if(h->endurance < 1) {
         if(h->state == STATE_STUNNED) {
@@ -1758,6 +1759,8 @@ static void har_palette_transform(damage_tracker *damage, vga_palette *pal, void
 void har_handle_stun(object *obj) {
     har *h = object_get_userdata(obj);
 
+    uint32_t old_endurance = h->endurance;
+
     if(h->health <= 0) { // Lock the stun meter to near-empty when KO'd
         h->endurance = h->endurance_max - 2;
     } else {
@@ -1804,6 +1807,8 @@ void har_handle_stun(object *obj) {
             har_stunned_done(obj);
         }
     }
+
+    log_debug("har endurance went from %d to %d on tick %d", old_endurance, h->endurance, obj->gs->int_tick);
 }
 
 void har_tick(object *obj) {

--- a/src/game/protos/object.c
+++ b/src/game/protos/object.c
@@ -50,9 +50,6 @@ void object_create(object *obj, game_state *gs, vec2i pos, vec2f vel) {
     // Attachment stuff
     obj->attached_to_id = 0;
 
-    // Fire orb wandering
-    obj->orb_val = random_int(&gs->rand, 255) - 127;
-
     // Animation playback related
     obj->cur_animation_own = OWNER_EXTERNAL;
     obj->cur_animation = NULL;
@@ -68,8 +65,6 @@ void object_create(object *obj, game_state *gs, vec2i pos, vec2f vel) {
     obj->cast_shadow = 0;
     obj->age = 0;
     player_create(obj);
-
-    random_seed(&obj->rand_state, rand_intmax());
 
     // For enabling multiple hits per move
     obj->q_counter = 0;

--- a/src/game/protos/object.h
+++ b/src/game/protos/object.h
@@ -104,8 +104,6 @@ struct object_t {
 
     int8_t orb_val;
 
-    struct random_t rand_state;
-
     float x_percent;
     float y_percent;
     float gravity;

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -868,6 +868,7 @@ uint32_t arena_state_hash(game_state *gs) {
         hash = ((hash << 5) + hash) + har->state;
         hash = ((hash << 5) + hash) + har->executing_move;
         hash = ((hash << 5) + hash) + obj_har->cur_animation->id;
+        hash = ((hash << 5) + hash) + random_get_seed(&gs->rand);
     }
     return hash;
 }
@@ -921,10 +922,10 @@ void arena_state_dump(game_state *gs, char *buf, size_t bufsize) {
         vec2f vel = object_get_vel(obj_har);
         off = snprintf(buf + off, bufsize - off,
                        "player %d  power %d agility %d endurance %d HAR id %d  pos %d,%d, health %d, endurance %d, "
-                       "velocity %f,%f, state %s, executing_move %d cur_anim %d\n",
+                       "velocity %f,%f, state %s, executing_move %d cur_anim %d seed %" PRIu32 "\n",
                        i, player->pilot->power, player->pilot->agility, player->pilot->endurance, har->id, pos.x, pos.y,
                        har->health, har->endurance, vel.x, vel.y, state_name(har->state), har->executing_move,
-                       obj_har->cur_animation->id);
+                       obj_har->cur_animation->id, random_get_seed(&gs->rand));
     }
 }
 
@@ -1032,6 +1033,8 @@ void arena_spawn_hazard(scene *scene) {
                 object_create(obj, scene->gs, info->ani.start_pos, vec2f_create(0, 0));
                 object_set_stl(obj, scene->bk_data->sound_translation_table);
                 object_set_animation(obj, &info->ani);
+                // fire pit wandering (in case this is an orb)
+                obj->orb_val = random_int(&scene->gs->rand, 255) - 127;
                 if(scene->id == SCENE_ARENA3 && info->ani.id == 0) {
                     // XXX fire pit orb has a bug whwre it double spawns. Use a custom animation string to avoid it
                     // it mioght be to do with the 'mp' tag, which we don't currently understand


### PR DESCRIPTION
Also, this adds the random seed to the arena hash so it's easier to detect a desync like this. Also adds some logging improvements for debugging.