### PR TITLE
Implement Lobby Match Settings

### DIFF
--- a/src/controller/spec_controller.c
+++ b/src/controller/spec_controller.c
@@ -49,12 +49,17 @@ int spec_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                 serial_create_from(&ser, (const char *)event.packet->data, event.packet->dataLength);
                 switch(serial_read_int8(&ser)) {
                     case 0: {
+                        match_settings ms;
                         // init packet, describes the pilots and arena, we can use this to start the arena
                         game_player *p1 = game_state_get_player(ctrl->gs, 0);
                         game_player *p2 = game_state_get_player(ctrl->gs, 1);
 
                         // force the speed to 3
                         game_state_set_speed(ctrl->gs, 10);
+
+                        // decode the match settings from the lobby and apply them
+                        game_state_decode_match_settings(&ser, &ms);
+                        game_state_copy_match_settings(ctrl->gs, &ms);
 
                         p1->pilot->har_id = serial_read_int8(&ser);
                         p1->pilot->pilot_id = serial_read_int8(&ser);

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -190,6 +190,24 @@ void game_state_match_settings_reset(game_state *gs) {
     gs->match_settings.sim = false;
 }
 
+void game_state_copy_match_settings(game_state *gs, const match_settings *ms) {
+    log_debug("Copying settings, hyper mode is %d", ms->fight_mode);
+    gs->match_settings.throw_range = ms->throw_range;
+    gs->match_settings.hit_pause = ms->hit_pause;
+    gs->match_settings.block_damage = ms->block_damage;
+    gs->match_settings.vitality = ms->vitality;
+    gs->match_settings.jump_height = ms->jump_height;
+    gs->match_settings.knock_down = ms->knock_down;
+    gs->match_settings.rehit = ms->rehit;
+    gs->match_settings.defensive_throws = ms->defensive_throws;
+    gs->match_settings.power1 = ms->power1;
+    gs->match_settings.power2 = ms->power2;
+    gs->match_settings.hazards = ms->hazards;
+    gs->match_settings.rounds = ms->rounds;
+    gs->match_settings.fight_mode = ms->fight_mode;
+    gs->match_settings.sim = false;
+}
+
 void game_state_match_settings_defaults(game_state *gs) {
     gs->match_settings.throw_range = 100;
     gs->match_settings.hit_pause = 4;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -191,7 +191,7 @@ void game_state_match_settings_reset(game_state *gs) {
 }
 
 void game_state_copy_match_settings(game_state *gs, const match_settings *ms) {
-    log_debug("Copying settings, hyper mode is %d", ms->fight_mode);
+    log_debug("Copying settings");
     gs->match_settings.throw_range = ms->throw_range;
     gs->match_settings.hit_pause = ms->hit_pause;
     gs->match_settings.block_damage = ms->block_damage;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -73,6 +73,44 @@ typedef struct {
     int playback_id;
 } playing_sound;
 
+// 14 bytes of match settings
+void game_state_encode_match_settings(serial *ser, match_settings *ms) {
+    serial_write_int16(ser, ms->throw_range);
+    serial_write_int16(ser, ms->hit_pause);
+    serial_write_int16(ser, ms->block_damage);
+    serial_write_int16(ser, ms->vitality);
+    serial_write_int16(ser, ms->jump_height);
+    uint32_t out = 0;
+    out |= (ms->knock_down & 0x3) << 0;
+    out |= (ms->rehit & 0x1) << 2;
+    out |= (ms->defensive_throws & 0x1) << 3;
+    out |= (ms->power1 & 0x1F) << 9;
+    out |= (ms->power2 & 0x1F) << 14;
+    out |= (ms->hazards & 0x1) << 19;
+    out |= (ms->rounds & 0x3) << 20;
+    out |= (ms->fight_mode & 0x1) << 24;
+
+    serial_write_int32(ser, out);
+}
+
+// 14 bytes of match settings
+void game_state_decode_match_settings(serial *ser, match_settings *ms) {
+    ms->throw_range = serial_read_int16(ser);
+    ms->hit_pause = serial_read_int16(ser);
+    ms->block_damage = serial_read_int16(ser);
+    ms->vitality = serial_read_int16(ser);
+    ms->jump_height = serial_read_int16(ser);
+    uint32_t in = serial_read_int32(ser);
+    ms->knock_down = (in >> 0) & 0x03;       // 00000000 00000000 00000000 00000011 (2)
+    ms->rehit = (in >> 2) & 0x01;            // 00000000 00000000 00000000 00000100 (1)
+    ms->defensive_throws = (in >> 3) & 0x01; // 00000000 00000000 00000000 00001000 (1)
+    ms->power1 = (in >> 9) & 0x1F;           // 00000000 00000000 00111110 00000000 (5)
+    ms->power2 = (in >> 14) & 0x1F;          // 00000000 00000111 11000000 00000000 (5)
+    ms->hazards = (in >> 19) & 0x01;         // 00000000 00001000 00000000 00000000 (1)
+    ms->rounds = (in >> 20) & 0x03;          // 00000000 00110000 00000000 00000000 (2)
+    ms->fight_mode = (in >> 24) & 0x01;      // 00000001 00000000 00000000 00000000 (1)
+}
+
 int game_state_get_assertion_operand(rec_assertion_operand *op, game_state *gs) {
     if(op->is_literal) {
         return op->value.literal;

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -111,6 +111,10 @@ void game_state_decode_match_settings(serial *ser, match_settings *ms) {
     ms->fight_mode = (in >> 24) & 0x01;      // 00000001 00000000 00000000 00000000 (1)
 }
 
+void game_state_set_pilot_name(game_state *gs, int pilot_id, const char *pilot_name) {
+    strncpy_or_truncate(gs->players[pilot_id]->pilot->name, pilot_name, sizeof(gs->players[pilot_id]->pilot->name));
+}
+
 int game_state_get_assertion_operand(rec_assertion_operand *op, game_state *gs) {
     if(op->is_literal) {
         return op->value.literal;

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -16,6 +16,7 @@ typedef struct ctrl_event_t ctrl_event;
 
 void game_state_encode_match_settings(serial *ser, match_settings *ms);
 void game_state_decode_match_settings(serial *ser, match_settings *ms);
+void game_state_set_pilot_name(game_state *gs, int pilot_id, const char *pilot_name);
 
 bool game_state_check_assertion_is_met(rec_assertion *ass, game_state *gs);
 

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -14,6 +14,9 @@ typedef struct game_player_t game_player;
 typedef struct object_t object;
 typedef struct ctrl_event_t ctrl_event;
 
+void game_state_encode_match_settings(serial *ser, match_settings *ms);
+void game_state_decode_match_settings(serial *ser, match_settings *ms);
+
 bool game_state_check_assertion_is_met(rec_assertion *ass, game_state *gs);
 
 void game_state_match_settings_reset(game_state *gs);

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -17,6 +17,7 @@ typedef struct ctrl_event_t ctrl_event;
 bool game_state_check_assertion_is_met(rec_assertion *ass, game_state *gs);
 
 void game_state_match_settings_reset(game_state *gs);
+void game_state_copy_match_settings(game_state *gs, const match_settings *ms);
 void game_state_match_settings_defaults(game_state *gs);
 int game_state_create(game_state *gs, engine_init_flags *init_flags);
 void game_state_free(game_state **gs);

--- a/src/game/gui/dialog.c
+++ b/src/game/gui/dialog.c
@@ -28,7 +28,7 @@ void dialog_yes_ok(component *c, void *userdata) {
     }
 }
 
-void dialog_create(dialog *dlg, dialog_style style, const char *text, int x, int y) {
+void dialog_create_h(dialog *dlg, dialog_style style, const char *text, int x, int y, int h) {
     gui_theme theme;
     gui_theme_defaults(&theme);
     theme.dialog.border_color = TEXT_MEDIUM_GREEN;
@@ -72,9 +72,13 @@ void dialog_create(dialog *dlg, dialog_style style, const char *text, int x, int
         menu_attach(menu2, button_create("OK", NULL, false, true, dialog_yes_ok, dlg));
     }
 
-    dlg->frame = gui_frame_create(&theme, x, y, w, 60);
+    dlg->frame = gui_frame_create(&theme, x, y, w, h);
     gui_frame_set_root(dlg->frame, menu);
     gui_frame_layout(dlg->frame);
+}
+
+void dialog_create(dialog *dlg, dialog_style style, const char *text, int x, int y) {
+    dialog_create_h(dlg, style, text, x, y, 60);
 }
 
 void dialog_free(dialog *dlg) {

--- a/src/game/gui/dialog.h
+++ b/src/game/gui/dialog.h
@@ -36,6 +36,7 @@ typedef struct dialog {
     dialog_clicked_cb clicked;
 } dialog;
 
+void dialog_create_h(dialog *dlg, dialog_style style, const char *text, int x, int y, int h);
 void dialog_create(dialog *dlg, dialog_style style, const char *text, int x, int y);
 void dialog_free(dialog *dlg);
 void dialog_show(dialog *dlg, int visible);

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -1104,7 +1104,7 @@ void lobby_tick(scene *scene, int paused) {
                     }
 
                     game_state_set_pilot_name(gs, player_id, local->name);
-                    game_state_set_pilot_name(gs, (player_id+1)%2, local->opponent->name);
+                    game_state_set_pilot_name(gs, (player_id + 1) % 2, local->opponent->name);
 
                     net_ctrl->har_obj_id = challengee->har_obj_id;
 
@@ -1281,7 +1281,7 @@ void lobby_tick(scene *scene, int paused) {
                             }
 
                             game_state_set_pilot_name(gs, player_id, local->name);
-                            game_state_set_pilot_name(gs, (player_id+1)%2, local->opponent->name);
+                            game_state_set_pilot_name(gs, (player_id + 1) % 2, local->opponent->name);
 
                             net_ctrl->har_obj_id = challengee->har_obj_id;
 
@@ -1386,7 +1386,7 @@ void lobby_tick(scene *scene, int paused) {
                         }
 
                         game_state_set_pilot_name(gs, player_id, local->name);
-                        game_state_set_pilot_name(gs, (player_id+1)%2, local->opponent->name);
+                        game_state_set_pilot_name(gs, (player_id + 1) % 2, local->opponent->name);
 
                         net_ctrl->har_obj_id = challengee->har_obj_id;
 

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -1103,6 +1103,9 @@ void lobby_tick(scene *scene, int paused) {
                         challengee = p1;
                     }
 
+                    game_state_set_pilot_name(gs, player_id, local->name);
+                    game_state_set_pilot_name(gs, (player_id+1)%2, local->opponent->name);
+
                     net_ctrl->har_obj_id = challengee->har_obj_id;
 
                     // Challenger -- Network
@@ -1277,6 +1280,9 @@ void lobby_tick(scene *scene, int paused) {
                                 challengee = p1;
                             }
 
+                            game_state_set_pilot_name(gs, player_id, local->name);
+                            game_state_set_pilot_name(gs, (player_id+1)%2, local->opponent->name);
+
                             net_ctrl->har_obj_id = challengee->har_obj_id;
 
                             // Challengee -- Network
@@ -1378,6 +1384,9 @@ void lobby_tick(scene *scene, int paused) {
                             player_id = 1;
                             challengee = p1;
                         }
+
+                        game_state_set_pilot_name(gs, player_id, local->name);
+                        game_state_set_pilot_name(gs, (player_id+1)%2, local->opponent->name);
 
                         net_ctrl->har_obj_id = challengee->har_obj_id;
 


### PR DESCRIPTION
Added a dialog to show match settings before challenging
Propagate match settings to the challenger and spectators

I made a hacky version of the show dialog function to extend the size to fit what I needed, there is obviously a better way.

The game now uses lobby names instead of pilot names during netplay