### PR TITLE
video: Handle surface 8bit/16bit mode better

### DIFF
--- a/shaders/palette.frag
+++ b/shaders/palette.frag
@@ -11,7 +11,7 @@ flat in int palette_limit;
 flat in int opacity;
 flat in uint options;
 
-// Atlas texture (GL_R16UI): uint16 palette index (0-1023) per texel.
+// Atlas texture (GL_R8UI or GL_R16UI): palette index per texel.
 uniform usampler2D atlas;
 
 // Remap texture (GL_R16UI, 1024x19): uint16 palette index (0-1023) per texel.

--- a/src/game/gui/text/text.c
+++ b/src/game/gui/text/text.c
@@ -407,7 +407,7 @@ void text_generate_document(text_document *td, str *buf0, font_size font_sz, uin
             } else if(sscanf(buf + start, "{CENTER %hu}%n", &center, &bytes_used) == 1 && bytes_used > 0) {
                 start += bytes_used;
                 // TODO we need to handle this properly, it will likely update the x offset
-            } else if(sscanf(buf + start, "{COLOR %hi}%n", &current_text_color, &bytes_used) == 1 && bytes_used > 0) {
+            } else if(sscanf(buf + start, "{COLOR %i}%n", &current_text_color, &bytes_used) == 1 && bytes_used > 0) {
                 start += bytes_used;
             } else if(sscanf(buf + start, "{SPACING %hu}%n", &current_line_spacing, &bytes_used) == 1 &&
                       bytes_used > 0) {

--- a/src/video/renderers/opengl3/helpers/remaps.c
+++ b/src/video/renderers/opengl3/helpers/remaps.c
@@ -15,14 +15,17 @@ typedef struct remaps {
 remaps *remaps_create(const GLuint texture_unit_id) {
     remaps *maps = omf_calloc(1, sizeof(remaps));
     maps->texture_unit_id = texture_unit_id;
-    maps->texture_id = texture_create(texture_unit_id, REMAPS_WIDTH, REMAPS_HEIGHT, GL_R16UI, GL_RED_INTEGER,
-                                      GL_UNSIGNED_SHORT, GL_NEAREST);
+    GLenum internal_fmt = (sizeof(vga_pixel) == 2) ? GL_R16UI : GL_R8UI;
+    GLenum type = (sizeof(vga_pixel) == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+    maps->texture_id =
+        texture_create(texture_unit_id, REMAPS_WIDTH, REMAPS_HEIGHT, internal_fmt, GL_RED_INTEGER, type, GL_NEAREST);
     return maps;
 }
 
 void remaps_update(const remaps *remaps, const vga_remap_tables *data) {
-    texture_update(remaps->texture_unit_id, remaps->texture_id, 0, 0, REMAPS_WIDTH, REMAPS_HEIGHT, GL_RED_INTEGER,
-                   GL_UNSIGNED_SHORT, (const char *)data);
+    GLenum type = (sizeof(vga_pixel) == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+    texture_update(remaps->texture_unit_id, remaps->texture_id, 0, 0, REMAPS_WIDTH, REMAPS_HEIGHT, GL_RED_INTEGER, type,
+                   data);
 }
 
 void remaps_free(remaps **maps) {

--- a/src/video/renderers/opengl3/helpers/texture_atlas.c
+++ b/src/video/renderers/opengl3/helpers/texture_atlas.c
@@ -33,8 +33,9 @@ texture_atlas *atlas_create(GLuint tex_unit, uint16_t width, uint16_t height) {
     atlas->w = width;
     atlas->h = height;
     atlas->tex_unit = tex_unit;
-    atlas->texture_id =
-        texture_create(tex_unit, width, height, GL_R16UI, GL_RED_INTEGER, GL_UNSIGNED_SHORT, GL_NEAREST);
+    GLenum internal_fmt = (sizeof(vga_pixel) == 2) ? GL_R16UI : GL_R8UI;
+    GLenum type = (sizeof(vga_pixel) == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+    atlas->texture_id = texture_create(tex_unit, width, height, internal_fmt, GL_RED_INTEGER, type, GL_NEAREST);
     log_debug("Texture atlas %dx%d created", width, height);
     return atlas;
 }
@@ -51,15 +52,15 @@ void atlas_free(texture_atlas **atlas) {
     }
 }
 
-bool atlas_insert(texture_atlas *atlas, const vga_index *data, uint16_t w, uint16_t h, uint16_t *nx, uint16_t *ny) {
+bool atlas_insert(texture_atlas *atlas, const vga_pixel *data, uint16_t w, uint16_t h, uint16_t *nx, uint16_t *ny) {
     sprite_region region;
     if(!sprite_packer_alloc(atlas->packer, w, h, &region)) {
         log_error("Texture atlas has no room for %dx%d area", w, h);
         return false;
     }
 
-    texture_update(atlas->tex_unit, atlas->texture_id, region.x, region.y, w, h, GL_RED_INTEGER, GL_UNSIGNED_SHORT,
-                   data);
+    GLenum type = (sizeof(vga_pixel) == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+    texture_update(atlas->tex_unit, atlas->texture_id, region.x, region.y, w, h, GL_RED_INTEGER, type, data);
     *nx = region.x;
     *ny = region.y;
     return true;

--- a/src/video/renderers/opengl3/helpers/texture_atlas.h
+++ b/src/video/renderers/opengl3/helpers/texture_atlas.h
@@ -10,7 +10,7 @@ typedef struct texture_atlas texture_atlas;
 texture_atlas *atlas_create(GLuint tex_unit, uint16_t width, uint16_t height);
 void atlas_free(texture_atlas **atlas);
 
-bool atlas_insert(texture_atlas *atlas, const vga_index *data, uint16_t w, uint16_t h, uint16_t *nx, uint16_t *ny);
+bool atlas_insert(texture_atlas *atlas, const vga_pixel *data, uint16_t w, uint16_t h, uint16_t *nx, uint16_t *ny);
 bool atlas_get(texture_atlas *atlas, const surface *surface, uint16_t *x, uint16_t *y, uint16_t *w, uint16_t *h);
 void atlas_reset(texture_atlas *atlas);
 

--- a/src/video/surface.c
+++ b/src/video/surface.c
@@ -8,7 +8,7 @@
 static unsigned int guid = 0;
 
 void surface_create(surface *sur, int w, int h) {
-    sur->data = omf_calloc(w * h, sizeof(vga_index));
+    sur->data = omf_calloc(w * h, sizeof(vga_pixel));
     sur->guid = guid++;
     sur->w = w;
     sur->h = h;
@@ -26,7 +26,7 @@ void surface_create_from_data_flip(surface *sur, int w, int h, const unsigned ch
     surface_create(sur, w, h);
     for(int y = 0; y < h; y++) {
         const unsigned char *src_row = src + y * w;
-        vga_index *dst_row = sur->data + (h - y - 1) * w;
+        vga_pixel *dst_row = sur->data + (h - y - 1) * w;
         for(int x = 0; x < w; x++) {
             dst_row[x] = src_row[x];
         }
@@ -56,9 +56,9 @@ void surface_create_from_flip_scale(surface *sur, const int w, const int h, cons
     surface_create(sur, w, h);
     for(int y = 0; y < h; y++) {
         const uint16_t *src_row = src + y * w;
-        vga_index *dst_row = sur->data + (h - y - 1) * w;
+        vga_pixel *dst_row = sur->data + (h - y - 1) * w;
         for(int x = 0; x < w; x++) {
-            dst_row[x] = (vga_index)(src_row[x] * scale + 0.5f);
+            dst_row[x] = (vga_pixel)(src_row[x] * scale + 0.5f);
         }
     }
     sur->transparent = -1;
@@ -78,13 +78,13 @@ void surface_free(surface *sur) {
 }
 
 void surface_clear(surface *sur) {
-    memset(sur->data, 0, sur->w * sur->h * sizeof(vga_index));
+    memset(sur->data, 0, sur->w * sur->h * sizeof(vga_pixel));
     sur->guid = guid++;
 }
 
 void surface_create_from(surface *dst, const surface *src) {
     surface_create(dst, src->w, src->h);
-    memcpy(dst->data, src->data, src->w * src->h * sizeof(vga_index));
+    memcpy(dst->data, src->data, src->w * src->h * sizeof(vga_pixel));
     dst->transparent = src->transparent;
 }
 

--- a/src/video/surface.h
+++ b/src/video/surface.h
@@ -10,7 +10,7 @@ typedef struct surface {
     int w;
     int h;
     int transparent;
-    vga_index *data;
+    vga_pixel *data;
 } surface;
 
 enum

--- a/src/video/vga_palette.h
+++ b/src/video/vga_palette.h
@@ -12,11 +12,15 @@
 // USE_EXTENDED_PALETTE is set by cmake
 #ifdef USE_EXTENDED_PALETTE
 #define VGA_PALETTE_SIZE VGA_EXTENDED_PALETTE_SIZE
+typedef uint16_t vga_pixel;
 #else
 #define VGA_PALETTE_SIZE VGA_STANDARD_PALETTE_SIZE
+typedef uint8_t vga_pixel;
 #endif
 
-typedef int16_t vga_index;
+// This is what we use for iterating and assigning values. It covers the uint16_t and uint8_t vga_pixel regions.
+// Assert should be used in handlers to ensure we stay withing the [0 ... n ... VGA_PALETTE_SIZE] region.
+typedef int32_t vga_index;
 
 typedef struct vga_color {
     unsigned char r;

--- a/src/video/vga_remap.h
+++ b/src/video/vga_remap.h
@@ -7,17 +7,17 @@
 #define VGA_REMAP_COUNT 19
 
 typedef struct vga_remap_table {
-    vga_index data[VGA_PALETTE_SIZE];
+    vga_pixel data[VGA_PALETTE_SIZE];
 } vga_remap_table;
 
-static_assert((sizeof(vga_index) * VGA_PALETTE_SIZE) == sizeof(vga_remap_table),
+static_assert((sizeof(vga_pixel) * VGA_PALETTE_SIZE) == sizeof(vga_remap_table),
               "vga_remap_table should pack properly");
 
 typedef struct vga_remap_tables {
     vga_remap_table tables[VGA_REMAP_COUNT];
 } vga_remap_tables;
 
-static_assert((sizeof(vga_index) * VGA_REMAP_COUNT * VGA_PALETTE_SIZE) == sizeof(vga_remap_tables),
+static_assert((sizeof(vga_pixel) * VGA_REMAP_COUNT * VGA_PALETTE_SIZE) == sizeof(vga_remap_tables),
               "vga_remap_tables should pack properly");
 
 void vga_remaps_init(vga_remap_tables *remaps);


### PR DESCRIPTION
Resize the surface data depending on whether we are in extended palette mode or not. Should save memory on lower-end platforms.