### PR TITLE
Alias ZLIB::ZLIBSTATIC for PNGConfig.cmake (Fix MSVC CI)

### DIFF
--- a/cmake-scripts/Dependencies.cmake
+++ b/cmake-scripts/Dependencies.cmake
@@ -92,6 +92,12 @@ if(USE_NATPMP)
 endif()
 
 if(USE_LIBPNG)
+    # HACK: alias ZLIB::ZLIBSTATIC for PNGConfig.cmake on x64-windows-static triplet
+    find_package(ZLIB REQUIRED)
+    if(NOT TARGET ZLIB::ZLIB)
+        add_library(ZLIB::ZLIB ALIAS ZLIB::ZLIBSTATIC)
+    endif()
+
     find_package(PNG REQUIRED)
     add_library(openomf::png INTERFACE IMPORTED)
     target_link_libraries(openomf::png INTERFACE PNG::PNG)


### PR DESCRIPTION
microsoft/vcpkg update to zlib broke libpng's PNGConfig.cmake.
PNGConfig.cmake expects to be able to link zlib with:
```
find_package(ZLIB REQUIRED)
target_link_libraries(... ZLIB::ZLIB)
```
But zlib is now exporting itself as `ZLIB::ZLIBSTATIC` when built as a static lib (such as the x64-windows-static triplet)

rather than wait around for upstream to fix their port, we can add an alias like so.