### PR TITLE
Improve Windows build process and documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,7 +2,7 @@
 
 ### Dependencies
 
-Use at least GCC 9 or Clang 10. MSVC is not supported.
+Use at least GCC 9 or Clang 10. MSVC is also supported, namely the version that ships with VS2022's (or higher) Build Tools.
 
 Required:
 * SDL2 (>=2.0.16): http://www.libsdl.org/download-2.0.php
@@ -14,6 +14,14 @@ Required:
 * libxmp: https://github.com/cmatsuoka/libxmp
 * opusfile: https://github.com/xiph/opusfile
 
+
+On Windows, a `vcpkg` installation is required. In turn, `vcpkg` can be used in Manifest mode to pull the required dependencies.
+Replace `C:\vcpkg` with a directory of your choice, if needed.
+
+```
+git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+C:\vcpkg\bootstrap-vcpkg.bat
+```
 
 On Ubuntu, it is possible to pull the libraries using apt-get.
 ```
@@ -39,7 +47,14 @@ project in GitHub.
 
 ### Compiling
 
-To compile (change install prefix if necessary):
+To compile on Windows, use the "x64 Native Tools Command Prompt for VS", located on your Start Menu:
+
+```
+cmake -B build -S . --toolchain C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+cmake --build build
+```
+
+To compile on other operating systems (change install prefix if necessary):
 
 ```
 $ mkdir -p build

--- a/BUILD.md
+++ b/BUILD.md
@@ -47,9 +47,10 @@ project in GitHub.
 
 ### Compiling
 
-To compile on Windows, use the "x64 Native Tools Command Prompt for VS", located on your Start Menu:
+To compile on Windows, use the "x64 Native Tools Command Prompt for VS":
 
 ```
+cd C:\path\to\openomf
 cmake -B build -S . --toolchain C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 cmake --build build
 ```

--- a/src/game/scenes/arena.c
+++ b/src/game/scenes/arena.c
@@ -1,4 +1,5 @@
 #include <SDL.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-  "builtin-baseline": "082b32b6c5de20fd01f61dfaa9856fcba849e73e",
   "dependencies": [
     {
       "name": "sdl2",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "builtin-baseline": "082b32b6c5de20fd01f61dfaa9856fcba849e73e",
   "dependencies": [
     {
       "name": "sdl2",


### PR DESCRIPTION
* **What my change is:** An attempt to facilitate building on Windows, using either MSVC (VS2022/2026) or Clang for Windows
* **What it does:** Essentially, it gets rid of the following two build errors when using Clang on Windows:

1. Signed vs unsigned comparisons in `keyboard_binds_key` (keyboard.c)
2. Usage of the `PRIu32` macro in `arena_state_dump` (arena.c) by relying on a transitive include (`#include <inttypes.h>` was added to the top of the file for this purpose)

It also documents a new building procedure on Windows, allowing Windows users/developers to choose between MSVC or Clang (see: BUILD.md)

* **Why it should be merged:** I believe this should be merged to not only provide users with two ways to compile on Windows, but also to correct the build errors stated above.

This is my very first PR; constructive feedback is, of course, welcome and appreciated.