### PR TITLE
Reenable MSVC warnings C4389 and C4459

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,14 +53,10 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4100")
     # C4456: declaration hides previous local declaration
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4456")
-    # C4459: declaration hides previous global declaration
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4459")
     # C4244: implicit conversion, possible loss of data
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244")
     # C4267: implicit conversion from size_t, possible loss of data
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267")
-    # C4389: 'equality-operator' : signed/unsigned mismatch
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4389")
     # _CRT_SECURE_NO_WARNINGS: disable warnings when calling functions like strncpy or sscanf
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
     # _CRT_NONSTDC_NO_WARNINGS: disable warnings when calling POSIX functions like fileno

--- a/src/controller/keyboard.h
+++ b/src/controller/keyboard.h
@@ -10,16 +10,16 @@ typedef struct keyboard_keys_t keyboard_keys;
 typedef struct keyboard_t keyboard;
 
 struct keyboard_keys_t {
-    unsigned jump_up;
-    unsigned jump_right;
-    unsigned walk_right;
-    unsigned duck_forward;
-    unsigned duck;
-    unsigned duck_back;
-    unsigned walk_back;
-    unsigned jump_left;
-    unsigned punch;
-    unsigned kick;
+    SDL_Scancode jump_up;
+    SDL_Scancode jump_right;
+    SDL_Scancode walk_right;
+    SDL_Scancode duck_forward;
+    SDL_Scancode duck;
+    SDL_Scancode duck_back;
+    SDL_Scancode walk_back;
+    SDL_Scancode jump_left;
+    SDL_Scancode punch;
+    SDL_Scancode kick;
 };
 
 struct keyboard_t {


### PR DESCRIPTION
No code currently trips these diagnostics.