### PR TITLE
Video renderer fixes

### DIFF
--- a/src/video/renderers/opengl3/gl3_renderer.c
+++ b/src/video/renderers/opengl3/gl3_renderer.c
@@ -333,10 +333,11 @@ static void move_target(void *userdata, int x, int y) {
     ctx->target_move_y = y;
 }
 
-static void render_prepare(void *userdata, unsigned framebuffer_options) {
+static void render_prepare(void *userdata, const unsigned framebuffer_options) {
     const gl3_context *ctx = userdata;
     object_array_prepare(ctx->objects);
 
+    activate_program(ctx->rgba_prog_id);
     bind_uniform_1u(ctx->rgba_prog_id, "framebuffer_options", framebuffer_options);
 }
 

--- a/src/video/vga_state.c
+++ b/src/video/vga_state.c
@@ -6,6 +6,7 @@
 #include "video/vga_state.h"
 
 #include "game/game_state.h"
+#include "utils/log.h"
 #include "utils/png_writer.h"
 #include <assert.h>
 
@@ -180,7 +181,11 @@ void vga_state_enable_palette_transform(vga_palette_transform transform_callback
     }
 #endif
 
-    assert(state.transformer_count < MAX_TRANSFORMER_COUNT - 1);
+    assert(state.transformer_count < MAX_TRANSFORMER_COUNT);
+    if(state.transformer_count >= MAX_TRANSFORMER_COUNT) {
+        log_error("Palette transformer limit reached, dropping transform");
+        return;
+    }
     state.transformers[state.transformer_count].callback = transform_callback;
     state.transformers[state.transformer_count].userdata = userdata;
     state.transformer_count++;

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -76,7 +76,7 @@ void video_scan_renderers(void) {
  * @return true if data was read, false if index is out of range
  */
 bool video_get_renderer_info(int index, const char **name, const char **description) {
-    if(index < 0 && index >= renderer_count) {
+    if(index < 0 || index >= renderer_count) {
         return false;
     }
     if(name != NULL) {


### PR DESCRIPTION
A few small independent fixes in the video layer: a uniform written to the wrong program, a broken index range check, and a missing overflow guard in the palette transformer list.