### PR TITLE
Harden controller action list handling

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -1272,14 +1272,14 @@ int net_controller_poll(controller *ctrl, ctrl_event **ev) {
         if(e->events[id][0] != 0 && e->tick == current_tick) {
             // events for the current tick, send em all
             int i = 0;
-            while(e->events[id][i]) {
+            while(i < MAX_EVENTS_PER_TICK && e->events[id][i]) {
                 controller_cmd(ctrl, e->events[id][i], ev);
                 i++;
             }
             return 0;
         } else if(e->events[id][0] != 0 && e->tick < current_tick) {
             int i = 0;
-            while(e->events[id][i] && i < MAX_EVENTS_PER_TICK) {
+            while(i < MAX_EVENTS_PER_TICK && e->events[id][i]) {
                 last = e->events[id][i];
                 i++;
             }

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -73,6 +73,7 @@ typedef struct {
 } wtf;
 
 #define MAX_EVENTS_PER_TICK 11
+#define EVENT_NAME_BUF_LEN (MAX_EVENTS_PER_TICK * 3 + 1)
 
 typedef struct {
     uint32_t tick;
@@ -469,8 +470,8 @@ int rewind_and_replay(wtf *data, controller *ctrl) {
                 }
 
                 if(data->trace_file) {
-                    char buf0[12];
-                    char buf1[12];
+                    char buf0[EVENT_NAME_BUF_LEN];
+                    char buf1[EVENT_NAME_BUF_LEN];
 
                     event_names(buf0, ev->events[0]);
                     event_names(buf1, ev->events[1]);
@@ -534,8 +535,8 @@ int rewind_and_replay(wtf *data, controller *ctrl) {
                                   arena_hash);
                 SDL_RWwrite(data->trace_file, buf, sz, 1);
 
-                char buf0[12];
-                char buf1[12];
+                char buf0[EVENT_NAME_BUF_LEN];
+                char buf1[EVENT_NAME_BUF_LEN];
 
                 event_names(buf0, ev->events[0]);
                 event_names(buf1, ev->events[1]);
@@ -658,8 +659,8 @@ void net_controller_free(controller *ctrl) {
         tick_events *ev = NULL;
         foreach(it, ev) {
             log_debug("tick %" PRIu32 " has events %d -- %d", ev->tick, ev->events[0][0], ev->events[1][0]);
-            char buf0[12];
-            char buf1[12];
+            char buf0[EVENT_NAME_BUF_LEN];
+            char buf1[EVENT_NAME_BUF_LEN];
 
             event_names(buf0, ev->events[0]);
             event_names(buf1, ev->events[1]);

--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <time.h>
 
+#include <SDL.h>
+
 #include "controller/net_controller.h"
 #include "game/game_state_type.h"
 #include "game/protos/scene.h"
@@ -72,7 +74,6 @@ typedef struct {
     int winner;
 } wtf;
 
-#define MAX_EVENTS_PER_TICK 11
 #define EVENT_NAME_BUF_LEN (MAX_EVENTS_PER_TICK * 3 + 1)
 
 typedef struct {
@@ -283,12 +284,7 @@ void send_events(wtf *data, int delay) {
            ev->tick < data->last_tick - data->local_proposal + delay) {
             // each tick is written as the 32 bit tick value and a 0 terminated list of u8 actions on that tick
             serial_write_uint32(&ser, ev->tick);
-            int i = 0;
-            while(ev->events[data->id][i] && i < MAX_EVENTS_PER_TICK) {
-                serial_write_int8(&ser, ev->events[data->id][i]);
-                i++;
-            }
-            serial_write_int8(&ser, 0);
+            serial_write_bytes(&ser, ev->events[data->id], MAX_EVENTS_PER_TICK);
             last_sent_tick = ev->tick;
         }
     }
@@ -819,22 +815,18 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                             }
                         }
 
-                        for(size_t i = ser.rpos; i < event.packet->dataLength;) {
+                        while(ser.rpos < ser.wpos) {
                             unsigned remote_tick = serial_read_uint32(&ser);
-                            // dispatch keypress to scene
-                            uint8_t action = 0;
-                            int k = 0;
-                            do {
-                                // read the 0 terminated action list for this tick
-                                action = serial_read_int8(&ser);
-                                k++;
-
+                            // read the 0 terminated action list for this tick
+                            uint8_t actions[MAX_EVENTS_PER_TICK];
+                            serial_read_bytes(&ser, actions, MAX_EVENTS_PER_TICK);
+                            for(int k = 0; k < MAX_EVENTS_PER_TICK && actions[k]; k++) {
+                                // dispatch keypress to scene
+                                uint8_t action = actions[k];
                                 if(data->synchronized && data->gs_bak) {
                                     if(remote_tick > data->last_received_tick) {
                                         has_received = true;
-                                        if(action) {
-                                            insert_event(data, remote_tick, action, abs(data->id - 1));
-                                        }
+                                        insert_event(data, remote_tick, action, abs(data->id - 1));
                                     }
                                 } else {
                                     if(action == ACT_ESC) {
@@ -843,8 +835,7 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                         controller_cmd(ctrl, action, ev);
                                     }
                                 }
-                            } while(action);
-                            i += 4 + k;
+                            }
                         }
                         if(data->synchronized && data->gs_bak) {
                             // the 20 is here to avoid doing blank replays too often

--- a/src/controller/net_controller.h
+++ b/src/controller/net_controller.h
@@ -2,9 +2,9 @@
 #define NET_CONTROLLER_H
 
 #define NET_INPUT_DELAY 2
+#define MAX_EVENTS_PER_TICK 11
 
 #include "controller/controller.h"
-#include <SDL.h>
 #include <enet/enet.h>
 
 void net_controller_create(controller *ctrl, ENetHost *host, ENetPeer *peer, ENetPeer *lobby, int id);

--- a/src/controller/rec_controller.c
+++ b/src/controller/rec_controller.c
@@ -225,7 +225,7 @@ void rec_controller_create(controller *ctrl, int player, sd_rec_file *rec) {
             data->max_tick = rec_move->tick;
         }
     }
-    log_debug("max tick is %" PRIu32, data->last_tick);
+    log_debug("max tick is %" PRIu32, data->max_tick);
     ctrl->data = data;
     ctrl->type = CTRL_TYPE_REC;
     ctrl->poll_fun = &rec_controller_poll;

--- a/src/controller/spec_controller.c
+++ b/src/controller/spec_controller.c
@@ -192,32 +192,6 @@ int spec_controller_poll(controller *ctrl, ctrl_event **ev) {
     return 0;
 }
 
-void spec_controller_find_old_last_action(controller *ctrl) {
-    spec_controller_data *data = ctrl->data;
-    uint32_t ticks = ctrl->gs->tick;
-
-    while(ticks-- != 0) {
-        bool found_action = false;
-        spec_controller_event *move;
-        unsigned int len;
-        if(hashmap_get_int(data->tick_lookup, ticks, (void **)(&move), &len) == 0) {
-            int i = 0;
-            uint8_t action;
-            while((action = move->actions[data->player_id][i])) {
-                found_action = true;
-                ctrl->last = action;
-            }
-        }
-        if(found_action) {
-            return;
-        }
-    }
-
-    // no action found
-    ctrl->last = ACT_STOP;
-    return;
-}
-
 ENetPeer *spec_controller_get_lobby_connection(controller *ctrl) {
     spec_controller_data *data = ctrl->data;
     return data->peer;

--- a/src/controller/spec_controller.c
+++ b/src/controller/spec_controller.c
@@ -1,4 +1,5 @@
 #include "controller/spec_controller.h"
+#include "controller/net_controller.h"
 #include "game/game_player.h"
 #include "game/game_state_type.h"
 #include "game/protos/scene.h"
@@ -9,7 +10,7 @@
 
 typedef struct {
     uint32_t ticks;
-    uint8_t actions[2][10];
+    uint8_t actions[2][MAX_EVENTS_PER_TICK];
 } spec_controller_event;
 
 typedef struct {
@@ -103,22 +104,11 @@ int spec_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
 
                     } break;
                     case 1: {
-                        uint8_t action;
-                        for(size_t i = ser.rpos; i < event.packet->dataLength;) {
-                            spec_controller_event event;
-                            memset(&event, 0, sizeof(spec_controller_event));
+                        while(ser.rpos < ser.wpos) {
+                            spec_controller_event event = {0};
                             event.ticks = serial_read_uint32(&ser);
-
-                            for(int j = 0; j < 2; j++) {
-                                int k = 0;
-                                do {
-                                    action = serial_read_int8(&ser);
-                                    event.actions[j][k] = action;
-                                    k++;
-                                } while(action);
-                                i += k;
-                            }
-                            i += 4;
+                            serial_read_bytes(&ser, event.actions[0], MAX_EVENTS_PER_TICK);
+                            serial_read_bytes(&ser, event.actions[1], MAX_EVENTS_PER_TICK);
                             hashmap_put_int(data->tick_lookup, event.ticks, &event, sizeof(spec_controller_event));
 
                             if(event.ticks > 100 && !data->started) {
@@ -168,13 +158,12 @@ int spec_controller_poll(controller *ctrl, ctrl_event **ev) {
         return 0;
     }
 
-    bool found_action = false;
-
     if(data->last_tick != ticks && ticks > 0) {
+        bool found_action = false;
         if(hashmap_get_int(data->tick_lookup, ticks, (void **)(&move), &len) == 0) {
             int i = 0;
             uint8_t action;
-            while((action = move->actions[data->player_id][i])) {
+            while(i < MAX_EVENTS_PER_TICK && (action = move->actions[data->player_id][i])) {
                 controller_cmd(ctrl, action, ev);
                 ctrl->last = action;
                 found_action = true;

--- a/src/game/utils/serial.c
+++ b/src/game/utils/serial.c
@@ -126,6 +126,24 @@ void serial_write_str(serial *s, const str *src) {
     serial_write(s, str_c(src), str_size(src));
 }
 
+void serial_write_bytes(serial *s, const uint8_t *buf, const size_t max) {
+    for(size_t i = 0; i < max && buf[i]; i++) {
+        serial_write_uint8(s, buf[i]);
+    }
+    serial_write_uint8(s, 0);
+}
+
+void serial_read_bytes(serial *s, uint8_t *buf, const size_t max) {
+    size_t i = 0;
+    uint8_t b;
+    memset(buf, 0, max);
+    while(s->rpos < s->wpos && (b = serial_read_uint8(s)) != 0) {
+        if(i < max) {
+            buf[i++] = b;
+        }
+    }
+}
+
 void serial_read_str(serial *s, str *dst) {
     const uint8_t len = serial_read_uint8(s);
     char buf[256 + 1];

--- a/src/game/utils/serial.h
+++ b/src/game/utils/serial.h
@@ -38,4 +38,22 @@ float serial_read_float(serial *s);
 void serial_copy(serial *dst, const serial *src);
 serial *serial_calloc_copy(const serial *src);
 
+/**
+ * @brief Write a zero-terminated byte list.
+ * @details Writes bytes from buf until the first zero or until max bytes have been
+ *    written, then writes a zero terminator.
+ * @param buf Bytes to write.
+ * @param max Maximum number of bytes to write, not counting the terminator.
+ */
+void serial_write_bytes(serial *s, const uint8_t *buf, size_t max);
+
+/**
+ * @brief Read a zero-terminated byte list.
+ * @details Fills buf with zeroes, then reads bytes up to and including the terminator
+ *    or until the readable data runs out. Bytes that do not fit are consumed and dropped.
+ * @param buf Destination buffer.
+ * @param max Capacity of the destination buffer.
+ */
+void serial_read_bytes(serial *s, uint8_t *buf, size_t max);
+
 #endif // SERIAL_H


### PR DESCRIPTION
Hardens how the controllers read and write per-tick action lists. Parsing moves into shared serial helpers and all scan loops get proper bounds, so malformed packets can no longer overflow the fixed-size buffers. Includes a couple of small cleanups.