### PR TITLE
Spectator mode crash and leak fixes

### DIFF
--- a/src/controller/spec_controller.c
+++ b/src/controller/spec_controller.c
@@ -118,6 +118,9 @@ int spec_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                     default: {
                     }
                 }
+                serial_free(&ser);
+                enet_packet_destroy(event.packet);
+                break;
             default: {
             }
         }

--- a/src/controller/spec_controller.c
+++ b/src/controller/spec_controller.c
@@ -1,10 +1,8 @@
 #include "controller/spec_controller.h"
 #include "controller/net_controller.h"
+#include "game/common_defines.h"
 #include "game/game_player.h"
-#include "game/game_state_type.h"
-#include "game/protos/scene.h"
-#include "game/scenes/arena.h"
-#include "game/scenes/vs.h"
+#include "game/game_state.h"
 #include "utils/allocator.h"
 #include "utils/log.h"
 
@@ -90,18 +88,11 @@ int spec_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
 
                         ctrl->gs->arena = data->nscene - SCENE_ARENA0;
 
-                        // jump into the arena scene
-                        ctrl->gs->this_id = SCENE_VS;
-                        ctrl->gs->next_id = SCENE_VS;
-
-                        if(scene_create(ctrl->gs->sc, ctrl->gs, SCENE_VS)) {
+                        // jump into the VS scene, keeping the lobby scene and its
+                        // network connection alive
+                        if(game_state_swap_scene(ctrl->gs, SCENE_VS)) {
                             log_error("Error while loading scene %d.", SCENE_VS);
                         }
-
-                        if(vs_create(ctrl->gs->sc)) {
-                            log_error("Error while creating arena");
-                        }
-
                     } break;
                     case 1: {
                         while(ser.rpos < ser.wpos) {
@@ -116,16 +107,9 @@ int spec_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                                 hashmap_put_int(data->tick_lookup, 0, &ctrl->gs->tick, sizeof(ticks));
                                 log_info("spectator start tick was %u", ticks);
 
-                                // jump into the arena scene
-                                // ctrl->gs->this_id = data->nscene;
-                                ctrl->gs->next_id = data->nscene;
-
-                                if(scene_create(ctrl->gs->sc, ctrl->gs, data->nscene)) {
+                                // jump into the arena scene, keeping the old scene alive
+                                if(game_state_swap_scene(ctrl->gs, data->nscene)) {
                                     log_error("Error while loading scene %d.", data->nscene);
-                                }
-
-                                if(arena_create(ctrl->gs->sc)) {
-                                    log_error("Error while creating arena");
                                 }
                                 data->started = true;
                             }

--- a/src/game/game_state.c
+++ b/src/game/game_state.c
@@ -707,11 +707,7 @@ void game_state_debug(game_state *gs) {
 #endif
 }
 
-int game_load_new(game_state *gs, int scene_id) {
-    // Free old scene
-    scene_free(gs->sc);
-    omf_free(gs->sc);
-
+int game_state_swap_scene(game_state *gs, int scene_id) {
     // Remove old objects
     render_obj *robj;
     iterator it;
@@ -837,6 +833,12 @@ error_1:
 error_0:
     omf_free(gs->sc);
     return 1;
+}
+
+int game_load_new(game_state *gs, int scene_id) {
+    scene_free(gs->sc);
+    omf_free(gs->sc);
+    return game_state_swap_scene(gs, scene_id);
 }
 
 void game_state_call_collide(game_state *gs) {

--- a/src/game/game_state.h
+++ b/src/game/game_state.h
@@ -40,6 +40,7 @@ unsigned int game_state_is_running(game_state *gs);
 unsigned int game_state_is_paused(game_state *gs);
 void game_state_set_paused(game_state *gs, unsigned int paused);
 void game_state_set_next(game_state *gs, unsigned int next_scene_id);
+int game_state_swap_scene(game_state *gs, int scene_id);
 game_player *game_state_get_player(const game_state *gs, int player_id);
 int game_state_num_players(game_state *gs);
 void game_state_init_demo(game_state *gs);


### PR DESCRIPTION
Fixes two spectator mode issues: a crash when switching scenes and a per-packet memory leak. Stacked on #1423.