### PR TITLE
Remember Lobby disconnect 

### DIFF
--- a/src/controller/net_controller.c
+++ b/src/controller/net_controller.c
@@ -25,6 +25,8 @@ typedef struct {
     uint32_t last_hb;
     uint32_t outstanding_hb;
     int disconnected;
+    bool lobby_disconnected;
+    bool opponent_disconnected;
     int rttbuf[100];
     int rttpos;
     int rttfilled;
@@ -610,6 +612,16 @@ ENetPeer *net_controller_get_lobby_connection(controller *ctrl) {
     return data->lobby;
 }
 
+bool net_controller_lobby_connected(controller *ctrl) {
+    wtf *data = ctrl->data;
+    return data->lobby != NULL && !data->lobby_disconnected;
+}
+
+bool net_controller_opponent_disconnected(controller *ctrl) {
+    wtf *data = ctrl->data;
+    return data->opponent_disconnected;
+}
+
 ENetHost *net_controller_get_host(controller *ctrl) {
     wtf *data = ctrl->data;
     return data->host;
@@ -1077,8 +1089,12 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                 if(event.peer == data->peer) {
                     log_debug("opponent peer disconnected!");
                     data->disconnected = 1;
+                    data->opponent_disconnected = true;
+                    if(event.peer == data->lobby) {
+                        data->lobby_disconnected = true;
+                    }
                     data->synchronized = false;
-                    data->winner = arena_is_over(ctrl->gs->sc);
+                    data->winner = scene_is_arena(ctrl->gs->sc) ? arena_is_over(ctrl->gs->sc) : -1;
                     if(data->winner == -1 && data->gs_bak) {
                         // match did not end cleanly
                         // so force the game to playback ALL events to try to update the trace/rec files
@@ -1088,10 +1104,12 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                     if(ctrl->gs->new_state) {
                         game_state_clone_free(ctrl->gs->new_state);
                         omf_free(ctrl->gs->new_state);
+                        ctrl->gs->new_state = NULL;
                     }
                     if(data->gs_bak) {
                         game_state_clone_free(data->gs_bak);
                         omf_free(data->gs_bak);
+                        data->gs_bak = NULL;
                     }
                     if(ctrl->gs->rec) {
                         sd_rec_finish(ctrl->gs->rec, ticks - data->local_proposal);
@@ -1105,8 +1123,14 @@ int net_controller_tick(controller *ctrl, uint32_t ticks0, ctrl_event **ev) {
                     }
                     event.peer->data = NULL;
                     return 1; // bail the fuck out
+                } else if(event.peer == data->lobby) {
+                    // Keep an established direct match running if only the lobby server goes away. Remember the
+                    // failure so the lobby scene can reconnect instead of reusing this disconnected peer later.
+                    log_warn("lobby server disconnected during netplay; direct opponent connection remains active");
+                    data->lobby_disconnected = true;
+                    break;
                 } else {
-                    log_debug("non-opponent peer disconnected, ignoring");
+                    log_debug("unrelated peer disconnected, ignoring");
                 }
                 event.peer->data = NULL;
                 break;

--- a/src/controller/net_controller.h
+++ b/src/controller/net_controller.h
@@ -16,6 +16,8 @@ bool net_controller_ready(controller *ctrl);
 int net_controller_tick_offset(controller *ctrl);
 
 ENetPeer *net_controller_get_lobby_connection(controller *ctrl);
+bool net_controller_lobby_connected(controller *ctrl);
+bool net_controller_opponent_disconnected(controller *ctrl);
 
 ENetHost *net_controller_get_host(controller *ctrl);
 int net_controller_get_winner(controller *ctrl);

--- a/src/game/audio/sound_tracker.c
+++ b/src/game/audio/sound_tracker.c
@@ -10,6 +10,10 @@
 #include <limits.h>
 #include <stdbool.h>
 
+// A rollback-resumed effect starts in the middle of its sample. Use a very
+// short fade to avoid a click without making brief impact sounds inaudible.
+#define ROLLBACK_SOUND_FADE_IN_MS 10
+
 void sound_tracker_create(sound_tracker *t) {
     vector_create(&t->entries, sizeof(playing_sound));
 }
@@ -109,6 +113,10 @@ void sound_tracker_merge(sound_tracker *old, sound_tracker *new) {
         vector_iter_begin(&old->entries, &it2);
         foreach(it2, s2) {
             if(s->sound_id == s2->sound_id && s->tick == s2->tick) {
+                // The replayed state only recorded this sound and therefore
+                // has no backend handle. Keep tracking the playback that was
+                // already started by the state being replaced.
+                s->playback_id = s2->playback_id;
                 found = true;
                 break;
             }
@@ -147,7 +155,7 @@ void sound_tracker_merge(sound_tracker *old, sound_tracker *new) {
                 opts.volume = s->volume;
                 opts.panning = s->panning;
                 opts.pitch = s->pitch;
-                opts.fade_in_ms = 500; // TODO decide on a fade in time
+                opts.fade_in_ms = ROLLBACK_SOUND_FADE_IN_MS;
                 s->playback_id = audio_play_source(&src, &opts);
             }
             sound_source_close(&src);

--- a/src/game/scenes/lobby.c
+++ b/src/game/scenes/lobby.c
@@ -1086,6 +1086,11 @@ void lobby_tick(scene *scene, int paused) {
                 if(local->opponent_peer && event.peer->address.host == local->opponent->address.host) {
                     log_debug("connected to peer outbound!");
 
+                    // NAT probes use a deliberately short timeout. Restore ENet's normal timeout window once the
+                    // connection succeeds so a brief packet-loss spike does not terminate the match.
+                    enet_peer_timeout(event.peer, ENET_PEER_TIMEOUT_LIMIT, ENET_PEER_TIMEOUT_MINIMUM,
+                                      ENET_PEER_TIMEOUT_MAXIMUM);
+
                     // TODO probably need a more specific cancel callback here
                     lobby_show_dialog(scene, DIALOG_STYLE_CANCEL, "Connected, synchronizing clocks...", NULL);
                     local->opponent_peer = event.peer;
@@ -1270,6 +1275,8 @@ void lobby_tick(scene *scene, int paused) {
                             }
                         } else if(!local->opponent_peer && event.peer->address.host == local->opponent->address.host) {
                             log_debug("connected to peer inbound!");
+                            enet_peer_timeout(event.peer, ENET_PEER_TIMEOUT_LIMIT, ENET_PEER_TIMEOUT_MINIMUM,
+                                              ENET_PEER_TIMEOUT_MAXIMUM);
                             local->opponent_peer = event.peer;
 
                             // TODO probably need a more specific cancel callback here
@@ -1747,21 +1754,37 @@ int lobby_create(scene *scene) {
     menu_attach(menu, exit_button);
 
     int winner = -1;
+    bool lobby_reconnect = false;
+    bool opponent_disconnected = false;
     // check if there's already a net controller provisioned
     // and harvest the information from it, if possible
     if(game_state_get_player(scene->gs, 0)->ctrl->type == CTRL_TYPE_NETWORK) {
-        local->peer = net_controller_get_lobby_connection(game_state_get_player(scene->gs, 0)->ctrl);
-        local->client = net_controller_get_host(game_state_get_player(scene->gs, 0)->ctrl);
-        local->nat = local->peer->data;
-        winner = net_controller_get_winner(game_state_get_player(scene->gs, 0)->ctrl);
-        local->mode = LOBBY_MAIN;
+        controller *ctrl = game_state_get_player(scene->gs, 0)->ctrl;
+        local->peer = net_controller_get_lobby_connection(ctrl);
+        local->client = net_controller_get_host(ctrl);
+        local->nat = local->peer ? local->peer->data : NULL;
+        winner = net_controller_get_winner(ctrl);
+        opponent_disconnected = net_controller_opponent_disconnected(ctrl);
+        lobby_reconnect = !net_controller_lobby_connected(ctrl);
+        if(lobby_reconnect) {
+            local->peer = NULL;
+        } else {
+            local->mode = LOBBY_MAIN;
+        }
         local->nat_tries = 12;
     } else if(game_state_get_player(scene->gs, 1)->ctrl->type == CTRL_TYPE_NETWORK) {
-        local->peer = net_controller_get_lobby_connection(game_state_get_player(scene->gs, 1)->ctrl);
-        local->client = net_controller_get_host(game_state_get_player(scene->gs, 1)->ctrl);
-        local->nat = local->peer->data;
-        winner = net_controller_get_winner(game_state_get_player(scene->gs, 1)->ctrl);
-        local->mode = LOBBY_MAIN;
+        controller *ctrl = game_state_get_player(scene->gs, 1)->ctrl;
+        local->peer = net_controller_get_lobby_connection(ctrl);
+        local->client = net_controller_get_host(ctrl);
+        local->nat = local->peer ? local->peer->data : NULL;
+        winner = net_controller_get_winner(ctrl);
+        opponent_disconnected = net_controller_opponent_disconnected(ctrl);
+        lobby_reconnect = !net_controller_lobby_connected(ctrl);
+        if(lobby_reconnect) {
+            local->peer = NULL;
+        } else {
+            local->mode = LOBBY_MAIN;
+        }
         local->nat_tries = 12;
     } else if(game_state_get_player(scene->gs, 0)->ctrl->type == CTRL_TYPE_SPECTATOR) {
         // in spectator mode, only the first controller can have the enet data
@@ -1824,7 +1847,13 @@ int lobby_create(scene *scene) {
 
         menu_set_submenu(menu, name_menu);
 
-        lobby_show_dialog(scene, DIALOG_STYLE_CANCEL, "Establishing network socket...", lobby_dialog_close_exit);
+        if(lobby_reconnect) {
+            char *message = opponent_disconnected ? "Opponent and lobby connections lost. Reconnecting..."
+                                                  : "Lobby connection lost. Reconnecting...";
+            lobby_show_dialog(scene, DIALOG_STYLE_CANCEL, message, lobby_dialog_close_exit);
+        } else {
+            lobby_show_dialog(scene, DIALOG_STYLE_CANCEL, "Establishing network socket...", lobby_dialog_close_exit);
+        }
 
     } else {
         serial ser;
@@ -1851,6 +1880,10 @@ int lobby_create(scene *scene) {
         ENetPacket *packet = enet_packet_create(ser.data, serial_len(&ser), ENET_PACKET_FLAG_RELIABLE);
         enet_peer_send(local->peer, 0, packet);
         serial_free(&ser);
+
+        if(opponent_disconnected) {
+            lobby_show_dialog(scene, DIALOG_STYLE_OK, "Opponent disconnected.", lobby_dialog_close);
+        }
     }
 
     scene_set_input_poll_cb(scene, lobby_input_tick);

--- a/testing/test_sound_tracker.c
+++ b/testing/test_sound_tracker.c
@@ -173,6 +173,29 @@ void test_merge_same_in_both_is_noop(void) {
     sound_tracker_free(&new_t);
 }
 
+void test_merge_same_transfers_playback_handle(void) {
+    null_audio_backend_reset_state();
+    sound_tracker old_t, new_t;
+    sound_tracker_create(&old_t);
+    sound_tracker_create(&new_t);
+
+    sound_tracker_play(&old_t, 5, false, 0, NULL);
+    sound_tracker_play(&new_t, 5, true, 0, NULL);
+
+    const playing_sound *old_sound = vector_get(&old_t.entries, 0);
+    playing_sound *new_sound = vector_get(&new_t.entries, 0);
+    CU_ASSERT_TRUE(old_sound->playback_id != AUDIO_INVALID_HANDLE);
+    CU_ASSERT_EQUAL(new_sound->playback_id, AUDIO_INVALID_HANDLE);
+
+    sound_tracker_merge(&old_t, &new_t);
+
+    CU_ASSERT_EQUAL(new_sound->playback_id, old_sound->playback_id);
+    CU_ASSERT_EQUAL(null_audio_backend_get_play_count(0), 1);
+
+    sound_tracker_free(&old_t);
+    sound_tracker_free(&new_t);
+}
+
 void test_merge_old_only_fades_out(void) {
     null_audio_backend_reset_state();
     sound_tracker old_t, new_t;
@@ -380,6 +403,7 @@ void sound_tracker_test_suite(CU_pSuite suite) {
     ADD_TEST("Test duration math per id", test_duration_math_per_id);
     ADD_TEST("Test clone copies entries independently", test_clone_copies_entries_independently);
     ADD_TEST("Test merge: identical entries are a no-op", test_merge_same_in_both_is_noop);
+    ADD_TEST("Test merge: identical entries retain playback handle", test_merge_same_transfers_playback_handle);
     ADD_TEST("Test merge: old-only entries fade out", test_merge_old_only_fades_out);
     ADD_TEST("Test merge: new-only entries start playback", test_merge_new_only_starts_playback);
     ADD_TEST("Test eviction when all channels are busy", test_eviction_when_all_channels_busy);


### PR DESCRIPTION
I had frequent disconnect issues, playing with my brother with both of us having a very good Ethernet connection ping 10ms.
I played with him after the changes and it was a lot more stable, there were still some disconnects, but at least those were not silent, and after those changes it was also possible to connect again after a disconnect without closing the software, which was the case before.

The second commit is about failing audio in a multiplayer match, in many cases the Audi effects were gone after the first match. Rollback combat sounds were faded in over 500 ms. Many hit sounds are shorter and therefore practically inaudible. The fade-in is now 10 ms; in addition, running sound handles are preserved during rollback.

All changes on the first commit:
The aggressive 1-second timeout for NAT connection attempts is reset to the ENet standard (5–30 seconds) after a successful connection. This was likely the main cause of the frequent disconnections.
A lobby failure no longer terminates the direct connection to opponents.
Dead lobby connections are detected upon return and reestablished.
When an opponent disconnects, the message “Opponent disconnected” now appears.
The issue with incorrect access to arena data during player selection has been fixed.
Two potential “double-free” issues upon disconnect have been resolved.
Relay connections are now correctly treated as simultaneous opponent and lobby failures.

Winx64
Commits assisted with ChatGPT5.6 Sol