### PR TITLE
video: Improve CRT filters

### DIFF
--- a/shaders/scalers/scanlines.frag
+++ b/shaders/scalers/scanlines.frag
@@ -1,14 +1,16 @@
 #version 330 core
 
-// CRT colors without the geometry stuff
+// CRT colors with scanlines
 // The ideas used here are mostly from https://github.com/libretro/slang-shaders/
 // and https://github.com/dosbox-staging/dosbox-staging shaders.
 
 // Tunables
+uniform float scanline_intensity = 0.25;
 uniform float color_bleed_weight = 0.35;
 const float color_bleed_spread = 1.0;
 const float source_gamma = 2.4;
 const float display_gamma = 2.2;
+const float native_height = 200.0;
 const float min_blend_width = 1.0 / 256.0;
 
 // In
@@ -18,6 +20,8 @@ uniform sampler2D framebuffer;
 
 // Out
 layout (location = 0) out vec4 color;
+
+const float pi = 3.14159265;
 
 vec4 sample_bilinear(vec2 texel_floor, vec2 texel_fract) {
     vec2 texel_size = 1.0 / texture_size;
@@ -60,6 +64,24 @@ void main() {
     vec3 linear_center = to_linear(center.rgb);
     vec3 linear_neighbors = (to_linear(left.rgb) + to_linear(right.rgb)) * 0.5;
     vec3 linear_color = mix(linear_center, linear_neighbors, color_bleed_weight);
+
+    // Scanline profile
+    float line_pos = tex_coord.y * native_height;
+    float gap_darkness = 0.5 + 0.5 * cos(2.0 * pi * line_pos);
+
+    // How many source lines a screen pixel covers
+    float lines_per_pixel = clamp(fwidth(line_pos), min_blend_width, 1.0);
+
+    // Fade the effect out smoothly instead of aliasing into moire
+    float attenuation = sin(pi * lines_per_pixel) / (pi * lines_per_pixel);
+
+    // Darken the gaps multiplicatively so shadow detail survives
+    float scanline_factor = 1.0 - scanline_intensity * gap_darkness * attenuation;
+
+    // Boost gap brightness so the mean brightness stays as it was
+    float brightness_compensation = 1.0 / (1.0 - 0.5 * scanline_intensity * attenuation);
+
+    linear_color *= scanline_factor * brightness_compensation;
 
     color = vec4(to_display(linear_color), center.a);
 }

--- a/src/game/scenes/mainmenu/menu_video.c
+++ b/src/game/scenes/mainmenu/menu_video.c
@@ -293,11 +293,11 @@ component *menu_video_create(scene *s) {
     }
 
     // scaling mode selector
-    menu_attach(menu, textselector_create_bind_opts(
-                          "SCALING:",
-                          "Sets output scaling mode. Nearest=crisp, Bilinear=smooth, CRT=CRT colors, "
-                          "Scanlines=CRT colors with scanlines.",
-                          NULL, NULL, &setting->video.scaling_mode, scaling_opts, 4));
+    menu_attach(
+        menu, textselector_create_bind_opts("SCALING:",
+                                            "Sets output scaling mode. Nearest=crisp, Bilinear=smooth, CRT=CRT colors, "
+                                            "Scanlines=CRT colors with scanlines.",
+                                            NULL, NULL, &setting->video.scaling_mode, scaling_opts, 4));
 
     // vsync and fullscreen
     menu_attach(menu, textselector_create_bind_opts("VSYNC", "Toggle vertical sync on or off.", NULL, NULL,

--- a/src/game/scenes/mainmenu/menu_video.c
+++ b/src/game/scenes/mainmenu/menu_video.c
@@ -203,7 +203,7 @@ component *menu_video_create(scene *s) {
     // Load settings etc.
     const char *offon_opts[] = {"OFF", "ON"};
     const char *aspect_opts[] = {"4:3", "NATIVE"};
-    const char *scaling_opts[] = {"NEAREST", "BILINEAR", "CRT"};
+    const char *scaling_opts[] = {"NEAREST", "BILINEAR", "CRT", "SCANLINES"};
     settings *setting = settings_get();
 
     // Create menu and its header
@@ -295,8 +295,9 @@ component *menu_video_create(scene *s) {
     // scaling mode selector
     menu_attach(menu, textselector_create_bind_opts(
                           "SCALING:",
-                          "Sets output scaling mode. Nearest=crisp, Bilinear=smooth, CRT=CRT emulation with scanlines.",
-                          NULL, NULL, &setting->video.scaling_mode, scaling_opts, 3));
+                          "Sets output scaling mode. Nearest=crisp, Bilinear=smooth, CRT=CRT colors, "
+                          "Scanlines=CRT colors with scanlines.",
+                          NULL, NULL, &setting->video.scaling_mode, scaling_opts, 4));
 
     // vsync and fullscreen
     menu_attach(menu, textselector_create_bind_opts("VSYNC", "Toggle vertical sync on or off.", NULL, NULL,

--- a/src/video/renderers/opengl3/gl3_renderer.c
+++ b/src/video/renderers/opengl3/gl3_renderer.c
@@ -76,9 +76,13 @@ static void get_scaling_shader_names(const int scaling_mode, const char **vert_s
             *vert_shader = "scalers/bilinear.vert";
             *frag_shader = "scalers/bilinear.frag";
             break;
-        case 2: // CRT
+        case 2: // CRT colors, no scanlines
             *vert_shader = "scalers/crt.vert";
             *frag_shader = "scalers/crt.frag";
+            break;
+        case 3: // CRT colors with scanlines
+            *vert_shader = "scalers/crt.vert";
+            *frag_shader = "scalers/scanlines.frag";
             break;
         default:
             *vert_shader = "scalers/none.vert";


### PR DESCRIPTION
Improved CRT shaders. Note that these are mostly copypasta; I cannot claim to fully understand the stuff (yet); note that the comments have not been updated with the code changes. Very much WIP.

Note: At least 2x framebuffer scaling is required for this to look right (due to how crt dots work). It might make sense to add in some sort of minimum requirement to the shaders (remove 1x from the option list, or somesuch thing).